### PR TITLE
[feat]: add mistral moe loader compatibility

### DIFF
--- a/kt-kernel/python/utils/amx.py
+++ b/kt-kernel/python/utils/amx.py
@@ -448,6 +448,10 @@ class NativeMoEWrapper(BaseMoEWrapper):
                     self.down_scales = [t.to(torch.float32).contiguous() for t in weights["down_scale"]]
                 assert self.gate_scales[0].dtype == torch.float32, "Expected float32 scales for FP8"
             elif self.method == "FP8_PERCHANNEL":
+                if self.gate_scales[0].dtype != torch.float32:
+                    self.gate_scales = [t.to(torch.float32).contiguous() for t in weights["gate_scale"]]
+                    self.up_scales = [t.to(torch.float32).contiguous() for t in weights["up_scale"]]
+                    self.down_scales = [t.to(torch.float32).contiguous() for t in weights["down_scale"]]
                 assert self.gate_scales[0].dtype == torch.float32, "Expected float32 scales for FP8_PERCHANNEL"
 
         t2 = time.time()


### PR DESCRIPTION
## Summary
- add Mistral MoE key format support in FP8/BF16 loaders
- add base-key fallback for weights without model. prefix
- infer FP8 scale type by tensor shape when suffix is weight_scale
- cast FP8_PERCHANNEL scales to float32 before AMX load

## Validation
- py_compile passes
- Mistral startup and minimal request validation passed in kt env