### PR TITLE
xxHash: fix link error due to non-position-independent code

### DIFF
--- a/csrc/balance_serve/CMakeLists.txt
+++ b/csrc/balance_serve/CMakeLists.txt
@@ -38,6 +38,7 @@ set(THIRD_PARTY_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../../third_party)
 set(THIRD_PARTY_BUILD_DIR ${CMAKE_CURRENT_BINARY_DIR}/third_party)
 add_subdirectory(${THIRD_PARTY_DIR}/prometheus-cpp ${THIRD_PARTY_BUILD_DIR}/prometheus-cpp EXCLUDE_FROM_ALL)
 add_subdirectory(${THIRD_PARTY_DIR}/xxHash/cmake_unofficial ${THIRD_PARTY_BUILD_DIR}/xxHash EXCLUDE_FROM_ALL)
+set_target_properties(xxhash PROPERTIES POSITION_INDEPENDENT_CODE ON)
 
 # add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/third_party/prometheus-cpp ${CMAKE_CURRENT_BINARY_DIR}/third_party/prometheus-cpp)
 set(SPDLOG_DIR ${THIRD_PARTY_DIR}/spdlog)


### PR DESCRIPTION
Add PROPERTIES POSITION_INDEPENDENT_CODE option to fix the following error:

/usr/bin/ld: ../../third_party/xxHash/libxxhash.a(xxhash.c.o): relocation R_X86_64_32S against `.rodata' can not be used when making a shared object; recompile with -fPIC

Trying to link a non-PIC static library libxxhash.a into a .so shared library, which is not allowed. The object file xxhash.c.o must be recompiled with explicit -fPIC support.