### PR TITLE
包含所有package

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,7 +69,7 @@ ktransformers = "ktransformers.server.main:main"
 
 [tool.setuptools.packages.find]
 where = ["./", ]
-include = ["ktransformers"]
+include = ["ktransformers","ktransformers.*"]
 [tool.black]
 line-length = 120
 preview = true


### PR DESCRIPTION
This pull request updates the `pyproject.toml` file to ensure that submodules of the `ktransformers` package are included during packaging.

* [`pyproject.toml`](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L72-R72): Modified the `include` field under `[tool.setuptools.packages.find]` to include `ktransformers.*`, ensuring that submodules of `ktransformers` are packaged.