### PR TITLE
revert using FP16 in XPU

### DIFF
--- a/ktransformers/local_chat.py
+++ b/ktransformers/local_chat.py
@@ -79,8 +79,9 @@ def local_chat(
     if mode == 'long_context':
         assert config.architectures[0] == "LlamaForCausalLM", "only LlamaForCausalLM support long_context mode"
         torch.set_default_dtype(torch.float16)
-    elif xpu_fp16_model(config):
-        torch.set_default_dtype(torch.float16)
+    # elif xpu_fp16_model(config):
+    #     # using FP16 may cause accuracy issues, triggering core dumped during runtime
+    #     torch.set_default_dtype(torch.float16)
     else:
         torch.set_default_dtype(config.torch_dtype)
 


### PR DESCRIPTION
- We found although using FP16 as torch default dtype can bring slightly better performance, it may trigger core dumped issue during runtime
- So in this PR, revert to default BF16 usage