### PR TITLE
[fix](cli): handle edge cases with empty NUMA nodes

### DIFF
--- a/kt-kernel/python/cli/utils/environment.py
+++ b/kt-kernel/python/cli/utils/environment.py
@@ -446,6 +446,9 @@ def _parse_cpu_flags(flags: list[str]) -> list[str]:
 def _parse_cpu_list(cpulist: str) -> list[int]:
     """Parse CPU list string like '0-3,8-11' to list of CPU IDs."""
     cpus = []
+    if cpulist == "":
+        # if there are no cpu cores for a specific numa node (for example, virtual numa on optane), return empty list
+        return cpus
     for part in cpulist.split(","):
         if "-" in part:
             start, end = part.split("-")


### PR DESCRIPTION
# What does this PR do?

When the system contains a NUMA node without any cores, the `_parse_cpu_list()` function crashes with the following error:

```
ValueError: invalid literal for int() with base 10: ''
```

This fix adds edge-case handling by returning an empty list. Further processing downstream will treat the return value as one single NUMA node, which is expected behavior.

## Technical background

Empty NUMA nodes appear on systems with Intel's Optane DCPMM modules. In standard Memory Mode, some system DRAM is used as a transparent direct-mapped cache for Optane modules, and thus will be considered one NUMA node per socket. In this case, the DRAM capacity is "absorbed" into that of Optane (for example, 64GiB DRAM+256GiB Optane = 256GiB visible to system, minus some overhead). However, there is also a technique to expand system RAM with Optane Modules by setting them to App Direct mode and them mapping them as memory on a virtual NUMA node with daxctl. This enables the capacity of DRAM and Optane to be presented as separate memory regions. Furthermore, this enables advanced LRU-based page promotion and demotion algorithm to be used.

## Before submitting

- [x] Did you read the [contributor guideline](https://github.com/kvcache-ai/ktransformers/blob/main/.github/CONTRIBUTING.md)?
- [ ] Did you write any new necessary tests? N/A