### PR TITLE
Add support HYGON DCU

### DIFF
--- a/install_dcu.sh
+++ b/install_dcu.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+set -e  
+
+# clear build dirs
+rm -rf build
+rm -rf *.egg-info
+rm -rf ktransformers/ktransformers_ext/build
+rm -rf ktransformers/ktransformers_ext/cuda/build
+rm -rf ktransformers/ktransformers_ext/cuda/dist
+rm -rf ktransformers/ktransformers_ext/cuda/*.egg-info
+
+echo "Installing python dependencies from requirements.txt"
+pip install -r requirements-local_chat.txt
+
+export USE_FASTPT_CUDA=True
+export CMAKE_BUILD_PARALLEL_LEVEL=32
+
+echo "Installing ktransformers"
+KTRANSFORMERS_FORCE_BUILD=TRUE pip install . --no-build-isolation
+echo "Installation completed successfully"

--- a/ktransformers/ktransformers_ext/cuda/gptq_marlin/gptq_marlin_dtypes.cuh
+++ b/ktransformers/ktransformers_ext/cuda/gptq_marlin/gptq_marlin_dtypes.cuh
@@ -55,7 +55,7 @@ class ScalarType<nv_bfloat16> {
   using FragC = Vec<float, 4>;
   using FragS = Vec<nv_bfloat162, 1>;
 
-#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 800
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 800 || KTRANSFORMERS_USE_DTK
   static __device__ float inline num2float(const nv_bfloat16 x) {
     return __bfloat162float(x);
   }

--- a/ktransformers/optimize/optimize_rules/DeepSeek-V3-Chat-dcu.yaml
+++ b/ktransformers/optimize/optimize_rules/DeepSeek-V3-Chat-dcu.yaml
@@ -1,0 +1,76 @@
+- match:
+    class: ktransformers.models.modeling_deepseek_v3.DeepseekV3RotaryEmbedding
+  replace:
+    class: ktransformers.operators.RoPE.YarnRotaryEmbeddingV3
+    kwargs:
+      generate_device: "cuda"
+      prefill_device: "cuda"
+
+- match:
+    name: "^lm_head$"  # regular expression 
+    class: torch.nn.Linear  # only match modules matching name and class simultaneously
+  replace:
+    class: ktransformers.operators.linear.KTransformersLinear  # optimized Kernel on quantized data types
+    kwargs:
+      generate_device: "cuda"
+      prefill_device: "cuda"
+      generate_op: "KLinearTorch"
+      prefill_op: "KLinearTorch"
+
+- match:
+    name: "^model\\.layers\\.(?!.*self_attn\\.kv_b_proj).*$"  # regular expression 
+    class: torch.nn.Linear  # only match modules matching name and class simultaneously
+  replace:
+    class: ktransformers.operators.linear.KTransformersLinear  # optimized Kernel on quantized data types
+    kwargs:
+      generate_device: "cuda"
+      prefill_device: "cuda"
+      generate_op: "KLinearTorch"
+      prefill_op: "KLinearTorch"
+- match:
+    name: "^model\\.layers\\..*\\.mlp$"
+    class: ktransformers.models.modeling_deepseek_v3.DeepseekV3MoE
+  replace:
+    class: ktransformers.operators.experts.KDeepseekV3MoE     # mlp module with custom forward function
+    kwargs:
+      generate_device: "cuda"
+      prefill_device: "cuda"
+- match:
+    class: ktransformers.models.modeling_deepseek_v3.MoEGate
+  replace:
+    class: ktransformers.operators.gate.KMoEGate
+    kwargs:
+      generate_device: "cuda:0"
+      prefill_device: "cuda:0"
+- match:
+    name: "^model\\.layers\\..*\\.mlp\\.experts$"
+  replace:
+    class: ktransformers.operators.experts.KTransformersExperts     # custom MoE Kernel with expert paralleism
+    kwargs:
+      prefill_device: "cuda"
+      prefill_op: "KExpertsTorch"
+      generate_device: "cpu"
+      generate_op: "KExpertsCPU"
+      out_device: "cuda"
+  recursive: False # don't recursively inject submodules of this module
+- match:
+    name: "^model\\.layers\\..*\\.self_attn$"
+  replace:
+    class: ktransformers.operators.attention.KDeepseekV2Attention # optimized MLA implementation
+    kwargs:
+      generate_device: "cuda"
+      prefill_device: "cuda"
+      absorb_for_prefill: False # change this to True to enable long context(prefill may slower).
+- match:
+    name: "^model$"
+  replace:
+    class: "ktransformers.operators.models.KDeepseekV2Model"
+    kwargs:
+      per_layer_prefill_intput_threshold: 0 # 0 is close layer wise prefill
+- match:
+    name: "^model.embed_tokens"
+  replace:
+    class: "default"
+    kwargs:
+      generate_device: "cpu"
+      prefill_device: "cpu"


### PR DESCRIPTION
This commit code is submit for KME and BW1000, and we also suppply the Z100 method.

Introduction
Enable  ktransformers on HYGON DCU.

Limitation

Marlin kernel is not supported on DCU(KME and BW1000) and will be support in future , the yaml change can  reference by  ktransformers/optimize/optimize_rules/DeepSeek-V3-Chat-dcu.yaml to Replace all instances of KLinearMarlin with KLinearTorch.

If you want to use ktransformers on Z100, you should do as follows:
1. Replace all instances of KLinearMarlin with KLinearTorch
2. Modify local_chat.py to replace all instances of flash_attention_2 with eager.
3. change code as pictures:
![image](https://github.com/user-attachments/assets/00083a66-79c5-4ef3-83ba-d03cf3a8feeb)
![image](https://github.com/user-attachments/assets/73bfd36d-e667-438d-95ab-ef42d073f40d)
![image](https://github.com/user-attachments/assets/8eb92946-ed84-4e29-8b22-5bd696adcf9b)
![image](https://github.com/user-attachments/assets/b29f2b92-9c40-47e6-9c2a-f224203f97b3)


Validation command:
 python3 ./ktransformers/local_chat.py --model_path  ./DeepSeek-R1  --gguf_path   ./DeepSeek-R1-GGUF/ --cpu_infer 65 --max_new_tokens 1000  --optimize-config-path ktransformers/optimize/optimize_rules/DeepSeek-V3-Chat-dcu.yaml


Chat: who are you
Greetings! I'm DeepSeek-R1, an artificial intelligence assistant created by DeepSeek. I'm at your service and would be delighted to assist ou with any inquiries or tasks you may have.