### PR TITLE
[feat](kt-kernel): Add utility script to merge loose layer weights to safetensors

### DIFF
--- a/kt-kernel/scripts/merge_cpu_weights.py
+++ b/kt-kernel/scripts/merge_cpu_weights.py
@@ -98,9 +98,9 @@ def process_layer(layer_path: str, amx_prefix: str, layer_idx: int) -> dict:
 
             for quant_file in quant_files:
                 filename = os.path.basename(quant_file)
-                parts = filename.split("_")
+                remainder = filename[len(f"{amx_prefix}_{proj_name}_"):]
                 try:
-                    expert_idx = int(parts[2])
+                    expert_idx = int(remainder.split("_")[0])
                 except (ValueError, IndexError):
                     print(f"    Warning: Could not parse expert index from {filename}", file=sys.stderr)
                     continue
@@ -110,9 +110,9 @@ def process_layer(layer_path: str, amx_prefix: str, layer_idx: int) -> dict:
 
             for scale_file in scale_files:
                 filename = os.path.basename(scale_file)
-                parts = filename.split("_")
+                remainder = filename[len(f"{amx_prefix}_{proj_name}_"):]
                 try:
-                    expert_idx = int(parts[2])
+                    expert_idx = int(remainder.split("_")[0])
                 except (ValueError, IndexError):
                     print(f"    Warning: Could not parse expert index from {filename}", file=sys.stderr)
                     continue


### PR DESCRIPTION
# merge_cpu_weights.py

This is a simple utility script that merges CPU weights currently in the loose layers format (created using `convert_cpu_weights.py` with `--no-merge-safetensor` for memory savings) into sharded safetensors for more convenient upload.

The relevant args are:
- `--input-path`: Input directory with nested `_layer_*` folders
- `--output`: Output directory for merged safetensors
- `--original-path`: Original model folder with config.json and tokenizer files to copy
- `--max-tensors`: Maximum tensors per safetensors shard (default: 3000)

I decided to keep the default shard size as 3000 tensors to match the existing behavior of `convert_cpu_weights.py`.

## Before submitting

- [X] Did you read the [contributor guideline](https://github.com/kvcache-ai/ktransformers/blob/main/.github/CONTRIBUTING.md)?
- [X] Did you write any new necessary tests? - None needed