### PR TITLE
update documentation to fix error in numa enablement

### DIFF
--- a/doc/en/install.md
+++ b/doc/en/install.md
@@ -95,7 +95,7 @@ Some preparation:
         # Make sure your system has dual sockets and double size RAM than the model's size (e.g. 1T RAM for 512G model)
         apt install libnuma-dev
         export USE_NUMA=1
-        make install_numa
+        make dev_install
         ```
 
    - For Windows

--- a/doc/en/install.md
+++ b/doc/en/install.md
@@ -91,10 +91,11 @@ Some preparation:
         ```
      - For those who have two cpu and 1T RAM:
 
-        ```shell
+       ```shell
         # Make sure your system has dual sockets and double size RAM than the model's size (e.g. 1T RAM for 512G model)
+        apt install libnuma-dev
         export USE_NUMA=1
-        bash install.sh # or `make dev_install`
+        make install_numa
         ```
 
    - For Windows


### PR DESCRIPTION
### Problem Statement

The current documentation does not correctly explain how to enable NUMA mode. Several issues have pointed out this issue:  

- #634  
- #769  

### Solution

This update improves the installation guide based on suggestions from these posts. I also tested the steps in my environment, and NUMA mode worked correctly.

### Recommended steps:

```shell
# Ensure your system has dual sockets and at least double the RAM size compared to the model size (e.g., 1TB RAM for a 512GB model)
apt install libnuma-dev
export USE_NUMA=1
make install_numa
```

