### PR TITLE
优化 CMake 多核编译参数逻辑

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -276,8 +276,13 @@ class CMakeBuild(BuildExtension):
                     "-DCMAKE_OSX_ARCHITECTURES={}".format(";".join(archs))]
 
         if "CMAKE_BUILD_PARALLEL_LEVEL" not in os.environ:
+            cpu_count = os.cpu_count()
+            if cpu_count is None:
+                cpu_count = 1
             if hasattr(self, "parallel") and self.parallel:
-                build_args += [f"-j{self.parallel}"]
+                build_args += [f"--parallel={self.parallel}"]
+            else:
+                build_args += [f"--parallel={cpu_count}"]
         print("CMake args:", cmake_args)
         build_temp = Path(ext.sourcedir) / "build"
         if not build_temp.exists():


### PR DESCRIPTION
*以下内容由AI生成，人工审核*

更改的代码段通过智能选择并行编译参数，显著提升构建速度并确保跨平台兼容性。以下是不同场景下的行为说明：

---

#### **1. 用户已设置 `CMAKE_BUILD_PARALLEL_LEVEL` 环境变量**
- **行为**：  
  更改的代码块**不会执行**，直接使用用户指定的值。  
  **示例**：  
  ```bash
  export CMAKE_BUILD_PARALLEL_LEVEL=4
  pip install ktransformers --no-build-isolation
  ```
  - CMake 将使用 `--parallel=4`，完全尊重用户配置。

---

#### **2. 用户未设置 `CMAKE_BUILD_PARALLEL_LEVEL`**
##### **场景 2.1：`self.parallel` 属性存在且有效**
- **行为**：  
  优先使用 `self.parallel` 的值。  
  **示例**：  
  若 `self.parallel = 8`，则添加 `--parallel=8`。  
  **适用场景**：  
  用户通过其他途径（如命令行参数）显式指定并行度。

##### **场景 2.2：`self.parallel` 不存在或为 `None`/`0`**
- **行为**：  
  自动检测逻辑 CPU 核心数（含超线程），并以此设置并行度。  
  **示例**：  
  - 4 核 8 线程 CPU → `--parallel=8`  
  - 无法检测 CPU 数（如旧系统）→ 回退到 `--parallel=1`（安全编译）

---

#### **3. 跨平台行为**
##### **Linux/macOS（Make/Ninja）**
- **参数转换**：  
  `--parallel=N` → 底层工具接收 `-jN`（Make）或 `-jN`（Ninja）。  
  **效果**：  
  完全利用多核资源，加速编译。

##### **Windows（MSBuild）**
- **参数转换**：  
  `--parallel=N` → MSBuild 的 `/m` 参数。  
  **效果**：  
  多进程编译，避免 `-jN` 的兼容性问题。

---

#### **4. 极端情况处理**
##### **场景 4.1：CPU 核心数检测失败**
- **行为**：  
  代码将 `cpu_count` 设为 `1`，回退到单线程编译。  
  **示例**：  
  某些虚拟化环境或旧硬件可能无法检测 CPU 数，此时安全编译。

##### **场景 4.2：用户显式禁用并行**
- **行为**：  
  设置 `CMAKE_BUILD_PARALLEL_LEVEL=1` 或 `self.parallel=1`。  
  **效果**：  
  强制单线程编译，便于调试或资源受限环境。

---

#### **总结**
此修改通过智能适配多核编译参数，实现了：
- ✅ **跨平台兼容**：支持 Make/Ninja/MSBuild。
- ✅ **用户优先级**：环境变量 > `self.parallel` > 自动检测。
- ✅ **安全回退**：CPU 检测失败时降级为单线程。
- ⚡ **性能提升**：充分利用硬件资源，减少编译时间。