### PR TITLE
fix: remove broken symlink in archive/ktransformers/

### DIFF
--- a/archive/ktransformers/ktransformers
+++ b/archive/ktransformers/ktransformers
@@ -1,1 +1,0 @@
-/home/djw/py311_717/ktransformers/ktransformers


### PR DESCRIPTION
The symlink `archive/ktransformers/ktransformers` points to `/home/djw/py311_717/ktransformers/ktransformers`, an absolute path on a developer's local machine. It was introduced in #1581 during the repository restructuring and is broken on every other machine.

Tools that recursively copy the repo tree (e.g. `shutil.copytree`) fail with `FileNotFoundError` on this dangling link.

# What does this PR do?

Remove the broken symlink in `archive/ktransformers/`.

Fixes #1905

## Before submitting

- [x] Did you read the [contributor guideline](https://github.com/kvcache-ai/ktransformers/blob/main/.github/CONTRIBUTING.md)?
- [x] Did you write any new necessary tests?

No tests needed — this is a one-line deletion of a dangling symlink in archived legacy code.
