### PR TITLE
Fix kv_b_proj shape for unsloth quantized models

### DIFF
--- a/ktransformers/util/utils.py
+++ b/ktransformers/util/utils.py
@@ -130,6 +130,7 @@ def load_cur_state_dict(module: nn.Module, gguf_loader: ModelLoader, prefix: str
                 attn_k_b = attn_k_b.transpose(1, 2).contiguous()
                 attn_v_b = load_dequantized_tensor(translated_key.replace("self_attn.kv_b_proj", "attn_v_b"), device=device).to(dtype=target_dtype)
                 kv_b_proj = torch.cat((attn_k_b, attn_v_b), dim=1)
+                kv_b_proj = kv_b_proj.contiguous() if kv_b_proj.ndim == 2 else kv_b_proj.flatten(0, 1).contiguous()
                 set_param(module, name, kv_b_proj)
                 del attn_k_b
                 del attn_v_b


### PR DESCRIPTION
Steps to reproduce:

`python ./ktransformers/server/main.py --model_path deepseek-ai/DeepSeek-R1-0528 --gguf_path /opt/gguf/DeepSeek-R1-0528-UD-Q2_K_XL --cpu_infer 48 --max_new_tokens 16384 --cache_lens 32768 --temperature 0.6 --top_p 0.95 --use_cuda_graph --host 0.0.0.0 --port 8080`

Error:
```
    |   File "/home/zhouye/ktransformers/venv/lib64/python3.11/site-packages/torch/nn/modules/module.py", line 1750, in _call_impl
    |     return forward_call(*args, **kwargs)
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |   File "/home/zhouye/ktransformers/venv/lib64/python3.11/site-packages/torch/nn/modules/linear.py", line 125, in forward
    |     return F.linear(input, self.weight, self.bias)
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    | RuntimeError: t() expects a tensor with <= 2 dimensions, but self is 3D
    +------------------------------------
```

Similar issue: #1353 

Some quantized models (UD-Q2_K_XL, etc.) has 3D k_b_proj and v_b_proj tensors, see reports in #1333
Add a flatten op on the first 2 dimensions if 3D tensors are detected.

This PR also includes fix in #1361