### PR TITLE
ensure that gguf_path argument is a directory.

### DIFF
--- a/ktransformers/util/custom_gguf.py
+++ b/ktransformers/util/custom_gguf.py
@@ -166,6 +166,8 @@ class GGUFLoader:
         # Check dir exist
         if not os.path.exists(gguf_path):
             raise FileNotFoundError(f"GGUF dir not found: {gguf_path}")
+        if os.path.isfile(gguf_path):
+            gguf_path = os.path.dirname(gguf_path)
         
         self.tensor_info = {}
         self.gguf_path = gguf_path
@@ -175,14 +177,18 @@ class GGUFLoader:
         self.tensor_device_map = {}
         
         # Walk through all the .gguf files in the directory
+        found_gguf = False
         for root, dirs, files in os.walk(gguf_path):
             for file in files:
                 if file.endswith(".gguf"):
+                    found_gguf = True
                     file_name = os.path.join(root, file)
                     with open(file_name, "rb") as f:
                         self.load_gguf(f)
                         if file_name not in self.file_data_map:
                             self.file_data_map[file_name] = np.memmap(file_name, mode = 'r')
+        if not found_gguf:
+            raise FileNotFoundError(f"Cannot find any .gguf files in: {gguf_path}")
                             
     def load_gguf(self, f):
         f.seek(0)


### PR DESCRIPTION
When pass gguf file to `--gguf_path`
```
python ktransformers/local_chat.py --model_path /workspace/models/Qwen2-57B-A14B-Instruct --gguf_path /workspace/models/Qwen2-57B-A14B-Instruct-GGUF/qwen2-57b-a14b-instruct-q4_k_m.gguf
```
`GGUFLoader.__init__` does not check whether gguf_path is a directory, and the error output is
```
Traceback (most recent call last):
  File "/workspace/ktransformers/ktransformers/local_chat.py", line 179, in <module>
    fire.Fire(local_chat)
  File "/opt/conda/lib/python3.11/site-packages/fire/core.py", line 135, in Fire
    component_trace = _Fire(component, args, parsed_flag_args, context, name)
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/conda/lib/python3.11/site-packages/fire/core.py", line 468, in _Fire
    component, remaining_args = _CallAndUpdateTrace(
                                ^^^^^^^^^^^^^^^^^^^^
  File "/opt/conda/lib/python3.11/site-packages/fire/core.py", line 684, in _CallAndUpdateTrace
    component = fn(*varargs, **kwargs)
                ^^^^^^^^^^^^^^^^^^^^^^
  File "/workspace/ktransformers/ktransformers/local_chat.py", line 110, in local_chat
    optimize_and_load_gguf(model, optimize_rule_path, gguf_path, config)
  File "/workspace/ktransformers/ktransformers/optimize/optimize.py", line 129, in optimize_and_load_gguf
    load_weights(module, gguf_loader)
  File "/workspace/ktransformers/ktransformers/util/utils.py", line 83, in load_weights
    load_weights(child, gguf_loader, prefix+name+".")
  File "/workspace/ktransformers/ktransformers/util/utils.py", line 85, in load_weights
    module.load()
  File "/workspace/ktransformers/ktransformers/operators/base_operator.py", line 60, in load
    utils.load_weights(child, self.gguf_loader, self.key+".")
  File "/workspace/ktransformers/ktransformers/util/utils.py", line 83, in load_weights
    load_weights(child, gguf_loader, prefix+name+".")
  File "/workspace/ktransformers/ktransformers/util/utils.py", line 81, in load_weights
    load_cur_state_dict(module, gguf_loader, prefix)
  File "/workspace/ktransformers/ktransformers/util/utils.py", line 76, in load_cur_state_dict
    raise Exception(f"can't find {translated_key} in GGUF file!")
Exception: can't find token_embd.weight in GGUF file!
```

After this patch, the output will be as follows:
```
Traceback (most recent call last):
  File "/workspace/ktransformers/ktransformers/local_chat.py", line 179, in <module>
    fire.Fire(local_chat)
  File "/opt/conda/lib/python3.11/site-packages/fire/core.py", line 135, in Fire
    component_trace = _Fire(component, args, parsed_flag_args, context, name)
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/conda/lib/python3.11/site-packages/fire/core.py", line 468, in _Fire
    component, remaining_args = _CallAndUpdateTrace(
                                ^^^^^^^^^^^^^^^^^^^^
  File "/opt/conda/lib/python3.11/site-packages/fire/core.py", line 684, in _CallAndUpdateTrace
    component = fn(*varargs, **kwargs)
                ^^^^^^^^^^^^^^^^^^^^^^
  File "/workspace/ktransformers/ktransformers/local_chat.py", line 110, in local_chat
    optimize_and_load_gguf(model, optimize_rule_path, gguf_path, config)
  File "/workspace/ktransformers/ktransformers/optimize/optimize.py", line 126, in optimize_and_load_gguf
    gguf_loader=GGUFLoader(gguf_path)
                ^^^^^^^^^^^^^^^^^^^^^
  File "/workspace/ktransformers/ktransformers/util/custom_gguf.py", line 170, in __init__
    raise NotADirectoryError(f"GGUF is not a dir: {gguf_path}")
NotADirectoryError: GGUF is not a dir: /workspace/models/Qwen2-57B-A14B-Instruct-GGUF/qwen2-57b-a14b-instruct-q4_k_m.gguf
```
