### PR TITLE
Fix RuntimeError on Windows caused by integer overflow in np.prod

### DIFF
--- a/ktransformers/util/custom_gguf.py
+++ b/ktransformers/util/custom_gguf.py
@@ -27,6 +27,7 @@ import torch
 import KTransformersOps
 from .custom_loader import SafeTensorLoader
 import ctypes
+import math
 
 class GGMLQuantizationType(IntEnum):
     F32     = 0
@@ -230,7 +231,7 @@ class GGUFLoader:
             shape = [read_value(f, DATA_TYPES["uint64"]) for _ in range(shape_len)]
             ggml_type = read_value(f, DATA_TYPES["uint32"])
             bad_offset = read_value(f, DATA_TYPES["uint64"])
-            n_elems = int(np.prod(shape))
+            n_elems = int(math.prod(shape))
             block_size, type_size = GGML_QUANT_SIZES[ggml_type]
             n_bytes = n_elems * type_size // block_size
             np_dims = tuple(reversed(shape))


### PR DESCRIPTION
When running on Windows platforms, users encounter `RuntimeError: probability tensor contains either inf, nan or element < 0`

This issue is caused by NumPy's np.prod function defaulting to int32 type on Windows, when calculating n_elems for larger layers, int32 easily overflows
The overflow results in negative values, causing tensors reference to point to the beginning of the GGUF file instead of the correct location
Reading incorrect data leads to NaN values in calculations, triggering the runtime error