### PR TITLE
[fix](kt-kernel): Drop Python-loaded weights after C++ weight loading in LlamafileMoEWrapper

### DIFF
--- a/kt-kernel/python/utils/llamafile.py
+++ b/kt-kernel/python/utils/llamafile.py
@@ -217,3 +217,6 @@ class LlamafileMoEWrapper(BaseMoEWrapper):
         # Load weights
         self.cpu_infer.submit(self.moe.load_weights_task(physical_to_logical_map_cpu.data_ptr()))
         self.cpu_infer.sync()
+
+        # Drop original weights after loading
+        self.weights_to_keep = None


### PR DESCRIPTION
# What does this PR do?
In the `LlamafileMoEWrapper`'s load_weights method, weights loaded by the Python loader are retained in weights_to_keep for TP-splitting and copying to the C++ backend. However, these weights are no longer needed after the C++ backend completes the loading process.
This PR ensures that the Python-loaded weights are explicitly dropped after the C++ backend finishes its operation, freeing up memory and preventing unnecessary retention of large weight tensors.

Fixes # (issue)
reset the `self.weights_to_keep` at the end of `LlamafileMoEWrapper.load_weights`

## Before submitting

- [x] Did you read the [contributor guideline](https://github.com/kvcache-ai/ktransformers/blob/main/.github/CONTRIBUTING.md)?
- [ ] Did you write any new necessary tests?