### PR TITLE
Fix typo about `GLIBCXX_3.4.32`

### DIFF
--- a/doc/en/install.md
+++ b/doc/en/install.md
@@ -45,7 +45,7 @@ Some preparation:
   sudo apt-get update 
   sudo apt-get install build-essential cmake ninja-build patchelf
   ```
-- We recommend using [Miniconda3](https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh) or [Anaconda3](https://repo.anaconda.com/archive/Anaconda3-2024.10-1-Linux-x86_64.sh) to create a virtual environment with Python=3.11 to run our program. Assuming your Anaconda installation directory is `~/anaconda3`, you should ensure that the version identifier of the GNU C++standard library used by Anaconda includes `GLIBCXX-3.4.32`
+- We recommend using [Miniconda3](https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh) or [Anaconda3](https://repo.anaconda.com/archive/Anaconda3-2024.10-1-Linux-x86_64.sh) to create a virtual environment with Python=3.11 to run our program. Assuming your Anaconda installation directory is `~/anaconda3`, you should ensure that the version identifier of the GNU C++standard library used by Anaconda includes `GLIBCXX_3.4.32`
 
   ```sh
   conda create --name ktransformers python=3.11


### PR DESCRIPTION
On my machine, `GLIBCXX-3.4.32` does not exist while I can see `GLIBCXX_3.4.32`.