### PR TITLE
[Fix] Shape error in KLinearMarlin

### DIFF
--- a/ktransformers/operators/linear.py
+++ b/ktransformers/operators/linear.py
@@ -347,7 +347,6 @@ class KLinearMarlin(KLinearBase):
             orig_shape[-1] = self.out_features
         if self.has_bias:
             x = x + self.bias
-        orig_shape[-1] = self.n
         return x.reshape(orig_shape).to(orig_dtype)
 
     def unload(self):


### PR DESCRIPTION
This pull request resolves issue #710, which occurred due to a duplicate and incorrect assignment to `orig_shape`. Specifically, the line 350 should be removed to prevent overwriting the intended value.

https://github.com/kvcache-ai/ktransformers/blob/4e43e8a4ee1da87ef1e0e107d68254e9497a1815/ktransformers/operators/linear.py#L343-L351