### PR TITLE
Introduce Testing Jobs for kTransformers Setup on Self-Hosted Runner

### DIFF
--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -1,0 +1,52 @@
+name: Install KTransformers
+run-name: Install KTransformers
+on:
+  workflow_dispatch:
+    inputs:
+      job_to_run:
+        description: "Which job to run?"
+        required: true
+        default: "install"
+        type: choice
+        options:
+          - create&install
+          - install
+jobs:
+  Install-KTransformers:
+    runs-on: self-hosted
+    steps:
+      - run: echo "🎉 The job was automatically triggered by a ${{ github.event_name }} event."
+      - run: echo "🔎 The name of your branch is ${{ github.ref }} and your repository is ${{ github.repository }}."
+      - name: Check out repository code
+        uses: actions/checkout@v4
+      - run: echo "💡 The ${{ github.repository }} repository has been cloned to the runner."
+      - name: Remove old conda environment
+        continue-on-error: true
+        if: ${{ inputs.job_to_run == 'create&install'}}
+        run: |
+          source /home/qujing3/anaconda3/etc/profile.d/conda.sh
+          conda env remove --name KTransformers-dev -y
+      - name: Create conda environment
+        if: ${{ inputs.job_to_run == 'create&install'}}
+        run: |
+          source /home/qujing3/anaconda3/etc/profile.d/conda.sh
+          conda create --name KTransformers-dev python=3.11
+          conda activate KTransformers-dev
+          conda install -c conda-forge libstdcxx-ng -y
+      - name: Install dependencies
+        if: ${{ inputs.job_to_run == 'create&install'}}
+        run: |
+          source /home/qujing3/anaconda3/etc/profile.d/conda.sh
+          conda activate KTransformers-dev
+          pip3 install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cu126
+          pip3 install packaging ninja cpufeature numpy
+          pip install ~/flash_attn-2.7.4.post1+cu12torch2.6cxx11abiTRUE-cp311-cp311-linux_x86_64.whl
+      - name: Install KTransformers
+        run: |
+          source /home/qujing3/anaconda3/etc/profile.d/conda.sh
+          conda activate KTransformers-dev
+          cd ${{ github.workspace }}
+          git submodule init
+          git submodule update
+          USE_NUMA=1 bash install.sh
+      - run: echo "This job's status is ${{ job.status }}."

--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -25,13 +25,13 @@ jobs:
         if: ${{ inputs.job_to_run == 'create&install'}}
         run: |
           source /home/qujing3/anaconda3/etc/profile.d/conda.sh
-          conda env remove --name KTransformers-dev -y
+          conda env remove --name ktransformers-dev -y
       - name: Create conda environment
         if: ${{ inputs.job_to_run == 'create&install'}}
         run: |
           source /home/qujing3/anaconda3/etc/profile.d/conda.sh
-          conda create --name KTransformers-dev python=3.11
-          conda activate KTransformers-dev
+          conda create --name ktransformers-dev python=3.11
+          conda activate ktransformers-dev
           conda install -c conda-forge libstdcxx-ng -y
       - name: Install dependencies
         if: ${{ inputs.job_to_run == 'create&install'}}

--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -37,14 +37,14 @@ jobs:
         if: ${{ inputs.job_to_run == 'create&install'}}
         run: |
           source /home/qujing3/anaconda3/etc/profile.d/conda.sh
-          conda activate KTransformers-dev
+          conda activate ktransformers-dev
           pip3 install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cu126
           pip3 install packaging ninja cpufeature numpy
           pip install ~/flash_attn-2.7.4.post1+cu12torch2.6cxx11abiTRUE-cp311-cp311-linux_x86_64.whl
       - name: Install KTransformers
         run: |
           source /home/qujing3/anaconda3/etc/profile.d/conda.sh
-          conda activate KTransformers-dev
+          conda activate ktransformers-dev
           cd ${{ github.workspace }}
           git submodule init
           git submodule update


### PR DESCRIPTION
This pull request introduces an enhanced `Install KTransformers` workflow tailored for self-hosted runners, addressing the lengthy installation process of kTransformers by providing flexible, manually triggered job options instead of automatic execution on push.

### Key Features:
1. **Manual Job Selection via `workflow_dispatch`**:  
   Considering the potentially long installation times, this workflow uses the `workflow_dispatch` event, allowing users to manually trigger it through the GitHub Actions interface and select the desired job. This avoids unnecessary runs on every push, saving time and resources.

2. **Two Job Options**:  
   - **`create&install`**:  
     A comprehensive reinstallation process that removes the existing `ktransformers-dev` Conda environment (if present), creates a new one with Python 3.11, installs all dependencies (including PyTorch, Flash Attention, etc.), and sets up kTransformers from scratch. This option ensures a clean slate but may take significant time due to the full setup.  
   - **`install`**:  
     A faster alternative that reuses the existing `ktransformers-dev` environment and only reinstalls kTransformers itself. Ideal for quick iterations or updates without rebuilding the entire dependency stack.

### Implementation Details:
- **Job Configuration**: Both options are consolidated into a single job (`Install-KTransformers`), with conditional steps (`if: ${{ inputs.job_to_run == 'create&install' }}`) to execute environment creation and dependency installation only when `create&install` is selected.
- **Robustness**: The `Remove old conda environment` step uses `continue-on-error: true` to gracefully handle cases where the environment doesn’t exist.
- **Efficiency**: Common steps (e.g., repository checkout, kTransformers installation) are reused across both options, reducing redundancy.

### Usage:
- Navigate to the “Actions” tab in the repository.
- Select the `Install KTransformers` workflow and click “Run workflow.”
- Choose either `create&install` (full setup) or `install` (quick reinstall) from the dropdown.
- Monitor the job logs for completion status.

### Testing Recommendation:
- Run `create&install` to validate the full installation process on a clean runner.
- Run `install` to confirm incremental updates work with an existing environment.

This workflow balances flexibility and performance, making it easier to manage kTransformers installations on self-hosted runners. Feedback is appreciated!