### PR TITLE
📝 Docs: Clarify CMake version requirement for CUDA dialects

### DIFF
--- a/doc/en/install.md
+++ b/doc/en/install.md
@@ -38,7 +38,8 @@ Some preparation:
       export CUDA_PATH=$CUDA_PATH:/usr/local/cuda
   fi
   ```
-- Linux-x86_64 with gcc, g++ and cmake (using Ubuntu as an example)
+- Linux-x86_64 with gcc, g++>=11 and cmake>=3.25 (using Ubuntu as an example)
+- **Note**: The default CMake version in Ubuntu 22.04 LTS or higher may not support newer CUDA language dialects (e.g., CUDA 20). This can cause errors such as Target "cmTC_xxxxxx" requires the language dialect "CUDA20", but CMake does not know the compile flags to use to enable it. To resolve this, install a newer CMake version, for instance, by adding the Kitware APT repository.
 
   ```sh
   sudo apt-get update 


### PR DESCRIPTION
Adds a note explaining that default CMake versions on systems like Ubuntu 22.04 LTS might not support newer CUDA dialects (e.g., CUDA 20), leading to specific build errors.

Recommends installing a newer CMake via the Kitware APT repository as a resolution. This helps users troubleshoot errors like: "Target ... requires the language dialect 'CUDA20', but CMake does not know the compile flags..."

Real logs for this error (on cmake 3.21.2, which is the latest version provided by sudo apt install cmake on Ubuntu 22.04 LTS):

```shell
USE_BALANCE_SERVE=1 bash ./install.sh
```

```shell
CMake Error in /home/****/ktransformers/csrc/balance_serve/build/CMakeFiles/CMakeTmp/CMakeLists.txt:
Target "cmTC_ac7ce" requires the language dialect "CUDA20" , but CMake does
not know the compile flags to use to enable it.
CMake Error at /home/****/miniconda3/envs/ktransformers/lib/python3.11/site-packages/torch/share/cmake/Caffe2/Modules_CUDA_fix/upstream/FindCUDA/select_compute_arch.cmake:120 (try_run):
Failed to generate test project build system.
Call Stack (most recent call first):
/home/****/miniconda3/envs/ktransformers/lib/python3.11/site-packages/torch/share/cmake/Caffe2/Modules_CUDA_fix/upstream/FindCUDA/select_compute_arch.cmake:180 (CUDA_DETECT_INSTALLED_GPUS)
/home/****/miniconda3/envs/ktransformers/lib/python3.11/site-packages/torch/share/cmake/Caffe2/public/utils.cmake:344 (cuda_select_nvcc_arch_flags)
/home/****/miniconda3/envs/ktransformers/lib/python3.11/site-packages/torch/share/cmake/Caffe2/public/cuda.cmake:331 (torch_cuda_get_nvcc_gencode_flag)
/home/****/miniconda3/envs/ktransformers/lib/python3.11/site-packages/torch/share/cmake/Caffe2/Caffe2Config.cmake:86 (include)
/home/****/miniconda3/envs/ktransformers/lib/python3.11/site-packages/torch/share/cmake/Torch/TorchConfig.cmake:68 (find_package)
CMakeLists.txt:64 (find_package)
-- Configuring incomplete, errors occurred!
See also "/home/****/ktransformers/csrc/balance_serve/build/CMakeFiles/CMakeOutput.log".
```

Updating `cmake` to 4.0.0 (provided by KitWare's 3rd-party repo resolved this problem).

It seems in recent updates (maybe >=0.2.4?), new module `balance_serve` used CUDA 20 dialects and caused this problem.