### PR TITLE
Add DeepSeek-like API

### DIFF
--- a/ktransformers/server/api/openai/endpoints/chat.py
+++ b/ktransformers/server/api/openai/endpoints/chat.py
@@ -90,13 +90,34 @@ async def chat_completion(request:Request,create:ChatCompletionCreate):
                 content = content + token
                 finish_reason = finish_reason
 
-        choice = Choice(
-            index = 0,
-            finish_reason = finish_reason,
-            message = ChatCompletionMessage(
-                content=content,
-                role="assistant"
-            ))
+        # 使用deepseek的api格式
+        if Config().user_ds_api:
+            # 分割字符串，提取</think>之前的部分
+            split_result = content.split("</think>", 1)
+            reasoning_content = split_result[0]
+
+            # 处理剩余部分，并去除紧接的换行符
+            content = split_result[1].lstrip('\n') if len(split_result) > 1 else ''
+
+            # 删除reasoning_content中的<think>\n
+            reasoning_content = reasoning_content.replace("<think>\n", "")
+
+            choice = Choice(
+                index=0,
+                finish_reason=finish_reason,
+                message=ChatCompletionMessage(
+                    content=content,
+                    reasoning_content=reasoning_content,
+                    role="assistant"
+                ))
+        else:
+            choice = Choice(
+                index = 0,
+                finish_reason = finish_reason,
+                message = ChatCompletionMessage(
+                    content=content,
+                    role="assistant"
+                ))
 
         chat_completion = ChatCompletion(
             id = id,

--- a/ktransformers/server/args.py
+++ b/ktransformers/server/args.py
@@ -92,6 +92,7 @@ class ArgumentParser:
         parser.add_argument("--user_secret_key", type=str, default=self.cfg.user_secret_key)
         parser.add_argument("--user_algorithm", type=str, default=self.cfg.user_algorithm)
         parser.add_argument("--force_think", action=argparse.BooleanOptionalAction, type=bool, default=self.cfg.user_force_think)
+        parser.add_argument("--ds_api", action=argparse.BooleanOptionalAction, type=bool, default=self.cfg.user_ds_api)
         parser.add_argument("--use_cuda_graph", action=argparse.BooleanOptionalAction, type=bool, default=self.cfg.use_cuda_graph)
 
         # web config
@@ -125,4 +126,5 @@ class ArgumentParser:
         self.cfg.server_port = args.port
         self.cfg.backend_type = args.type
         self.cfg.user_force_think = args.force_think
+        self.cfg.user_ds_api = args.ds_api
         return args

--- a/ktransformers/server/config/config.py
+++ b/ktransformers/server/config/config.py
@@ -85,6 +85,7 @@ class Config(metaclass=Singleton):
         self.user_secret_key = self.user_config.get("secret_key", "")
         self.user_algorithm = self.user_config.get("algorithm", "")
         self.user_force_think = self.user_config.get("force_think", False)
+        self.user_ds_api = self.user_config.get("ds_api", False)
 
         # model config
         self.model: dict = cfg.get("model", {})


### PR DESCRIPTION
Add DeepSeek-like API which returns content and thoughts separately (content & reasoning_content) to support agents frameworks such as Browser-use. Set flag "--ds_api" to enable.