### PR TITLE
Fix Qwen3.5 FP8 load for VL detection

### DIFF
--- a/kt-kernel/python/utils/loader.py
+++ b/kt-kernel/python/utils/loader.py
@@ -318,7 +318,7 @@ class FP8SafeTensorLoader(SafeTensorLoader):
                         # VL models(Qwen3.5): model.layers.{N} -> model.language_model.layers.{N}
                         self._is_vl_model = True
                         print("[FP8SafeTensorLoader] Detected VL model")
-                        return
+                    return
                 elif f".{gate}.weight_scale" in key and "weight_scale_inv" not in key:
                     self._scale_suffix = "weight_scale"
                     self._is_per_channel = True


### PR DESCRIPTION
# What does this PR do?

1, Fix Qwen3.5 FP8 load. For VL models(Qwen3.5), modify base_key: model.layers.{N} -> model.language_model.layers.{N}
2, clean DUPLICATED class BF16SafeTensorLoader(SafeTensorLoader) , only the first overrided one.

## Before submitting

- [ ] Did you read the [contributor guideline](https://github.com/kvcache-ai/ktransformers/blob/main/.github/CONTRIBUTING.md)?
- [ ] Did you write any new necessary tests?