### PR TITLE
Fix NoneType object has no attribute zero_

### DIFF
--- a/ktransformers/models/custom_cache.py
+++ b/ktransformers/models/custom_cache.py
@@ -172,7 +172,8 @@ class StaticCache(transformers.StaticCache):
         for layer_idx in range(len(self.key_cache)):
             # In-place ops prevent breaking the static address
             self.key_cache[layer_idx].zero_()
-            self.value_cache[layer_idx].zero_()
+            if self.value_cache[layer_idx] is not None:
+                self.value_cache[layer_idx].zero_()
     
     def get_max_cache_shape(self) -> Tuple[int, int, int, int]:
         """Returns the maximum shape of the cache."""


### PR DESCRIPTION
This PR fixes: Server won't fulfill any requests after updating to v0.2.1. 

commit: 65d73ea

command line: ktransformers --model_path deepseek-ai/DeepSeek-R1 --gguf_path /burner/huggingface/hub/models--unsl
oth--DeepSeek-R1-GGUF/snapshots/c1cd3da7ff0130842ea01b16f714c13181dd429e/DeepSeek-R1-Q4_K_M --max_new_tokens 8000 --cpu_infer 97 --fo
rce_think True

cause: 
https://github.com/kvcache-ai/ktransformers/blob/3c6035aa8ad5c429299630f8c6f673896fbd7b16/ktransformers/models/custom_cache.py#L95