### PR TITLE
musa: support bf16

### DIFF
--- a/ktransformers/ktransformers_ext/cpu_backend/vendors/musa.h
+++ b/ktransformers/ktransformers_ext/cpu_backend/vendors/musa.h
@@ -1,7 +1,9 @@
 #pragma once
 
 #include <musa_runtime.h>
+#include <musa_bf16.h>
 
 #define cudaLaunchHostFunc musaLaunchHostFunc
 #define cudaStream_t musaStream_t
 #define cudaHostFn_t musaHostFn_t
+#define nv_bfloat16 mt_bfloat16

--- a/setup.py
+++ b/setup.py
@@ -350,6 +350,7 @@ elif MUSA_HOME is not None:
         "at::cuda": "at::musa",
         "#include <ATen/cuda/CUDAContext.h>": "#include \"torch_musa/csrc/aten/musa/MUSAContext.h\"",
         "#include <c10/cuda/CUDAGuard.h>": "#include \"torch_musa/csrc/core/MUSAGuard.h\"",
+        "nv_bfloat16": "mt_bfloat16",
         }).run()
     ops_module = MUSAExtension('KTransformersOps', [
         'ktransformers/ktransformers_ext/cuda_musa/custom_gguf/dequant.mu',


### PR DESCRIPTION
In recent changes, `nv_bfloat16` is now used in building the `KTransformers` extension. This PR adds support for `nv_bfloat16` on the `MUSA` side.

### Testing Done

- [x] `make dev_install`