### PR TITLE
modeling_deepseek_v3: fix GenerationMixin warning

### DIFF
--- a/ktransformers/models/modeling_deepseek_v3.py
+++ b/ktransformers/models/modeling_deepseek_v3.py
@@ -30,6 +30,7 @@ from torch.nn import BCEWithLogitsLoss, CrossEntropyLoss, MSELoss
 
 from transformers.activations import ACT2FN
 from transformers.cache_utils import Cache, DynamicCache, StaticCache
+from transformers.generation import GenerationMixin
 from transformers.modeling_attn_mask_utils import (
     AttentionMaskConverter,
     _prepare_4d_attention_mask,
@@ -1598,7 +1599,7 @@ class DeepseekV3Model(DeepseekV3PreTrainedModel):
 
         return causal_mask
 
-class DeepseekV3ForCausalLM(DeepseekV3PreTrainedModel):
+class DeepseekV3ForCausalLM(DeepseekV3PreTrainedModel, GenerationMixin):
     _tied_weights_keys = ["lm_head.weight"]
 
     def __init__(self, config):


### PR DESCRIPTION
Fix GenerationMixin warning introduced by upgrading transformers to 4.51.3.

DeepseekV3ForCausallM has generative capabilities, as `prepare inputs for generation' is explicitly overwritten.
However, it doesn't directly inherit from `GenerationMixin`. 
From v4.50- onwards, *PreTrainedModel' will NOTinherit from `GenerationMixin’, 
and this model will lose the ability to call generate` and other related functions.
- lf you're using 'trust remote code=True’, you can get rid of this warning, by loading the model with an auto class. See https://huggingface.co/docs/transformers/en/model doc/autoffauto-classes
- lf you are the owner of the model architecture code, please modify your model class such that it inherits fromGenerationMixin`(after `PreTrainedModel`, otherwise you'l get an exception).
- lf you are not the owner of the model architecture class, please contact the model code owner to update it.using default optimize rule for DeepseekV3ForCausalLM