### PR TITLE
Fix build failure on msvc

### DIFF
--- a/csrc/ktransformers_ext/cpu_backend/shared_mem_buffer.cpp
+++ b/csrc/ktransformers_ext/cpu_backend/shared_mem_buffer.cpp
@@ -9,6 +9,7 @@
  **/
 #include "shared_mem_buffer.h"
 #include <cstdio>
+#include <new>
 
 SharedMemBuffer::SharedMemBuffer() {
     buffer_ = nullptr;
@@ -17,7 +18,7 @@ SharedMemBuffer::SharedMemBuffer() {
 
 SharedMemBuffer::~SharedMemBuffer() {
     if (buffer_) {
-        free(buffer_);
+        ::operator delete(buffer_, std::align_val_t(64));
     }
 }
 
@@ -28,9 +29,9 @@ void SharedMemBuffer::alloc(void* object, std::vector<std::pair<void**, uint64_t
     }
     if (size > size_) {
         if (buffer_) {
-            free(buffer_);
+            ::operator delete(buffer_, std::align_val_t(64));
         }
-        buffer_ = std::aligned_alloc(64, size);
+        buffer_ = ::operator new(size, std::align_val_t(64));
 
         size_ = size;
         for (auto& obj_requests : hist_requests_) {

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,10 @@ if dev_backend == "xpu":
         "pytorch-triton-xpu==3.3.0"
     ]
 else:
-    triton_dep = ["triton>=3.2"]
+    triton_dep = [
+        "triton >= 3.2; sys_platform != 'win32' and sys_platform != 'Windows'",
+        "triton-windows >= 3.2; sys_platform == 'win32' or sys_platform == 'Windows'"
+    ]
 
 with_balance = os.environ.get("USE_BALANCE_SERVE", "0") == "1"
 


### PR DESCRIPTION
- Replaced std::aligned_alloc with ::operator new(size_t, std::align_val_t) to ensure compatibility across both Linux and Windows platforms, as MSVC does not support the former.
- Modified dependencies for Windows builds by replacing the direct dependency on triton with triton-windows, as the standard triton package cannot be directly used on Windows systems.