### PR TITLE
fix typo for top_p

### DIFF
--- a/ktransformers/server/backend/interfaces/ktransformers.py
+++ b/ktransformers/server/backend/interfaces/ktransformers.py
@@ -35,7 +35,7 @@ class KTransformersInterface(TransformersInterface):
             generation_config = GenerationConfig(
                 max_length=args.max_new_tokens,
                 temperature=args.temperature,
-                top_p=args.temperature,
+                top_p=args.top_p,
                 do_sample=True
             )
         


### PR DESCRIPTION
Fix the default argument for top_p. Corrected from args.temperature to args.top_p