### PR TITLE
balance_serve: Add g++ to compiler list

### DIFF
--- a/csrc/balance_serve/CMakeLists.txt
+++ b/csrc/balance_serve/CMakeLists.txt
@@ -1,6 +1,6 @@
 
 cmake_minimum_required(VERSION 3.21)
-find_program(GCC_COMPILER NAMES g++-13 g++-12 g++-11 REQUIRED)
+find_program(GCC_COMPILER NAMES g++-13 g++-12 g++-11 g++ REQUIRED)
 set(CMAKE_CXX_COMPILER ${GCC_COMPILER})
 
 # 显示选定的编译器

--- a/csrc/balance_serve/kvc2/CMakeLists.txt
+++ b/csrc/balance_serve/kvc2/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.21)
 
-find_program(GCC_COMPILER NAMES g++-13 g++-12 g++-11 REQUIRED)
+find_program(GCC_COMPILER NAMES g++-13 g++-12 g++-11 g++ REQUIRED)
 set(CMAKE_CXX_COMPILER ${GCC_COMPILER})
 
 project(kvcache-manager VERSION 0.1.0)


### PR DESCRIPTION
In some OS distributions, g++ exists in the following form:

  $ ls -l /usr/bin/g++*
  -rwxr-xr-x 4 root root 985784 Dec  9 12:51 /usr/bin/g++

So make sure to add g++ to the compiler list as well.