### PR TITLE
Reduce idle CPU usage by replacing polling with blocking in worker threads

### DIFF
--- a/kt-kernel/cpu_backend/worker_pool.cpp
+++ b/kt-kernel/cpu_backend/worker_pool.cpp
@@ -95,7 +95,11 @@ InNumaPool::InNumaPool(int max_thread_num, int numa_id, int threads_id_start) {
 
 InNumaPool::~InNumaPool() {
   for (int i = 0; i < total_worker_count; i++) {
-    thread_state_[i].status.store(ThreadStatus::EXIT, std::memory_order_release);
+    {
+      std::lock_guard<std::mutex> lock(thread_state_[i].mutex);
+      thread_state_[i].status.store(ThreadStatus::EXIT, std::memory_order_release);
+    }
+    thread_state_[i].cv.notify_one();
   }
   for (int i = 0; i < total_worker_count; i++) {
     if (workers_[i].joinable()) {
@@ -152,7 +156,11 @@ void InNumaPool::do_work_stealing_job_async(int task_num, std::function<void(int
   curr_.store(0, std::memory_order_release);
   end_ = task_num;
   for (int i = 0; i < worker_count; i++) {
-    thread_state_[i].status.store(ThreadStatus::WORKING, std::memory_order_release);
+    {
+      std::lock_guard<std::mutex> lock(thread_state_[i].mutex);
+      thread_state_[i].status.store(ThreadStatus::WORKING, std::memory_order_release);
+    }
+    thread_state_[i].cv.notify_one();
   }
   WorkerPool::thread_local_id = 0;
   process_tasks(0);
@@ -216,7 +224,10 @@ void InNumaPool::worker_thread(int thread_id, int numa_id) {
       auto now = std::chrono::high_resolution_clock::now();
       auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(now - start).count();
       if (duration > 50) {
-        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+        std::unique_lock<std::mutex> lock(thread_state_[thread_id].mutex);
+        thread_state_[thread_id].cv.wait(lock, [&] {
+          return thread_state_[thread_id].status.load(std::memory_order_acquire) != ThreadStatus::WAITING;
+        });
       }
     } else if (status == ThreadStatus::EXIT) {
       return;
@@ -243,6 +254,8 @@ void NumaJobDistributor::init(std::vector<int> numa_ids) {
   this->numa_ids = numa_ids;
   for (size_t i = 0; i < numa_count; i++) {
     status.push_back(nullptr);
+    mutexes.push_back(std::make_unique<std::mutex>());
+    cvs.push_back(std::make_unique<std::condition_variable>());
   }
 
   workers.resize(numa_count);
@@ -264,6 +277,8 @@ void NumaJobDistributor::init(std::vector<int> numa_ids, std::vector<int> thread
   this->numa_ids = numa_ids;
   for (size_t i = 0; i < numa_count; i++) {
     status.push_back(nullptr);
+    mutexes.push_back(std::make_unique<std::mutex>());
+    cvs.push_back(std::make_unique<std::condition_variable>());
   }
 
   workers.resize(numa_count);
@@ -315,7 +330,11 @@ void NumaJobDistributor::init(std::vector<int> numa_ids, std::vector<int> thread
 
 NumaJobDistributor::~NumaJobDistributor() {
   for (int i = 0; i < numa_count; i++) {
-    status[i]->store(ThreadStatus::EXIT, std::memory_order_release);
+    {
+      std::lock_guard<std::mutex> lock(*mutexes[i]);
+      status[i]->store(ThreadStatus::EXIT, std::memory_order_release);
+    }
+    cvs[i]->notify_one();
   }
   for (int i = 0; i < numa_count; i++) {
     if (workers[i].joinable()) {
@@ -332,7 +351,11 @@ void NumaJobDistributor::do_numa_job(std::function<void(int)> compute_func) {
   for (int i = 0; i < numa_count; i++) {
     if (i == me_numa) continue;
 
-    status[i]->store(ThreadStatus::WORKING, std::memory_order_release);
+    {
+      std::lock_guard<std::mutex> lock(*mutexes[i]);
+      status[i]->store(ThreadStatus::WORKING, std::memory_order_release);
+    }
+    cvs[i]->notify_one();
   }
   compute_func(me_numa);
   for (int i = 0; i < numa_count; i++) {
@@ -346,7 +369,11 @@ void NumaJobDistributor::do_numa_job(std::function<void(int)> compute_func) {
 void NumaJobDistributor::do_numa_job(std::function<void(int)> compute_func) {
   this->compute_func = compute_func;
   for (int i = 0; i < numa_count; i++) {
-    status[i]->store(ThreadStatus::WORKING, std::memory_order_release);
+    {
+      std::lock_guard<std::mutex> lock(*mutexes[i]);
+      status[i]->store(ThreadStatus::WORKING, std::memory_order_release);
+    }
+    cvs[i]->notify_one();
   }
   for (int i = 0; i < numa_count; i++) {
     while (status[i]->load(std::memory_order_acquire) == ThreadStatus::WORKING) {
@@ -373,7 +400,10 @@ void NumaJobDistributor::worker_thread(int numa_id) {
       auto now = std::chrono::high_resolution_clock::now();
       auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(now - start).count();
       if (duration > 50) {
-        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+        std::unique_lock<std::mutex> lock(*mutexes[numa_id]);
+        cvs[numa_id]->wait(lock, [&] {
+          return status[numa_id]->load(std::memory_order_acquire) != ThreadStatus::WAITING;
+        });
       }
     } else if (stat == ThreadStatus::EXIT) {
       return;

--- a/kt-kernel/cpu_backend/worker_pool.h
+++ b/kt-kernel/cpu_backend/worker_pool.h
@@ -62,6 +62,8 @@ enum ThreadStatus {
 
 struct alignas(64) ThreadState {
   std::atomic<ThreadStatus> status;
+  std::mutex mutex;
+  std::condition_variable cv;
 #ifdef PROFILE_BALANCE
   size_t finish_ns;
 #endif
@@ -119,6 +121,8 @@ class NumaJobDistributor {
   int numa_count;
   std::vector<int> numa_ids;
   std::vector<std::unique_ptr<std::atomic<ThreadStatus>>> status;
+  std::vector<std::unique_ptr<std::mutex>> mutexes;
+  std::vector<std::unique_ptr<std::condition_variable>> cvs;
   std::function<void(int)> compute_func;
   std::vector<std::thread> workers;
 


### PR DESCRIPTION
This PR eliminates excessive idle CPU usage in the CPU backend threadpools by replacing fixed-interval polling (`sleep_for(1ms)`) with condition-variable-based blocking.

The current behavior is that worker threads spin for `50ms` upon first becoming idle, and then enter a `1ms` sleep-based polling loop. This results in around ~2% idle CPU utilization per thread. On my configuration with `--kt-cpuinfer 128`, this adds up to around ~256%, or ~2.5 cores worth of constant CPU utilization while no inference requests are running.

With this PR:
- Worker threads retain the existing `50ms` active period
- Replace `sleep_for(1ms)` with `std::condition_variable::wait`
- Add per-thread:
  - `std::mutex`
  - `std::condition_variable`
- Notify threads (`notify_one`) when transitioning to `WORKING` or `EXIT`

After applying these changes locally, the inference server's idle CPU usage drops from ~256% to a mere ~1-2%.

## Before submitting

- [x] Did you read the [contributor guideline](https://github.com/kvcache-ai/ktransformers/blob/main/.github/CONTRIBUTING.md)?
- [ ] Did you write any new necessary tests?