### PR TITLE
MUSA: Conditionally remove torch and numpy from dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 flake_find:
-	cd ktransformers && flake8 | grep -Eo '[A-Z][0-9]{3}' | sort | uniq| paste -sd ',' - 
+	cd ktransformers && flake8 | grep -Eo '[A-Z][0-9]{3}' | sort | uniq| paste -sd ',' -
 format:
 	@cd ktransformers && black .
 	@black setup.py
@@ -14,7 +14,11 @@ dev_install:
 
 # install ktransformers
 	echo "Installing python dependencies from requirements.txt"
-	pip install -r requirements-local_chat.txt
+	@if command -v mcc > /dev/null 2>&1; then \
+		bash -c 'pip install -r <(grep -v -E "torch|numpy" requirements-local_chat.txt)'; \
+	else \
+		pip install -r requirements-local_chat.txt; \
+	fi
 
 	echo "Installing ktransformers"
 	KTRANSFORMERS_FORCE_BUILD=TRUE pip install -e . -v --no-build-isolation

--- a/install.sh
+++ b/install.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -e  
+set -e
 
 # clear build dirs
 rm -rf build
@@ -10,7 +10,11 @@ rm -rf ktransformers/ktransformers_ext/cuda/dist
 rm -rf ktransformers/ktransformers_ext/cuda/*.egg-info
 
 echo "Installing python dependencies from requirements.txt"
-pip install -r requirements-local_chat.txt
+if command -v mcc > /dev/null 2>&1; then
+    bash -c 'pip install -r <(grep -v -E "torch|numpy" requirements-local_chat.txt)'
+else
+    pip install -r requirements-local_chat.txt
+fi
 
 echo "Installing ktransformers"
 KTRANSFORMERS_FORCE_BUILD=TRUE pip install . --no-build-isolation

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
   "setuptools",
-  "torch >= 2.3.0", 
+  "torch >= 2.3.0",
   "ninja",
   "packaging",
   "cpufeature"
@@ -12,25 +12,7 @@ build-backend = "setuptools.build_meta"
 
 name = "ktransformers"
 
-dynamic = ["version"]
-
-dependencies = [
-  "torch >= 2.3.0",
-  "transformers == 4.43.2",
-  "fastapi >= 0.111.0",
-  "uvicorn >= 0.30.1",
-  "langchain >= 0.2.0",
-  "blessed >= 1.20.0",
-  "accelerate >= 0.31.0",
-  "sentencepiece >= 0.1.97",
-  "setuptools",
-  "ninja",
-  "wheel",
-  "colorlog",
-  "build",
-  "fire",
-  "protobuf"
-]
+dynamic = ["version", "dependencies"]
 
 requires-python = ">=3.10"
 

--- a/setup.py
+++ b/setup.py
@@ -328,6 +328,23 @@ class CMakeBuild(BuildExtension):
             ["cmake", "--build", ".", "--verbose", *build_args], cwd=build_temp, check=True
         )
 
+dependencies = [
+    "torch >= 2.3.0",
+    "transformers == 4.43.2",
+    "fastapi >= 0.111.0",
+    "uvicorn >= 0.30.1",
+    "langchain >= 0.2.0",
+    "blessed >= 1.20.0",
+    "accelerate >= 0.31.0",
+    "sentencepiece >= 0.1.97",
+    "setuptools",
+    "ninja",
+    "wheel",
+    "colorlog",
+    "build",
+    "fire",
+    "protobuf"
+]
 if CUDA_HOME is not None:
     ops_module = CUDAExtension('KTransformersOps', [
         'ktransformers/ktransformers_ext/cuda/custom_gguf/dequant.cu',
@@ -345,6 +362,7 @@ if CUDA_HOME is not None:
         }
     )
 elif MUSA_HOME is not None:
+    dependencies.remove("torch >= 2.3.0")
     SimplePorting(cuda_dir_path="ktransformers/ktransformers_ext/cuda", mapping_rule={
         # Common rules
         "at::cuda": "at::musa",
@@ -372,6 +390,7 @@ else:
 
 setup(
     version=VersionInfo().get_package_version(),
+    install_requires=dependencies,
     cmdclass={"bdist_wheel":BuildWheelsCommand ,"build_ext": CMakeBuild},
     ext_modules=[
         CMakeExtension("cpuinfer_ext"),


### PR DESCRIPTION
[Torch MUSA](https://github.com/MooreThreads/torch_musa) requires a specific pre-built `Torch` version and a fixed `NumPy` version. This PR conditionally removes `Torch` and `NumPy` from dependencies by checking whether `mcc` is available.