### PR TITLE
[fix](llamafile-moe): fix the argument passed to `llamafile_sgemm`

### DIFF
--- a/kt-kernel/operators/llamafile/moe.hpp
+++ b/kt-kernel/operators/llamafile/moe.hpp
@@ -628,7 +628,7 @@ class LLAMA_MOE_TP {
                           config_.hidden_size / ggml_blck_size((ggml_type)config_.gate_type), gate_proj_ptr,
                           config_.hidden_size / ggml_blck_size((ggml_type)config_.gate_type), gate_input_ptr,
                           config_.hidden_size / ggml_blck_size((ggml_type)config_.gate_type), gate_output_ptr,
-                          config_.intermediate_size, 0, 1, GGML_TASK_TYPE_COMPUTE, (ggml_type)config_.gate_type,
+                          m_block, 0, 1, GGML_TASK_TYPE_COMPUTE, (ggml_type)config_.gate_type,
                           ggml_internal_get_type_traits((ggml_type)config_.gate_type).vec_dot_type, GGML_TYPE_F32,
                           GGML_PREC_DEFAULT);
           void* up_input_ptr = m_local_up_input_ptr_[expert_idx];
@@ -643,7 +643,7 @@ class LLAMA_MOE_TP {
               m_block, m_local_num_[expert_idx], config_.hidden_size / ggml_blck_size((ggml_type)config_.up_type),
               up_proj_ptr, config_.hidden_size / ggml_blck_size((ggml_type)config_.up_type), up_input_ptr,
               config_.hidden_size / ggml_blck_size((ggml_type)config_.up_type), up_output_ptr,
-              config_.intermediate_size, 0, 1, GGML_TASK_TYPE_COMPUTE, (ggml_type)config_.up_type,
+              m_block, 0, 1, GGML_TASK_TYPE_COMPUTE, (ggml_type)config_.up_type,
               ggml_internal_get_type_traits((ggml_type)config_.up_type).vec_dot_type, GGML_TYPE_F32, GGML_PREC_DEFAULT);
           for (int i = 0; i < m_local_num_[expert_idx]; i++) {
             for (int j = ith * m_block; j < (ith + 1) * m_block; j++) {
@@ -696,7 +696,7 @@ class LLAMA_MOE_TP {
                           config_.intermediate_size / ggml_blck_size((ggml_type)config_.down_type), down_proj_ptr,
                           config_.intermediate_size / ggml_blck_size((ggml_type)config_.down_type), down_input_ptr,
                           config_.intermediate_size / ggml_blck_size((ggml_type)config_.down_type), down_output_ptr,
-                          config_.hidden_size, 0, 1, GGML_TASK_TYPE_COMPUTE, (ggml_type)config_.down_type,
+                          m_block, 0, 1, GGML_TASK_TYPE_COMPUTE, (ggml_type)config_.down_type,
                           ggml_internal_get_type_traits((ggml_type)config_.down_type).vec_dot_type, GGML_TYPE_F32,
                           GGML_PREC_DEFAULT);
         },


### PR DESCRIPTION
# What does this PR do?
Fix the arguments passed to `llamafile_sgemm` in the moe operator in llamafile so that the `ldc` parameter always receives the right row-stride value of the output matrix.

## Before submitting

- [x] Did you read the [contributor guideline](https://github.com/kvcache-ai/ktransformers/blob/main/.github/CONTRIBUTING.md)?
- [ ] Did you write any new necessary tests?