### PR TITLE
cpuinfer: filter repeated backend instantiation

### DIFF
--- a/ktransformers/operators/cpuinfer.py
+++ b/ktransformers/operators/cpuinfer.py
@@ -727,8 +727,13 @@ class CPUInferKVCache:
 
 class CPUInfer:
     cpuinfer = None
+    cur_backend_thread_num = 0
+    
     def __init__(self, thread_num):
-        CPUInfer.cpuinfer = cpuinfer_ext.CPUInfer(thread_num)
+        if thread_num > CPUInfer.cur_backend_thread_num:
+            CPUInfer.cur_backend_thread_num = thread_num
+            del CPUInfer.cpuinfer
+            CPUInfer.cpuinfer = cpuinfer_ext.CPUInfer(thread_num)
 
     def submit(self, task):
         CPUInfer.cpuinfer.submit(task)


### PR DESCRIPTION
Currently `CPUInfer` will be instantiated twice as **class(or static) attributes** of the two CPU operator (`KLinearCPUInfer` and `KExpertsCPU`), if both files are imported.

```py
# ktransformers/operators/linear.py:362
class KLinearCPUInfer(KLinearBase):
    CPU_INFER = CPUInfer(Config().cpu_infer)

# ktransformers/operators/experts.py:115
class KExpertsCPU(KExpertsBase):
    input_tensor_cpu:Tensor = None
    expert_ids_cpu:Tensor = None
    weights_cpu:Tensor = None
    output_cpu:Tensor = None
    output_gpu_map:dict = {} # Manage output tensor buffer on different gpu
    #stream_map:dict = {} # Manage cuda stream on different gpu
    #gguf_loader:GGUFLoader = None
    CPU_INFER = CPUInfer(Config().cpu_infer)
```

Considering `__init__` method of class `CPUInfer`, this repetition leads to multiple instantiation of `Backend`s (also the worker threads) and `TaskQueue`s.

This commit filters repeated `CPUInfer.__init__()`s by maintaining a maximum number of threads requested.