### PR TITLE
[fix] improve Sglang kt-kernel detect time duration

### DIFF
--- a/kt-kernel/python/cli/utils/sglang_checker.py
+++ b/kt-kernel/python/cli/utils/sglang_checker.py
@@ -324,7 +324,7 @@ def check_sglang_kt_kernel_support(use_cache: bool = True, silent: bool = False)
             [sys.executable, "-m", "sglang.launch_server", "--help"],
             capture_output=True,
             text=True,
-            timeout=90,
+            timeout=90,  # Increased for slow CUDA init and module loading in some environments
         )
 
         help_output = result.stdout + result.stderr


### PR DESCRIPTION
# What does this PR do?

Increase timeout for Check if --kt-gpu-prefill-token-threshold is in the help output to 90 seconds.
In cloud environments,CUDA initialization and Python module loading can easily exceed 30 seconds.

Fixes # (issue)

# https://github.com/kvcache-ai/ktransformers/issues/1785

## Before submitting

- [x] Did you read the [contributor guideline](https://github.com/kvcache-ai/ktransformers/blob/main/.github/CONTRIBUTING.md)?
- [x] Did you write any new necessary tests?