### PR TITLE
[feat](kt-kernel): add AVX2/AVX-VNNI RAWINT4 MoE backend

### DIFF
--- a/doc/en/kt-kernel/AVX2-Tutorial.md
+++ b/doc/en/kt-kernel/AVX2-Tutorial.md
@@ -12,6 +12,7 @@ This tutorial explains how to run KTransformers on machines that only support AV
   - [Example: Qwen3-30B-A3B (BF16)](#example-qwen3-30b-a3b-bf16)
   - [Example: Qwen3.5-35B-A3B-FP8 (FP8)](#example-qwen35-35b-a3b-fp8-fp8)
   - [Example: Qwen3-30B-A3B-GPTQ-Int4 (GPTQ_INT4)](#example-qwen3-30b-a3b-gptq-int4-gptq_int4)
+  - [Example: Kimi-K2.5 (RAWINT4)](#example-kimi-k25-rawint4)
   - [Sending Requests](#sending-requests)
 - [Performance Tuning](#performance-tuning)
 - [FAQ](#faq)
@@ -23,6 +24,7 @@ This tutorial explains how to run KTransformers on machines that only support AV
 | `BF16` | BF16 native precision | Zero precision loss, uses BF16 weights directly |
 | `FP8` | FP8 block quantization |  |
 | `GPTQ_INT4` | INT4 GPTQ |  |
+| `RAWINT4` | Raw INT4 with BF16 scales | Used by Kimi-K2.5; weights stored in compressed SafeTensor format |
 
 
 ## Hardware Requirements
@@ -71,7 +73,7 @@ kt doctor
 
 ## Starting the Inference Server
 
-Use `--kt-method BF16`, `FP8`, or `GPTQ_INT4`. KT-Kernel will **automatically detect** the CPU and fall back to the AVX2 backend when AVX512/AMX is unavailable.
+Use `--kt-method BF16`, `FP8`, `GPTQ_INT4`, or `RAWINT4`. KT-Kernel will **automatically detect** the CPU and fall back to the AVX2 backend when AVX512/AMX is unavailable.
 
 ### Example: Qwen3-30B-A3B (BF16)
 
@@ -153,6 +155,36 @@ python -m sglang.launch_server \
   --max-total-tokens 32000 \
   --enable-mixed-chunk \
   --tensor-parallel-size 1 \
+  --disable-shared-experts-fusion
+```
+
+### Example: Kimi-K2.5 (RAWINT4)
+
+> **Note**: The following command is optimized for 4x RTX PRO 6000 Blackwell (96GB each) + AMD Threadripper PRO 5995WX (64 cores, 1 NUMA node) + 256GB RAM.
+
+```bash
+# Download the model
+huggingface-cli download moonshotai/Kimi-K2.5 --local-dir /path/to/Kimi-K2.5
+
+# Start the server
+python -m sglang.launch_server \
+  --host 0.0.0.0 --port 30000 \
+  --model /path/to/Kimi-K2.5 \
+  --kt-weight-path /path/to/Kimi-K2.5 \
+  --kt-cpuinfer 64 \
+  --kt-threadpool-count 1 \
+  --kt-num-gpu-experts 228 \
+  --kt-enable-dynamic-expert-update \
+  --kt-method RAWINT4 \
+  --attention-backend flashinfer \
+  --trust-remote-code \
+  --mem-fraction-static 0.95 \
+  --chunked-prefill-size 8192 \
+  --max-running-requests 4 \
+  --context-length 262144 \
+  --enable-mixed-chunk \
+  --tensor-parallel-size 4 \
+  --enable-p2p-check \
   --disable-shared-experts-fusion
 ```
 

--- a/doc/zh/AVX2-Tutorial_zh.md
+++ b/doc/zh/AVX2-Tutorial_zh.md
@@ -12,6 +12,7 @@
   - [示例：Qwen3-30B-A3B (BF16)](#示例qwen3-30b-a3b-bf16)
   - [示例：Qwen3.5-35B-A3B-FP8 (FP8)](#示例qwen35-35b-a3b-fp8-fp8)
   - [示例：Qwen3-30B-A3B-GPTQ-Int4 (GPTQ_INT4)](#示例qwen3-30b-a3b-gptq-int4-gptq_int4)
+  - [示例：Kimi-K2.5 (RAWINT4)](#示例kimi-k25-rawint4)
   - [发送请求](#发送请求)
 - [性能调优](#性能调优)
 - [常见问题](#常见问题)
@@ -23,6 +24,7 @@
 | `BF16` | BF16 原精度 | 零精度损失，直接使用 BF16 权重 |
 | `FP8` | FP8 分块量化 |  |
 | `GPTQ_INT4` | INT4 GPTQ |  |
+| `RAWINT4` | Raw INT4 + BF16 缩放因子 | Kimi-K2.5 专用；权重以压缩 SafeTensor 格式存储 |
 
 
 ## 硬件要求
@@ -71,7 +73,7 @@ kt doctor
 
 ## 启动推理服务
 
-使用 `--kt-method BF16`、`FP8` 或 `GPTQ_INT4`，KT-Kernel 会**自动检测** CPU 并在缺少 AVX512/AMX 时回退到 AVX2 后端。
+使用 `--kt-method BF16`、`FP8`、`GPTQ_INT4` 或 `RAWINT4`，KT-Kernel 会**自动检测** CPU 并在缺少 AVX512/AMX 时回退到 AVX2 后端。
 
 ### 示例：Qwen3-30B-A3B (BF16)
 
@@ -155,6 +157,37 @@ python -m sglang.launch_server \
   --tensor-parallel-size 1 \
   --disable-shared-experts-fusion
 ```
+
+### 示例：Kimi-K2.5 (RAWINT4)
+
+> **说明**：以下命令针对 4x RTX PRO 6000 Blackwell（各 96GB）+ AMD Threadripper PRO 5995WX（64 核，1 NUMA 节点）+ 256GB RAM 优化。
+
+```bash
+# 下载模型
+huggingface-cli download moonshotai/Kimi-K2.5 --local-dir /path/to/Kimi-K2.5
+
+# 启动服务
+python -m sglang.launch_server \
+  --host 0.0.0.0 --port 30000 \
+  --model /path/to/Kimi-K2.5 \
+  --kt-weight-path /path/to/Kimi-K2.5 \
+  --kt-cpuinfer 64 \
+  --kt-threadpool-count 1 \
+  --kt-num-gpu-experts 228 \
+  --kt-enable-dynamic-expert-update \
+  --kt-method RAWINT4 \
+  --attention-backend flashinfer \
+  --trust-remote-code \
+  --mem-fraction-static 0.95 \
+  --chunked-prefill-size 8192 \
+  --max-running-requests 4 \
+  --context-length 262144 \
+  --enable-mixed-chunk \
+  --tensor-parallel-size 4 \
+  --enable-p2p-check \
+  --disable-shared-experts-fusion
+```
+
 
 ### 发送请求
 

--- a/kt-kernel/ext_bindings.cpp
+++ b/kt-kernel/ext_bindings.cpp
@@ -9,13 +9,8 @@
  **/
 // Python bindings
 #include <sys/types.h>
-#include <sys/wait.h>
-#include <unistd.h>
 
-#include <cpptrace/cpptrace.hpp>
-#include <csignal>
 #include <cstddef>
-#include <cstring>
 
 #include "cpu_backend/cpuinfer.h"
 #include "cpu_backend/worker_pool.h"
@@ -47,8 +42,6 @@ static const bool _is_plain_ = false;
 #include "operators/amx/k2-moe.hpp"
 #include "operators/amx/la/amx_kernels.hpp"
 #include "operators/amx/moe.hpp"
-#include "operators/amx/sft_moe.hpp"
-#include "operators/moe-sft-tp.hpp"
 #endif
 // AVX2 backends — always available on x86_64 (no AMX/AVX512 dependency)
 #if defined(__x86_64__)
@@ -56,6 +49,8 @@ static const bool _is_plain_ = false;
 #include "operators/avx2/fp8-moe.hpp"
 #include "operators/avx2/gptq_int4_avxvnni-moe.hpp"
 #include "operators/avx2/gptq_int4-moe.hpp"
+#include "operators/avx2/raw_int4_avxvnni-moe.hpp"
+#include "operators/avx2/raw_int4-moe.hpp"
 #endif
 
 #include <pybind11/stl.h>  // std::vector/std::pair/std::string conversions
@@ -73,7 +68,6 @@ static const bool _is_plain_ = false;
 
 namespace py = pybind11;
 using namespace pybind11::literals;
-
 
 py::object to_float_ptr(uintptr_t input_ptr, int size, ggml_type type) {
   if (type < 0 || type >= GGML_TYPE_COUNT) {
@@ -241,165 +235,6 @@ class MOEBindings {
   };
 };
 
-#if defined(__x86_64__) && defined(USE_AMX_AVX_KERNEL)
-template <class T>
-class MOESFTBindings {
- public:
-  class WarmUpBindings {
-   public:
-    struct Args {
-      CPUInfer* cpuinfer;
-      TP_MOE_SFT<T>* moe;
-    };
-    static void inner(void* args) {
-      Args* args_ = (Args*)args;
-      args_->cpuinfer->enqueue(&TP_MOE_SFT<T>::warm_up, args_->moe);
-    }
-    static std::pair<intptr_t, intptr_t> cpuinfer_interface(std::shared_ptr<TP_MOE_SFT<T>> moe) {
-      Args* args = new Args{nullptr, moe.get()};
-      return std::make_pair((intptr_t)&inner, (intptr_t)args);
-    }
-  };
-
-  class LoadWeightsBindings {
-   public:
-    struct Args {
-      CPUInfer* cpuinfer;
-      TP_MOE_SFT<T>* moe;
-    };
-    static void inner(void* args) {
-      Args* args_ = (Args*)args;
-      args_->cpuinfer->enqueue(&TP_MOE_SFT<T>::load_weights, args_->moe);
-    }
-    static std::pair<intptr_t, intptr_t> cpuinfer_interface(std::shared_ptr<TP_MOE_SFT<T>> moe) {
-      Args* args = new Args{nullptr, moe.get()};
-      return std::make_pair((intptr_t)&inner, (intptr_t)args);
-    }
-  };
-
-  class ForwardSFTBindings {
-   public:
-    struct Args {
-      CPUInfer* cpuinfer;
-      TP_MOE_SFT<T>* moe;
-      intptr_t qlen;
-      int k;
-      intptr_t expert_ids;
-      intptr_t weights;
-      intptr_t input;
-      intptr_t output;
-      bool save_for_backward;
-    };
-    static void inner(void* args) {
-      Args* args_ = (Args*)args;
-      args_->cpuinfer->enqueue(&TP_MOE_SFT<T>::forward_sft_binding, args_->moe, args_->qlen, args_->k,
-                               args_->expert_ids, args_->weights, args_->input, args_->output,
-                               args_->save_for_backward);
-    }
-    static std::pair<intptr_t, intptr_t> cpuinfer_interface(std::shared_ptr<TP_MOE_SFT<T>> moe, intptr_t qlen, int k,
-                                                            intptr_t expert_ids, intptr_t weights, intptr_t input,
-                                                            intptr_t output, bool save_for_backward) {
-      Args* args = new Args{nullptr, moe.get(), qlen, k, expert_ids, weights, input, output, save_for_backward};
-      return std::make_pair((intptr_t)&inner, (intptr_t)args);
-    }
-  };
-
-  class BackwardBindings {
-   public:
-    struct Args {
-      CPUInfer* cpuinfer;
-      TP_MOE_SFT<T>* moe;
-      intptr_t grad_output;
-      intptr_t grad_input;
-      intptr_t grad_gate_lora_a;
-      intptr_t grad_gate_lora_b;
-      intptr_t grad_up_lora_a;
-      intptr_t grad_up_lora_b;
-      intptr_t grad_down_lora_a;
-      intptr_t grad_down_lora_b;
-      intptr_t grad_weights;
-    };
-    static void inner(void* args) {
-      Args* args_ = (Args*)args;
-      args_->cpuinfer->enqueue(&TP_MOE_SFT<T>::backward_binding, args_->moe, args_->grad_output, args_->grad_input,
-                               args_->grad_gate_lora_a, args_->grad_gate_lora_b, args_->grad_up_lora_a,
-                               args_->grad_up_lora_b, args_->grad_down_lora_a, args_->grad_down_lora_b,
-                               args_->grad_weights);
-    }
-    static std::pair<intptr_t, intptr_t> cpuinfer_interface(std::shared_ptr<TP_MOE_SFT<T>> moe, intptr_t grad_output,
-                                                            intptr_t grad_input, intptr_t grad_gate_lora_a,
-                                                            intptr_t grad_gate_lora_b, intptr_t grad_up_lora_a,
-                                                            intptr_t grad_up_lora_b, intptr_t grad_down_lora_a,
-                                                            intptr_t grad_down_lora_b, intptr_t grad_weights) {
-      Args* args = new Args{nullptr,          moe.get(),        grad_output,    grad_input,
-                            grad_gate_lora_a, grad_gate_lora_b, grad_up_lora_a, grad_up_lora_b,
-                            grad_down_lora_a, grad_down_lora_b, grad_weights};
-      return std::make_pair((intptr_t)&inner, (intptr_t)args);
-    }
-  };
-
-  class UpdateLoRAWeightsBindings {
-   public:
-    struct Args {
-      CPUInfer* cpuinfer;
-      TP_MOE_SFT<T>* moe;
-      intptr_t gate_lora_a;
-      intptr_t gate_lora_b;
-      intptr_t up_lora_a;
-      intptr_t up_lora_b;
-      intptr_t down_lora_a;
-      intptr_t down_lora_b;
-    };
-    static void inner(void* args) {
-      // Debug code for Bug #18 - commented out after fix verified
-      // printf("[DEBUG UpdateLoRAWeightsBindings::inner] called\n");
-      Args* args_ = (Args*)args;
-      // printf("  moe=%p, gate_lora_a=%p, gate_lora_b=%p\n", (void*)args_->moe, (void*)args_->gate_lora_a,
-      // (void*)args_->gate_lora_b); printf("  up_lora_a=%p, up_lora_b=%p\n", (void*)args_->up_lora_a,
-      // (void*)args_->up_lora_b); printf("  down_lora_a=%p, down_lora_b=%p\n", (void*)args_->down_lora_a,
-      // (void*)args_->down_lora_b);
-      args_->cpuinfer->enqueue(&TP_MOE_SFT<T>::update_lora_weights_binding, args_->moe, args_->gate_lora_a,
-                               args_->gate_lora_b, args_->up_lora_a, args_->up_lora_b, args_->down_lora_a,
-                               args_->down_lora_b);
-      // printf("[DEBUG UpdateLoRAWeightsBindings::inner] enqueue done\n");
-    }
-    static std::pair<intptr_t, intptr_t> cpuinfer_interface(std::shared_ptr<TP_MOE_SFT<T>> moe, intptr_t gate_lora_a,
-                                                            intptr_t gate_lora_b, intptr_t up_lora_a,
-                                                            intptr_t up_lora_b, intptr_t down_lora_a,
-                                                            intptr_t down_lora_b) {
-      Args* args =
-          new Args{nullptr, moe.get(), gate_lora_a, gate_lora_b, up_lora_a, up_lora_b, down_lora_a, down_lora_b};
-      return std::make_pair((intptr_t)&inner, (intptr_t)args);
-    }
-  };
-};
-
-template <typename MoeSftTP>
-void bind_moe_sft_module(py::module_& moe_module, const char* name) {
-  using MoeClass = TP_MOE_SFT<MoeSftTP>;
-  using MoeBindings = MOESFTBindings<MoeSftTP>;
-
-  py::class_<MoeClass, MoE_Interface, std::shared_ptr<MoeClass>>(moe_module, name)
-      .def(py::init<MOESFTConfig>())
-      .def("warm_up_task", &MoeBindings::WarmUpBindings::cpuinfer_interface)
-      .def("load_weights_task", &MoeBindings::LoadWeightsBindings::cpuinfer_interface)
-      .def("forward_sft_task", &MoeBindings::ForwardSFTBindings::cpuinfer_interface)
-      .def("backward_task", &MoeBindings::BackwardBindings::cpuinfer_interface)
-      .def("update_lora_weights_task", &MoeBindings::UpdateLoRAWeightsBindings::cpuinfer_interface)
-      .def("warm_up", &MoeClass::warm_up)
-      .def("load_weights", &MoeClass::load_weights)
-      .def("forward_sft", &MoeClass::forward_sft_binding)
-      .def("backward", &MoeClass::backward_binding)
-      .def("update_lora_weights", &MoeClass::update_lora_weights_binding)
-      .def("prepare_and_save_bwd",
-           [](MoeClass& self, intptr_t gate, intptr_t up, intptr_t down, const std::string& path) {
-             self.prepare_and_save_bwd((void*)gate, (void*)up, (void*)down, path);
-           })
-      .def("submit_backward_repack", &MoeClass::submit_backward_repack)
-      .def("wait_backward_repack", &MoeClass::wait_backward_repack);
-}
-#endif  // defined(__x86_64__) && defined(USE_AMX_AVX_KERNEL)
-
 template <typename MoeTP>
 void bind_moe_module(py::module_& moe_module, const char* name) {
   using MoeClass = TP_MOE<MoeTP>;
@@ -473,7 +308,6 @@ void bind_moe_module(py::module_& moe_module, const char* name) {
 }
 
 PYBIND11_MODULE(kt_kernel_ext, m) {
-
   py::class_<WorkerPool>(m, "WorkerPool").def(py::init<int>());
   py::class_<WorkerPoolConfig>(m, "WorkerPoolConfig")
       .def(py::init<>())
@@ -677,12 +511,6 @@ PYBIND11_MODULE(kt_kernel_ext, m) {
       .def(py::init([](int expert_num, int routed_expert_num, int hidden_size, int intermediate_size) {
         return GeneralMOEConfig(expert_num, routed_expert_num, hidden_size, intermediate_size);
       }))
-      .def(py::init(
-          [](int expert_num, int routed_expert_num, int hidden_size, int intermediate_size, int num_gpu_experts) {
-            GeneralMOEConfig cfg(expert_num, routed_expert_num, hidden_size, intermediate_size);
-            cfg.num_gpu_experts = num_gpu_experts;
-            return cfg;
-          }))
       .def(py::init([](int expert_num, int routed_expert_num, int hidden_size, int intermediate_size,
                        uintptr_t gpu_experts_mask_ptr) {
         GeneralMOEConfig cfg(expert_num, routed_expert_num, hidden_size, intermediate_size);
@@ -690,11 +518,6 @@ PYBIND11_MODULE(kt_kernel_ext, m) {
         cfg.compute_num_gpu_experts();
         return cfg;
       }))
-      // Core config fields (required for Python access after construction)
-      .def_readwrite("expert_num", &GeneralMOEConfig::expert_num)
-      .def_readwrite("num_experts_per_tok", &GeneralMOEConfig::num_experts_per_tok)
-      .def_readwrite("hidden_size", &GeneralMOEConfig::hidden_size)
-      .def_readwrite("intermediate_size", &GeneralMOEConfig::intermediate_size)
       .def_readwrite("layer_idx", &GeneralMOEConfig::layer_idx)
       .def_readwrite("pool", &GeneralMOEConfig::pool)
 
@@ -733,18 +556,9 @@ PYBIND11_MODULE(kt_kernel_ext, m) {
       .DEF_PTR_2D_PROPERTY(GeneralMOEConfig, up_zeros)
       .DEF_PTR_2D_PROPERTY(GeneralMOEConfig, down_zeros)
 
-      .DEF_PTR_2D_PROPERTY(GeneralMOEConfig, gate_bwd_projs)
-      .DEF_PTR_2D_PROPERTY(GeneralMOEConfig, up_bwd_projs)
-      .DEF_PTR_2D_PROPERTY(GeneralMOEConfig, down_bwd_projs)
-      .DEF_PTR_2D_PROPERTY(GeneralMOEConfig, gate_bwd_scales)
-      .DEF_PTR_2D_PROPERTY(GeneralMOEConfig, up_bwd_scales)
-      .DEF_PTR_2D_PROPERTY(GeneralMOEConfig, down_bwd_scales)
-
       .def_readwrite("path", &GeneralMOEConfig::path)
       .def_readwrite("save", &GeneralMOEConfig::save)
       .def_readwrite("load", &GeneralMOEConfig::load)
-      .def_readwrite("share_backward_bb", &GeneralMOEConfig::share_backward_bb)
-      .def_readwrite("share_cache_pool", &GeneralMOEConfig::share_cache_pool)
       .def_readwrite("m_block", &GeneralMOEConfig::m_block)
       .def_readwrite("group_min_len", &GeneralMOEConfig::group_min_len)
       .def_readwrite("group_max_len", &GeneralMOEConfig::group_max_len)
@@ -753,24 +567,8 @@ PYBIND11_MODULE(kt_kernel_ext, m) {
       .def_readwrite("up_type", &GeneralMOEConfig::up_type)
       .def_readwrite("down_type", &GeneralMOEConfig::down_type)
       .def_readwrite("hidden_type", &GeneralMOEConfig::hidden_type)
-      .def_readwrite("max_cache_depth", &GeneralMOEConfig::max_cache_depth)
 
       ;
-
-  // MOESFTConfig - extends GeneralMOEConfig with LoRA support
-  py::class_<MOESFTConfig, GeneralMOEConfig>(moe_module, "MOESFTConfig")
-      .def(py::init<>())
-      .def(py::init([](int expert_num, int routed_expert_num, int hidden_size, int intermediate_size) {
-        return MOESFTConfig(expert_num, routed_expert_num, hidden_size, intermediate_size);
-      }))
-      .def_readwrite("lora_rank", &MOESFTConfig::lora_rank)
-      .def_readwrite("lora_alpha", &MOESFTConfig::lora_alpha)
-      .DEF_PTR_PROPERTY(MOESFTConfig, gate_lora_a)
-      .DEF_PTR_PROPERTY(MOESFTConfig, gate_lora_b)
-      .DEF_PTR_PROPERTY(MOESFTConfig, up_lora_a)
-      .DEF_PTR_PROPERTY(MOESFTConfig, up_lora_b)
-      .DEF_PTR_PROPERTY(MOESFTConfig, down_lora_a)
-      .DEF_PTR_PROPERTY(MOESFTConfig, down_lora_b);
 
   py::class_<MoE_Interface, std::shared_ptr<MoE_Interface>>(moe_module, "MoE_Interface");
 
@@ -787,33 +585,17 @@ PYBIND11_MODULE(kt_kernel_ext, m) {
   bind_moe_module<AMX_FP8_MOE_TP<amx::GemmKernel224FP8>>(moe_module, "AMXFP8_MOE");
   bind_moe_module<AMX_FP8_PERCHANNEL_MOE_TP<amx::GemmKernel224FP8PerChannel>>(moe_module, "AMXFP8PerChannel_MOE");
 #endif
-  // SFT MoE with LoRA support (BF16, INT8, INT4, AWQ, K2)
-  bind_moe_sft_module<AMX_SFT_MOE_TP<amx::GemmKernel224BF>>(moe_module, "AMXBF16_SFT_MOE");
-  bind_moe_sft_module<AMX_SFT_MOE_TP<amx::GemmKernel224Int8>>(moe_module, "AMXInt8_SFT_MOE");
-  bind_moe_sft_module<AMX_SFT_MOE_TP<amx::GemmKernel224Int4>>(moe_module, "AMXInt4_SFT_MOE");
-  // bind_moe_sft_module<AMX_SFT_MOE_TP<amx::GemmKernel224Int4_1>>(moe_module, "AMXInt4_1_SFT_MOE");
-  // bind_moe_sft_module<AMX_SFT_MOE_TP<amx::GemmKernel224Int4_1_LowKGroup, AMX_AWQ_MOE_TP>>(moe_module,
-  //                                                                                         "AMXInt4_1KGroup_SFT_MOE");
-  // bind_moe_sft_module<AMX_SFT_MOE_TP<amx::GemmKernel224Int4SmallKGroup, AMX_K2_MOE_TP>>(moe_module,
-  //                                                                                       "AMXInt4_KGroup_SFT_MOE");
-  // SFT MoE with SkipLoRA=true (skip all LoRA computation in backward, only compute base weight grad_input)
-  bind_moe_sft_module<AMX_SFT_MOE_TP<amx::GemmKernel224BF, AMX_MOE_TP, true>>(moe_module, "AMXBF16_SFT_MOE_SkipLoRA");
-  bind_moe_sft_module<AMX_SFT_MOE_TP<amx::GemmKernel224Int8, AMX_MOE_TP, true>>(moe_module, "AMXInt8_SFT_MOE_SkipLoRA");
-  bind_moe_sft_module<AMX_SFT_MOE_TP<amx::GemmKernel224Int4, AMX_MOE_TP, true>>(moe_module, "AMXInt4_SFT_MOE_SkipLoRA");
-  // bind_moe_sft_module<AMX_SFT_MOE_TP<amx::GemmKernel224Int4_1, AMX_MOE_TP, true>>(moe_module,
-  //                                                                                 "AMXInt4_1_SFT_MOE_SkipLoRA");
-  // bind_moe_sft_module<AMX_SFT_MOE_TP<amx::GemmKernel224Int4_1_LowKGroup, AMX_AWQ_MOE_TP, true>>(
-  //     moe_module, "AMXInt4_1KGroup_SFT_MOE_SkipLoRA");
-  // bind_moe_sft_module<AMX_SFT_MOE_TP<amx::GemmKernel224Int4SmallKGroup, AMX_K2_MOE_TP, true>>(
-  //     moe_module, "AMXInt4_KGroup_SFT_MOE_SkipLoRA");
 #endif
 // AVX2 backends — available on all x86_64 (no AMX/AVX512 requirement)
 #if defined(__x86_64__)
   bind_moe_module<AVX2_BF16_MOE_TP<avx2::GemmKernelAVX2BF16>>(moe_module, "AVX2BF16_MOE");
   bind_moe_module<AVX2_FP8_MOE_TP<avx2::GemmKernelAVX2FP8>>(moe_module, "AVX2FP8_MOE");
   bind_moe_module<AVX2_GPTQ_INT4_MOE_TP<avx2::GemmKernelAVX2GPTQInt4>>(moe_module, "AVX2GPTQInt4_MOE");
+  bind_moe_module<AVX2_RAW_INT4_MOE_TP<avx2::GemmKernelAVX2RawInt4>>(moe_module, "AVX2RawInt4_MOE");
   bind_moe_module<AVXVNNI256_GPTQ_INT4_MOE_TP<avxvnni::GemmKernelAVXVNNI256GPTQInt4>>(moe_module,
                                                                                         "AVXVNNI256GPTQInt4_MOE");
+  bind_moe_module<AVXVNNI256_RAW_INT4_MOE_TP<avxvnni_rawint4::GemmKernelAVXVNNI256RawInt4>>(moe_module,
+                                                                                              "AVXVNNI256RawInt4_MOE");
 #endif
 
 #if defined(USE_MOE_KERNEL)
@@ -975,30 +757,3 @@ PYBIND11_MODULE(kt_kernel_ext, m) {
   utils.def("from_float", &from_float_ptr, "Convert tensor from float32 to any GGML type", py::arg("input"),
             py::arg("size"), py::arg("type"));
 }
-
-static void warmup_cpptrace() {
-  // 避免第一次调用触发 lazy-loading（malloc 等） :contentReference[oaicite:7]{index=7}
-  cpptrace::frame_ptr buffer[10];
-  (void)cpptrace::safe_generate_raw_trace(buffer, 10);
-  cpptrace::safe_object_frame frame{};
-  cpptrace::get_safe_object_frame(buffer[0], &frame);
-}
-
-static void crash_handler(int signo, siginfo_t* /*info*/, void* /*ucontext*/) {
-  const char* head = "=== crash: signal received ===\n";
-  write(STDERR_FILENO, head, std::strlen(head));
-  cpptrace::generate_trace().print();
-  _exit(128 + signo);
-}
-
-__attribute__((constructor)) static void install_handlers() {
-  struct sigaction sa;
-  std::memset(&sa, 0, sizeof(sa));
-  sa.sa_sigaction = &crash_handler;
-  sa.sa_flags = SA_SIGINFO;
-  sigemptyset(&sa.sa_mask);
-
-  sigaction(SIGSEGV, &sa, nullptr);
-  sigaction(SIGABRT, &sa, nullptr);
-}
-

--- a/kt-kernel/ext_bindings.cpp
+++ b/kt-kernel/ext_bindings.cpp
@@ -9,8 +9,13 @@
  **/
 // Python bindings
 #include <sys/types.h>
+#include <sys/wait.h>
+#include <unistd.h>
 
+#include <cpptrace/cpptrace.hpp>
+#include <csignal>
 #include <cstddef>
+#include <cstring>
 
 #include "cpu_backend/cpuinfer.h"
 #include "cpu_backend/worker_pool.h"
@@ -42,6 +47,8 @@ static const bool _is_plain_ = false;
 #include "operators/amx/k2-moe.hpp"
 #include "operators/amx/la/amx_kernels.hpp"
 #include "operators/amx/moe.hpp"
+#include "operators/amx/sft_moe.hpp"
+#include "operators/moe-sft-tp.hpp"
 #endif
 // AVX2 backends — always available on x86_64 (no AMX/AVX512 dependency)
 #if defined(__x86_64__)
@@ -68,6 +75,7 @@ static const bool _is_plain_ = false;
 
 namespace py = pybind11;
 using namespace pybind11::literals;
+
 
 py::object to_float_ptr(uintptr_t input_ptr, int size, ggml_type type) {
   if (type < 0 || type >= GGML_TYPE_COUNT) {
@@ -235,6 +243,165 @@ class MOEBindings {
   };
 };
 
+#if defined(__x86_64__) && defined(USE_AMX_AVX_KERNEL)
+template <class T>
+class MOESFTBindings {
+ public:
+  class WarmUpBindings {
+   public:
+    struct Args {
+      CPUInfer* cpuinfer;
+      TP_MOE_SFT<T>* moe;
+    };
+    static void inner(void* args) {
+      Args* args_ = (Args*)args;
+      args_->cpuinfer->enqueue(&TP_MOE_SFT<T>::warm_up, args_->moe);
+    }
+    static std::pair<intptr_t, intptr_t> cpuinfer_interface(std::shared_ptr<TP_MOE_SFT<T>> moe) {
+      Args* args = new Args{nullptr, moe.get()};
+      return std::make_pair((intptr_t)&inner, (intptr_t)args);
+    }
+  };
+
+  class LoadWeightsBindings {
+   public:
+    struct Args {
+      CPUInfer* cpuinfer;
+      TP_MOE_SFT<T>* moe;
+    };
+    static void inner(void* args) {
+      Args* args_ = (Args*)args;
+      args_->cpuinfer->enqueue(&TP_MOE_SFT<T>::load_weights, args_->moe);
+    }
+    static std::pair<intptr_t, intptr_t> cpuinfer_interface(std::shared_ptr<TP_MOE_SFT<T>> moe) {
+      Args* args = new Args{nullptr, moe.get()};
+      return std::make_pair((intptr_t)&inner, (intptr_t)args);
+    }
+  };
+
+  class ForwardSFTBindings {
+   public:
+    struct Args {
+      CPUInfer* cpuinfer;
+      TP_MOE_SFT<T>* moe;
+      intptr_t qlen;
+      int k;
+      intptr_t expert_ids;
+      intptr_t weights;
+      intptr_t input;
+      intptr_t output;
+      bool save_for_backward;
+    };
+    static void inner(void* args) {
+      Args* args_ = (Args*)args;
+      args_->cpuinfer->enqueue(&TP_MOE_SFT<T>::forward_sft_binding, args_->moe, args_->qlen, args_->k,
+                               args_->expert_ids, args_->weights, args_->input, args_->output,
+                               args_->save_for_backward);
+    }
+    static std::pair<intptr_t, intptr_t> cpuinfer_interface(std::shared_ptr<TP_MOE_SFT<T>> moe, intptr_t qlen, int k,
+                                                            intptr_t expert_ids, intptr_t weights, intptr_t input,
+                                                            intptr_t output, bool save_for_backward) {
+      Args* args = new Args{nullptr, moe.get(), qlen, k, expert_ids, weights, input, output, save_for_backward};
+      return std::make_pair((intptr_t)&inner, (intptr_t)args);
+    }
+  };
+
+  class BackwardBindings {
+   public:
+    struct Args {
+      CPUInfer* cpuinfer;
+      TP_MOE_SFT<T>* moe;
+      intptr_t grad_output;
+      intptr_t grad_input;
+      intptr_t grad_gate_lora_a;
+      intptr_t grad_gate_lora_b;
+      intptr_t grad_up_lora_a;
+      intptr_t grad_up_lora_b;
+      intptr_t grad_down_lora_a;
+      intptr_t grad_down_lora_b;
+      intptr_t grad_weights;
+    };
+    static void inner(void* args) {
+      Args* args_ = (Args*)args;
+      args_->cpuinfer->enqueue(&TP_MOE_SFT<T>::backward_binding, args_->moe, args_->grad_output, args_->grad_input,
+                               args_->grad_gate_lora_a, args_->grad_gate_lora_b, args_->grad_up_lora_a,
+                               args_->grad_up_lora_b, args_->grad_down_lora_a, args_->grad_down_lora_b,
+                               args_->grad_weights);
+    }
+    static std::pair<intptr_t, intptr_t> cpuinfer_interface(std::shared_ptr<TP_MOE_SFT<T>> moe, intptr_t grad_output,
+                                                            intptr_t grad_input, intptr_t grad_gate_lora_a,
+                                                            intptr_t grad_gate_lora_b, intptr_t grad_up_lora_a,
+                                                            intptr_t grad_up_lora_b, intptr_t grad_down_lora_a,
+                                                            intptr_t grad_down_lora_b, intptr_t grad_weights) {
+      Args* args = new Args{nullptr,          moe.get(),        grad_output,    grad_input,
+                            grad_gate_lora_a, grad_gate_lora_b, grad_up_lora_a, grad_up_lora_b,
+                            grad_down_lora_a, grad_down_lora_b, grad_weights};
+      return std::make_pair((intptr_t)&inner, (intptr_t)args);
+    }
+  };
+
+  class UpdateLoRAWeightsBindings {
+   public:
+    struct Args {
+      CPUInfer* cpuinfer;
+      TP_MOE_SFT<T>* moe;
+      intptr_t gate_lora_a;
+      intptr_t gate_lora_b;
+      intptr_t up_lora_a;
+      intptr_t up_lora_b;
+      intptr_t down_lora_a;
+      intptr_t down_lora_b;
+    };
+    static void inner(void* args) {
+      // Debug code for Bug #18 - commented out after fix verified
+      // printf("[DEBUG UpdateLoRAWeightsBindings::inner] called\n");
+      Args* args_ = (Args*)args;
+      // printf("  moe=%p, gate_lora_a=%p, gate_lora_b=%p\n", (void*)args_->moe, (void*)args_->gate_lora_a,
+      // (void*)args_->gate_lora_b); printf("  up_lora_a=%p, up_lora_b=%p\n", (void*)args_->up_lora_a,
+      // (void*)args_->up_lora_b); printf("  down_lora_a=%p, down_lora_b=%p\n", (void*)args_->down_lora_a,
+      // (void*)args_->down_lora_b);
+      args_->cpuinfer->enqueue(&TP_MOE_SFT<T>::update_lora_weights_binding, args_->moe, args_->gate_lora_a,
+                               args_->gate_lora_b, args_->up_lora_a, args_->up_lora_b, args_->down_lora_a,
+                               args_->down_lora_b);
+      // printf("[DEBUG UpdateLoRAWeightsBindings::inner] enqueue done\n");
+    }
+    static std::pair<intptr_t, intptr_t> cpuinfer_interface(std::shared_ptr<TP_MOE_SFT<T>> moe, intptr_t gate_lora_a,
+                                                            intptr_t gate_lora_b, intptr_t up_lora_a,
+                                                            intptr_t up_lora_b, intptr_t down_lora_a,
+                                                            intptr_t down_lora_b) {
+      Args* args =
+          new Args{nullptr, moe.get(), gate_lora_a, gate_lora_b, up_lora_a, up_lora_b, down_lora_a, down_lora_b};
+      return std::make_pair((intptr_t)&inner, (intptr_t)args);
+    }
+  };
+};
+
+template <typename MoeSftTP>
+void bind_moe_sft_module(py::module_& moe_module, const char* name) {
+  using MoeClass = TP_MOE_SFT<MoeSftTP>;
+  using MoeBindings = MOESFTBindings<MoeSftTP>;
+
+  py::class_<MoeClass, MoE_Interface, std::shared_ptr<MoeClass>>(moe_module, name)
+      .def(py::init<MOESFTConfig>())
+      .def("warm_up_task", &MoeBindings::WarmUpBindings::cpuinfer_interface)
+      .def("load_weights_task", &MoeBindings::LoadWeightsBindings::cpuinfer_interface)
+      .def("forward_sft_task", &MoeBindings::ForwardSFTBindings::cpuinfer_interface)
+      .def("backward_task", &MoeBindings::BackwardBindings::cpuinfer_interface)
+      .def("update_lora_weights_task", &MoeBindings::UpdateLoRAWeightsBindings::cpuinfer_interface)
+      .def("warm_up", &MoeClass::warm_up)
+      .def("load_weights", &MoeClass::load_weights)
+      .def("forward_sft", &MoeClass::forward_sft_binding)
+      .def("backward", &MoeClass::backward_binding)
+      .def("update_lora_weights", &MoeClass::update_lora_weights_binding)
+      .def("prepare_and_save_bwd",
+           [](MoeClass& self, intptr_t gate, intptr_t up, intptr_t down, const std::string& path) {
+             self.prepare_and_save_bwd((void*)gate, (void*)up, (void*)down, path);
+           })
+      .def("submit_backward_repack", &MoeClass::submit_backward_repack)
+      .def("wait_backward_repack", &MoeClass::wait_backward_repack);
+}
+#endif  // defined(__x86_64__) && defined(USE_AMX_AVX_KERNEL)
+
 template <typename MoeTP>
 void bind_moe_module(py::module_& moe_module, const char* name) {
   using MoeClass = TP_MOE<MoeTP>;
@@ -308,6 +475,7 @@ void bind_moe_module(py::module_& moe_module, const char* name) {
 }
 
 PYBIND11_MODULE(kt_kernel_ext, m) {
+
   py::class_<WorkerPool>(m, "WorkerPool").def(py::init<int>());
   py::class_<WorkerPoolConfig>(m, "WorkerPoolConfig")
       .def(py::init<>())
@@ -511,6 +679,12 @@ PYBIND11_MODULE(kt_kernel_ext, m) {
       .def(py::init([](int expert_num, int routed_expert_num, int hidden_size, int intermediate_size) {
         return GeneralMOEConfig(expert_num, routed_expert_num, hidden_size, intermediate_size);
       }))
+      .def(py::init(
+          [](int expert_num, int routed_expert_num, int hidden_size, int intermediate_size, int num_gpu_experts) {
+            GeneralMOEConfig cfg(expert_num, routed_expert_num, hidden_size, intermediate_size);
+            cfg.num_gpu_experts = num_gpu_experts;
+            return cfg;
+          }))
       .def(py::init([](int expert_num, int routed_expert_num, int hidden_size, int intermediate_size,
                        uintptr_t gpu_experts_mask_ptr) {
         GeneralMOEConfig cfg(expert_num, routed_expert_num, hidden_size, intermediate_size);
@@ -518,6 +692,11 @@ PYBIND11_MODULE(kt_kernel_ext, m) {
         cfg.compute_num_gpu_experts();
         return cfg;
       }))
+      // Core config fields (required for Python access after construction)
+      .def_readwrite("expert_num", &GeneralMOEConfig::expert_num)
+      .def_readwrite("num_experts_per_tok", &GeneralMOEConfig::num_experts_per_tok)
+      .def_readwrite("hidden_size", &GeneralMOEConfig::hidden_size)
+      .def_readwrite("intermediate_size", &GeneralMOEConfig::intermediate_size)
       .def_readwrite("layer_idx", &GeneralMOEConfig::layer_idx)
       .def_readwrite("pool", &GeneralMOEConfig::pool)
 
@@ -556,9 +735,18 @@ PYBIND11_MODULE(kt_kernel_ext, m) {
       .DEF_PTR_2D_PROPERTY(GeneralMOEConfig, up_zeros)
       .DEF_PTR_2D_PROPERTY(GeneralMOEConfig, down_zeros)
 
+      .DEF_PTR_2D_PROPERTY(GeneralMOEConfig, gate_bwd_projs)
+      .DEF_PTR_2D_PROPERTY(GeneralMOEConfig, up_bwd_projs)
+      .DEF_PTR_2D_PROPERTY(GeneralMOEConfig, down_bwd_projs)
+      .DEF_PTR_2D_PROPERTY(GeneralMOEConfig, gate_bwd_scales)
+      .DEF_PTR_2D_PROPERTY(GeneralMOEConfig, up_bwd_scales)
+      .DEF_PTR_2D_PROPERTY(GeneralMOEConfig, down_bwd_scales)
+
       .def_readwrite("path", &GeneralMOEConfig::path)
       .def_readwrite("save", &GeneralMOEConfig::save)
       .def_readwrite("load", &GeneralMOEConfig::load)
+      .def_readwrite("share_backward_bb", &GeneralMOEConfig::share_backward_bb)
+      .def_readwrite("share_cache_pool", &GeneralMOEConfig::share_cache_pool)
       .def_readwrite("m_block", &GeneralMOEConfig::m_block)
       .def_readwrite("group_min_len", &GeneralMOEConfig::group_min_len)
       .def_readwrite("group_max_len", &GeneralMOEConfig::group_max_len)
@@ -567,8 +755,24 @@ PYBIND11_MODULE(kt_kernel_ext, m) {
       .def_readwrite("up_type", &GeneralMOEConfig::up_type)
       .def_readwrite("down_type", &GeneralMOEConfig::down_type)
       .def_readwrite("hidden_type", &GeneralMOEConfig::hidden_type)
+      .def_readwrite("max_cache_depth", &GeneralMOEConfig::max_cache_depth)
 
       ;
+
+  // MOESFTConfig - extends GeneralMOEConfig with LoRA support
+  py::class_<MOESFTConfig, GeneralMOEConfig>(moe_module, "MOESFTConfig")
+      .def(py::init<>())
+      .def(py::init([](int expert_num, int routed_expert_num, int hidden_size, int intermediate_size) {
+        return MOESFTConfig(expert_num, routed_expert_num, hidden_size, intermediate_size);
+      }))
+      .def_readwrite("lora_rank", &MOESFTConfig::lora_rank)
+      .def_readwrite("lora_alpha", &MOESFTConfig::lora_alpha)
+      .DEF_PTR_PROPERTY(MOESFTConfig, gate_lora_a)
+      .DEF_PTR_PROPERTY(MOESFTConfig, gate_lora_b)
+      .DEF_PTR_PROPERTY(MOESFTConfig, up_lora_a)
+      .DEF_PTR_PROPERTY(MOESFTConfig, up_lora_b)
+      .DEF_PTR_PROPERTY(MOESFTConfig, down_lora_a)
+      .DEF_PTR_PROPERTY(MOESFTConfig, down_lora_b);
 
   py::class_<MoE_Interface, std::shared_ptr<MoE_Interface>>(moe_module, "MoE_Interface");
 
@@ -585,6 +789,25 @@ PYBIND11_MODULE(kt_kernel_ext, m) {
   bind_moe_module<AMX_FP8_MOE_TP<amx::GemmKernel224FP8>>(moe_module, "AMXFP8_MOE");
   bind_moe_module<AMX_FP8_PERCHANNEL_MOE_TP<amx::GemmKernel224FP8PerChannel>>(moe_module, "AMXFP8PerChannel_MOE");
 #endif
+  // SFT MoE with LoRA support (BF16, INT8, INT4, AWQ, K2)
+  bind_moe_sft_module<AMX_SFT_MOE_TP<amx::GemmKernel224BF>>(moe_module, "AMXBF16_SFT_MOE");
+  bind_moe_sft_module<AMX_SFT_MOE_TP<amx::GemmKernel224Int8>>(moe_module, "AMXInt8_SFT_MOE");
+  bind_moe_sft_module<AMX_SFT_MOE_TP<amx::GemmKernel224Int4>>(moe_module, "AMXInt4_SFT_MOE");
+  // bind_moe_sft_module<AMX_SFT_MOE_TP<amx::GemmKernel224Int4_1>>(moe_module, "AMXInt4_1_SFT_MOE");
+  // bind_moe_sft_module<AMX_SFT_MOE_TP<amx::GemmKernel224Int4_1_LowKGroup, AMX_AWQ_MOE_TP>>(moe_module,
+  //                                                                                         "AMXInt4_1KGroup_SFT_MOE");
+  // bind_moe_sft_module<AMX_SFT_MOE_TP<amx::GemmKernel224Int4SmallKGroup, AMX_K2_MOE_TP>>(moe_module,
+  //                                                                                       "AMXInt4_KGroup_SFT_MOE");
+  // SFT MoE with SkipLoRA=true (skip all LoRA computation in backward, only compute base weight grad_input)
+  bind_moe_sft_module<AMX_SFT_MOE_TP<amx::GemmKernel224BF, AMX_MOE_TP, true>>(moe_module, "AMXBF16_SFT_MOE_SkipLoRA");
+  bind_moe_sft_module<AMX_SFT_MOE_TP<amx::GemmKernel224Int8, AMX_MOE_TP, true>>(moe_module, "AMXInt8_SFT_MOE_SkipLoRA");
+  bind_moe_sft_module<AMX_SFT_MOE_TP<amx::GemmKernel224Int4, AMX_MOE_TP, true>>(moe_module, "AMXInt4_SFT_MOE_SkipLoRA");
+  // bind_moe_sft_module<AMX_SFT_MOE_TP<amx::GemmKernel224Int4_1, AMX_MOE_TP, true>>(moe_module,
+  //                                                                                 "AMXInt4_1_SFT_MOE_SkipLoRA");
+  // bind_moe_sft_module<AMX_SFT_MOE_TP<amx::GemmKernel224Int4_1_LowKGroup, AMX_AWQ_MOE_TP, true>>(
+  //     moe_module, "AMXInt4_1KGroup_SFT_MOE_SkipLoRA");
+  // bind_moe_sft_module<AMX_SFT_MOE_TP<amx::GemmKernel224Int4SmallKGroup, AMX_K2_MOE_TP, true>>(
+  //     moe_module, "AMXInt4_KGroup_SFT_MOE_SkipLoRA");
 #endif
 // AVX2 backends — available on all x86_64 (no AMX/AVX512 requirement)
 #if defined(__x86_64__)
@@ -756,4 +979,30 @@ PYBIND11_MODULE(kt_kernel_ext, m) {
 
   utils.def("from_float", &from_float_ptr, "Convert tensor from float32 to any GGML type", py::arg("input"),
             py::arg("size"), py::arg("type"));
+}
+
+static void warmup_cpptrace() {
+  // 避免第一次调用触发 lazy-loading（malloc 等） :contentReference[oaicite:7]{index=7}
+  cpptrace::frame_ptr buffer[10];
+  (void)cpptrace::safe_generate_raw_trace(buffer, 10);
+  cpptrace::safe_object_frame frame{};
+  cpptrace::get_safe_object_frame(buffer[0], &frame);
+}
+
+static void crash_handler(int signo, siginfo_t* /*info*/, void* /*ucontext*/) {
+  const char* head = "=== crash: signal received ===\n";
+  write(STDERR_FILENO, head, std::strlen(head));
+  cpptrace::generate_trace().print();
+  _exit(128 + signo);
+}
+
+__attribute__((constructor)) static void install_handlers() {
+  struct sigaction sa;
+  std::memset(&sa, 0, sizeof(sa));
+  sa.sa_sigaction = &crash_handler;
+  sa.sa_flags = SA_SIGINFO;
+  sigemptyset(&sa.sa_mask);
+
+  sigaction(SIGSEGV, &sa, nullptr);
+  sigaction(SIGABRT, &sa, nullptr);
 }

--- a/kt-kernel/operators/avx2/raw_int4-moe.hpp
+++ b/kt-kernel/operators/avx2/raw_int4-moe.hpp
@@ -1,0 +1,685 @@
+/**
+ * @Description  : AVX2 RAWINT4 MoE operator for Kimi native INT4 weights
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * RAWINT4 stores signed int4 weights packed two values per byte, plus BF16
+ * K-group scales. This AVX2 backend keeps the native layout so GPU layerwise
+ * prefill can reuse the same weight buffers, and uses BF16 activations with
+ * FP32 accumulation for CPU decode.
+ **/
+#ifndef CPUINFER_OPERATOR_AVX2_RAW_INT4_MOE_H
+#define CPUINFER_OPERATOR_AVX2_RAW_INT4_MOE_H
+
+#include "avx2_bf16_gemm.hpp"
+#include "avx2_bf16_utils.hpp"
+#include "gptq_int4_dequant.hpp"
+#include "moe_base.hpp"
+
+namespace avx2 {
+
+// Local, RAWINT4-only variant of gptq_sym_dequant_8x4bit that skips the
+// per-group scale multiply. Callers fold the scale in via a single FMA after
+// the K-loop so the inner path avoids a broadcast+mul per packed int32.
+static inline __m256 rawint4_dequant_8x4bit_unscaled(uint32_t packed_weight) {
+  const __m256i shifts = _mm256_set_epi32(28, 24, 20, 16, 12, 8, 4, 0);
+  __m256i packed_v = _mm256_set1_epi32(packed_weight);
+  __m256i nibbles = _mm256_and_si256(_mm256_srlv_epi32(packed_v, shifts),
+                                     _mm256_set1_epi32(0xF));
+  __m256 w = _mm256_cvtepi32_ps(nibbles);
+  return _mm256_sub_ps(w, _mm256_set1_ps(8.0f));
+}
+
+struct GemmKernelAVX2RawInt4 {
+  using dt = uint8_t;
+  using output_t = float;
+  static constexpr int M_STEP = 1;
+  static constexpr int N_STEP = 8;
+  static constexpr int K_STEP = 8;
+  static constexpr int N_BLOCK = 64;
+  static constexpr int K_BLOCK = 128;
+  static constexpr double ELEMENT_SIZE = 0.5;
+
+  static void config() {}
+
+  static int recommended_nth(int n) { return std::max(1, div_up(n, N_BLOCK)); }
+
+  static std::pair<int, int> split_range_n(int n, int ith, int nth) { return split_range(n, ith, nth); }
+
+  struct BufferA {
+    ggml_bf16_t* data = nullptr;
+    size_t max_m = 0;
+    size_t k = 0;
+
+    BufferA() = default;
+    BufferA(size_t m, size_t k_, int, void* ptr) : data((ggml_bf16_t*)ptr), max_m(m), k(k_) {}
+
+    static size_t required_size(size_t m, size_t k, int) { return m * k * sizeof(ggml_bf16_t); }
+
+    void set_data(void* ptr) { data = (ggml_bf16_t*)ptr; }
+
+    void from_mat(int m, const ggml_bf16_t* src, int ith, int nth) {
+      if (ith == 0 && nth == 1) {
+        std::memcpy(data, src, (size_t)m * k * sizeof(ggml_bf16_t));
+      } else {
+        auto [m_start, m_end] = split_range(m, ith, nth);
+        std::memcpy(data + m_start * k, src + m_start * k,
+                    (size_t)(m_end - m_start) * k * sizeof(ggml_bf16_t));
+      }
+    }
+  };
+
+  struct BufferB {
+    uint8_t* b = nullptr;
+    float* d = nullptr;
+    int n = 0;
+    int k = 0;
+    int k_group_size = 0;
+    int k_group_count = 0;
+
+    BufferB() = default;
+
+    // Full allocation: b and d packed into a single aligned block.
+    BufferB(int n_, int k_, int k_group_size_, void* ptr)
+        : b((uint8_t*)ptr), n(n_), k(k_), k_group_size(k_group_size_) {
+      if (k_group_size <= 0 || k % k_group_size != 0 || k % 8 != 0) {
+        throw std::runtime_error("RAWINT4 requires k aligned to group_size and 8");
+      }
+      k_group_count = k / k_group_size;
+      d = (float*)((uint8_t*)ptr + ((size_t)n * k / 2));
+    }
+
+    // Scale-only allocation: b points to external (mmap'd) weight data; d owns scale_ptr.
+    // Used when weights are consumed directly from safetensor mmap without copying.
+    BufferB(int n_, int k_, int k_group_size_, void* scale_ptr, std::nullptr_t /*scale_only*/)
+        : b(nullptr), n(n_), k(k_), k_group_size(k_group_size_) {
+      if (k_group_size <= 0 || k % k_group_size != 0 || k % 8 != 0) {
+        throw std::runtime_error("RAWINT4 requires k aligned to group_size and 8");
+      }
+      k_group_count = k / k_group_size;
+      d = (float*)scale_ptr;
+    }
+
+    // Full size: packed INT4 weights + float32 scales.
+    static size_t required_size(size_t n, size_t k, int k_group_size) {
+      return n * k / 2 + n * (k / k_group_size) * sizeof(float);
+    }
+
+    // Scale-only size: only float32 scales (b will point to external weight data).
+    static size_t required_size_scale_only(size_t n, size_t k, int k_group_size) {
+      return n * (k / k_group_size) * sizeof(float);
+    }
+
+    void from_raw_mat(const uint8_t* proj, int ith, int nth) {
+      if (b == nullptr) return;  // scale-only mode: b is an external pointer set later
+      auto [n_start, n_end] = split_range_n(n, ith, nth);
+      const size_t row_bytes = (size_t)k / 2;
+      std::memcpy(b + (size_t)n_start * row_bytes, proj + (size_t)n_start * row_bytes,
+                  (size_t)(n_end - n_start) * row_bytes);
+    }
+  };
+
+  struct BufferC {
+    float* data = nullptr;
+    size_t max_m = 0;
+    size_t n = 0;
+
+    BufferC() = default;
+    BufferC(size_t m, size_t n_, void* ptr) : data((float*)ptr), max_m(m), n(n_) {}
+
+    static size_t required_size(size_t m, size_t n) { return m * n * sizeof(float); }
+
+    void set_data(void* ptr) { data = (float*)ptr; }
+
+    void to_mat(int m, ggml_bf16_t* dst, int ith, int nth) {
+      auto [n_start, n_end] = split_range((int)n, ith, nth);
+      for (int mi = 0; mi < m; mi++) {
+        float* src_row = data + (size_t)mi * n;
+        ggml_bf16_t* dst_row = dst + (size_t)mi * n;
+        int j = n_start;
+        for (; j + 8 <= n_end; j += 8) {
+          store_fp32_to_bf16(dst_row + j, _mm256_loadu_ps(src_row + j));
+        }
+        for (; j < n_end; j++) {
+          dst_row[j] = GGML_FP32_TO_BF16(src_row[j]);
+        }
+      }
+    }
+  };
+};
+
+static inline void gemm_raw_int4(int m, int n, int k, GemmKernelAVX2RawInt4::BufferA& a,
+                                 GemmKernelAVX2RawInt4::BufferB& b, GemmKernelAVX2RawInt4::BufferC& c, int ith,
+                                 int nth) {
+  auto [n_start, n_end] = split_range(n, ith, nth);
+  const int group_size = b.k_group_size;
+  const int group_count = b.k_group_count;
+  const size_t row_bytes = (size_t)k / 2;
+
+  for (int ni = n_start; ni < n_end; ni++) {
+    const uint8_t* b_row = b.b + (size_t)ni * row_bytes;
+    const float* b_scales = b.d + (size_t)ni * group_count;
+
+    // Prefetch the head of the next B row while we chew through this one.
+    // Streams the decoupled weight pages for large N without blocking.
+    if (ni + 1 < n_end) {
+      const uint8_t* b_next = b.b + (size_t)(ni + 1) * row_bytes;
+      _mm_prefetch((const char*)b_next, _MM_HINT_T0);
+      _mm_prefetch((const char*)(b_next + 64), _MM_HINT_T0);
+    }
+
+    for (int mi = 0; mi < m; mi++) {
+      const ggml_bf16_t* a_row = a.data + (size_t)mi * a.k;
+
+      // Running vector total: each group folds in via a single FMA with its
+      // scale broadcast, so we only do one horizontal reduction per (mi, ni).
+      __m256 total_acc = _mm256_setzero_ps();
+      float scalar_tail = 0.0f;
+
+      for (int g = 0; g < group_count; g++) {
+        const float scale = b_scales[g];
+        const int k_base = g * group_size;
+
+        __m256 acc1 = _mm256_setzero_ps();
+        __m256 acc2 = _mm256_setzero_ps();
+        __m256 acc3 = _mm256_setzero_ps();
+        __m256 acc4 = _mm256_setzero_ps();
+
+        int ki = 0;
+        for (; ki + 32 <= group_size; ki += 32) {
+          uint32_t p0, p1, p2, p3;
+          std::memcpy(&p0, b_row + (k_base + ki) / 2, sizeof(uint32_t));
+          std::memcpy(&p1, b_row + (k_base + ki + 8) / 2, sizeof(uint32_t));
+          std::memcpy(&p2, b_row + (k_base + ki + 16) / 2, sizeof(uint32_t));
+          std::memcpy(&p3, b_row + (k_base + ki + 24) / 2, sizeof(uint32_t));
+          acc1 = _mm256_fmadd_ps(load_bf16_to_fp32(a_row + k_base + ki),
+                                 rawint4_dequant_8x4bit_unscaled(p0), acc1);
+          acc2 = _mm256_fmadd_ps(load_bf16_to_fp32(a_row + k_base + ki + 8),
+                                 rawint4_dequant_8x4bit_unscaled(p1), acc2);
+          acc3 = _mm256_fmadd_ps(load_bf16_to_fp32(a_row + k_base + ki + 16),
+                                 rawint4_dequant_8x4bit_unscaled(p2), acc3);
+          acc4 = _mm256_fmadd_ps(load_bf16_to_fp32(a_row + k_base + ki + 24),
+                                 rawint4_dequant_8x4bit_unscaled(p3), acc4);
+        }
+        __m256 g_acc = _mm256_add_ps(_mm256_add_ps(acc1, acc3), _mm256_add_ps(acc2, acc4));
+
+        for (; ki + 8 <= group_size; ki += 8) {
+          uint32_t packed;
+          std::memcpy(&packed, b_row + (k_base + ki) / 2, sizeof(uint32_t));
+          g_acc = _mm256_fmadd_ps(load_bf16_to_fp32(a_row + k_base + ki),
+                                  rawint4_dequant_8x4bit_unscaled(packed), g_acc);
+        }
+
+        // Fold this group's unscaled accumulator into the running total with
+        // one scale-broadcast FMA — saves (group_count - 1) hsum reductions
+        // compared to reducing per group.
+        total_acc = _mm256_fmadd_ps(g_acc, _mm256_broadcast_ss(&scale), total_acc);
+
+        for (; ki < group_size; ki++) {
+          const uint8_t packed = b_row[(k_base + ki) / 2];
+          const int nibble = ((k_base + ki) & 1) ? (packed >> 4) : (packed & 0x0F);
+          scalar_tail += GGML_BF16_TO_FP32(a_row[k_base + ki]) * (float)(nibble - 8) * scale;
+        }
+      }
+
+      c.data[(size_t)mi * n + ni] = hsum_avx2(total_acc) + scalar_tail;
+    }
+  }
+}
+
+}  // namespace avx2
+
+template <class T = avx2::GemmKernelAVX2RawInt4>
+class AVX2_RAW_INT4_MOE_TP : public AVX2_MOE_BASE<T, AVX2_RAW_INT4_MOE_TP<T>> {
+  using Base = AVX2_MOE_BASE<T, AVX2_RAW_INT4_MOE_TP<T>>;
+  using Base::config_;
+  using Base::down_ba_;
+  using Base::down_bb_;
+  using Base::down_bc_;
+  using Base::gate_bb_;
+  using Base::gate_bc_;
+  using Base::gate_up_ba_;
+  using Base::m_local_num_;
+  using Base::tp_part_idx;
+  using Base::up_bb_;
+  using Base::up_bc_;
+
+ public:
+  using typename Base::input_t;
+  using typename Base::output_t;
+
+  AVX2_RAW_INT4_MOE_TP() = default;
+  AVX2_RAW_INT4_MOE_TP(GeneralMOEConfig config, int tp_part_idx_ = 0) : Base(config, tp_part_idx_) {}
+
+  void derived_init() {
+    if (config_.quant_config.group_size == 0 || config_.quant_config.zero_point) {
+      throw std::runtime_error("RAWINT4 AVX2 MoE only supports KGroup signed INT4 without zero point");
+    }
+    printf("Created AVX2_RAW_INT4_MOE_TP %d at numa %d (group_size=%d)\n", tp_part_idx,
+           numa_node_of_cpu(sched_getcpu()), config_.quant_config.group_size);
+  }
+
+  size_t buffer_a_required_size_impl(size_t m, size_t k) const {
+    return T::BufferA::required_size(m, k, config_.quant_config.group_size);
+  }
+  size_t buffer_b_required_size_impl(size_t n, size_t k) const {
+    // When per-expert source pointers are available, only allocate float32 scales.
+    // Weights will be served directly from the mmap'd safetensor data (no copy).
+    if (!config_.gate_projs.empty()) {
+      return T::BufferB::required_size_scale_only(n, k, config_.quant_config.group_size);
+    }
+    return T::BufferB::required_size(n, k, config_.quant_config.group_size);
+  }
+  size_t buffer_c_required_size_impl(size_t m, size_t n) const { return T::BufferC::required_size(m, n); }
+
+  std::shared_ptr<typename T::BufferA> make_buffer_a_impl(size_t m, size_t k, void* data) const {
+    return std::make_shared<typename T::BufferA>(m, k, config_.quant_config.group_size, data);
+  }
+  std::shared_ptr<typename T::BufferB> make_buffer_b_impl(size_t n, size_t k, void* data) const {
+    // Scale-only mode: b is nullptr here; set externally in load_weights().
+    if (!config_.gate_projs.empty()) {
+      return std::make_shared<typename T::BufferB>((int)n, (int)k, config_.quant_config.group_size, data, nullptr);
+    }
+    return std::make_shared<typename T::BufferB>((int)n, (int)k, config_.quant_config.group_size, data);
+  }
+  std::shared_ptr<typename T::BufferC> make_buffer_c_impl(size_t m, size_t n, void* data) const {
+    return std::make_shared<typename T::BufferC>(m, n, data);
+  }
+
+  void do_gate_up_gemm(bool do_up, int expert_idx, int ith, int nth, int) {
+    int m = m_local_num_[expert_idx];
+    auto& bb = do_up ? up_bb_[expert_idx] : gate_bb_[expert_idx];
+    auto& bc = do_up ? up_bc_[expert_idx] : gate_bc_[expert_idx];
+    avx2::gemm_raw_int4(m, config_.intermediate_size, config_.hidden_size, *gate_up_ba_[expert_idx], *bb, *bc, ith,
+                        nth);
+  }
+
+  void do_down_gemm(int expert_idx, int ith, int nth, int) {
+    int m = m_local_num_[expert_idx];
+    avx2::gemm_raw_int4(m, config_.hidden_size, config_.intermediate_size, *down_ba_[expert_idx],
+                        *down_bb_[expert_idx], *down_bc_[expert_idx], ith, nth);
+  }
+
+  void load_weights() {
+    int group_size = config_.quant_config.group_size;
+    const uint64_t* physical_to_logical_map = (const uint64_t*)config_.physical_to_logical_map;
+    auto pool = config_.pool->get_subpool(tp_part_idx);
+
+    const bool use_per_expert = !config_.gate_projs.empty();
+    if (!use_per_expert && config_.gate_proj == nullptr) {
+      throw std::runtime_error("RAWINT4 AVX2 MoE requires weight pointers");
+    }
+    if (!use_per_expert && config_.gate_scale == nullptr) {
+      throw std::runtime_error("RAWINT4 AVX2 MoE requires scale pointers");
+    }
+
+    if (use_per_expert) {
+      // Direct-pointer mode: BufferB.b is set to point into the mmap'd safetensor data
+      // (no weight copy). Only float32 scales are allocated and converted.
+      //
+      // For gate/up: source shape [intermediate_size_full, hidden_size/2] row-major.
+      //   TP partition tp_part_idx handles rows [tp_part_idx * n_per_tp, (tp_part_idx+1) * n_per_tp).
+      //   These are contiguous in memory → simple byte offset: tp_part_idx * n_per_tp * (k/2).
+      //   With kt_threadpool_count=1 (tp_part_idx=0): offset = 0.
+      //
+      // For down: source shape [hidden_size, intermediate_size_full/2] row-major.
+      //   TP partition tp_part_idx handles columns [tp_part_idx * n_per_tp/2, ...) per row.
+      //   These are NOT contiguous across rows for tp_count > 1.
+      //   This mode therefore requires kt_threadpool_count=1 (enforced in outer TP wrapper).
+      pool->do_work_stealing_job(
+          config_.expert_num, nullptr,
+          [this, physical_to_logical_map](int expert_idx) {
+            if (expert_idx < 0 || expert_idx >= config_.expert_num || gate_bb_[expert_idx] == nullptr ||
+                up_bb_[expert_idx] == nullptr || down_bb_[expert_idx] == nullptr) {
+              return;
+            }
+            uint64_t logical_expert_id = expert_map(physical_to_logical_map, expert_idx);
+            // Gate/Up row offset for this TP partition (bytes).
+            size_t gate_tp_byte_offset =
+                (size_t)tp_part_idx * config_.intermediate_size * config_.hidden_size / 2;
+            gate_bb_[expert_idx]->b =
+                (uint8_t*)config_.gate_projs[0][logical_expert_id] + gate_tp_byte_offset;
+            up_bb_[expert_idx]->b =
+                (uint8_t*)config_.up_projs[0][logical_expert_id] + gate_tp_byte_offset;
+            // Down column offset (bytes per row start). Correct only for tp_count=1.
+            size_t down_tp_byte_offset = (size_t)tp_part_idx * config_.intermediate_size / 2;
+            down_bb_[expert_idx]->b =
+                (uint8_t*)config_.down_projs[0][logical_expert_id] + down_tp_byte_offset;
+          },
+          nullptr);
+
+      // Scale conversion: BF16 → float32.
+      pool->do_work_stealing_job(
+          config_.expert_num, nullptr,
+          [this, physical_to_logical_map, group_size](int task_id) {
+            uint64_t expert_idx = task_id;
+            if (expert_idx >= (uint64_t)config_.expert_num || gate_bb_[expert_idx] == nullptr ||
+                up_bb_[expert_idx] == nullptr || down_bb_[expert_idx] == nullptr) {
+              return;
+            }
+            uint64_t logical_expert_id = expert_map(physical_to_logical_map, expert_idx);
+            size_t scale_elem_count = ((size_t)config_.hidden_size * config_.intermediate_size) / group_size;
+            // Gate/Up scale offset: rows [tp_part_idx * n_per_tp, ...) of scale[n_total, k/gs].
+            size_t gate_scale_tp_offset =
+                (size_t)tp_part_idx * config_.intermediate_size * (config_.hidden_size / group_size);
+            // Down scale offset: cols [tp_part_idx * (n_per_tp/gs), ...) per row. Correct for tp_count=1.
+            size_t down_scale_tp_offset = (size_t)tp_part_idx * (config_.intermediate_size / group_size);
+            convert_or_copy(gate_bb_[expert_idx]->d,
+                            (const ggml_bf16_t*)config_.gate_scales[0][logical_expert_id] + gate_scale_tp_offset,
+                            scale_elem_count);
+            convert_or_copy(up_bb_[expert_idx]->d,
+                            (const ggml_bf16_t*)config_.up_scales[0][logical_expert_id] + gate_scale_tp_offset,
+                            scale_elem_count);
+            convert_or_copy(down_bb_[expert_idx]->d,
+                            (const ggml_bf16_t*)config_.down_scales[0][logical_expert_id] + down_scale_tp_offset,
+                            scale_elem_count);
+          },
+          nullptr);
+    } else {
+      // Flat-buffer mode: copy TP-sliced weights from flat buffer into allocated BufferB.b.
+      int nth = T::recommended_nth(config_.intermediate_size);
+      pool->do_work_stealing_job(
+          nth * config_.expert_num, nullptr,
+          [this, nth, physical_to_logical_map](int task_id) {
+            uint64_t expert_idx = task_id / nth;
+            if (config_.should_skip_expert(expert_idx)) return;
+            uint64_t logical_expert_id = expert_map(physical_to_logical_map, expert_idx);
+            int ith = task_id % nth;
+            size_t weight_offset = ((size_t)logical_expert_id * config_.intermediate_size * config_.hidden_size) / 2;
+            gate_bb_[expert_idx]->from_raw_mat((const uint8_t*)config_.gate_proj + weight_offset, ith, nth);
+            up_bb_[expert_idx]->from_raw_mat((const uint8_t*)config_.up_proj + weight_offset, ith, nth);
+          },
+          nullptr);
+
+      int nth_down = T::recommended_nth(config_.hidden_size);
+      pool->do_work_stealing_job(
+          nth_down * config_.expert_num, nullptr,
+          [this, nth_down, physical_to_logical_map](int task_id) {
+            uint64_t expert_idx = task_id / nth_down;
+            if (config_.should_skip_expert(expert_idx)) return;
+            uint64_t logical_expert_id = expert_map(physical_to_logical_map, expert_idx);
+            int ith = task_id % nth_down;
+            size_t weight_offset = ((size_t)logical_expert_id * config_.hidden_size * config_.intermediate_size) / 2;
+            down_bb_[expert_idx]->from_raw_mat((const uint8_t*)config_.down_proj + weight_offset, ith, nth_down);
+          },
+          nullptr);
+
+      // Scale conversion in flat-buffer mode.
+      pool->do_work_stealing_job(
+          config_.expert_num, nullptr,
+          [this, physical_to_logical_map, group_size](int task_id) {
+            uint64_t expert_idx = task_id;
+            if (config_.should_skip_expert(expert_idx)) return;
+            uint64_t logical_expert_id = expert_map(physical_to_logical_map, expert_idx);
+            size_t scale_elem_count = ((size_t)config_.hidden_size * config_.intermediate_size) / group_size;
+            convert_or_copy(gate_bb_[expert_idx]->d,
+                            (ggml_bf16_t*)config_.gate_scale + logical_expert_id * scale_elem_count,
+                            scale_elem_count);
+            convert_or_copy(up_bb_[expert_idx]->d,
+                            (ggml_bf16_t*)config_.up_scale + logical_expert_id * scale_elem_count,
+                            scale_elem_count);
+            convert_or_copy(down_bb_[expert_idx]->d,
+                            (ggml_bf16_t*)config_.down_scale + logical_expert_id * scale_elem_count,
+                            scale_elem_count);
+          },
+          nullptr);
+    }
+  }
+
+  static inline void fp32_to_bf16(ggml_bf16_t* dst, const float* src, size_t count) { convert_or_copy(dst, src, count); }
+
+  void write_weights_to_buffer(int gpu_tp_count, int cpu_tp_count, int expert_id, const GeneralMOEConfig& full_config,
+                               const std::vector<uintptr_t>& w13_weight_ptrs,
+                               const std::vector<uintptr_t>& w13_scale_ptrs,
+                               const std::vector<uintptr_t>& w2_weight_ptrs,
+                               const std::vector<uintptr_t>& w2_scale_ptrs) const {
+    if (expert_id < 0 || expert_id >= config_.expert_num || gate_bb_[expert_id] == nullptr ||
+        up_bb_[expert_id] == nullptr || down_bb_[expert_id] == nullptr) {
+      throw std::runtime_error("RAWINT4 write_weights_to_buffer requested an expert without loaded weights");
+    }
+    const int group_size = config_.quant_config.group_size;
+    auto pool = config_.pool->get_subpool(tp_part_idx);
+
+    size_t cpu_tp_weight_elem_count = (size_t)config_.intermediate_size * config_.hidden_size;
+    size_t cpu_tp_weight_bytes = cpu_tp_weight_elem_count / 2;
+    size_t cpu_tp_scale_elem_count = cpu_tp_weight_elem_count / group_size;
+    size_t gpu_tp_weight_elem_count = (size_t)full_config.intermediate_size * full_config.hidden_size / gpu_tp_count;
+    size_t gpu_tp_weight_bytes = gpu_tp_weight_elem_count / 2;
+    size_t gpu_tp_scale_elem_count = gpu_tp_weight_elem_count / group_size;
+
+    if (cpu_tp_count >= gpu_tp_count) {
+      int target_gpu_tp = tp_part_idx / (cpu_tp_count / gpu_tp_count);
+      int local_idx = tp_part_idx % (cpu_tp_count / gpu_tp_count);
+      uint8_t* w13_weight_dst = (uint8_t*)w13_weight_ptrs[target_gpu_tp];
+      ggml_bf16_t* w13_scale_dst = (ggml_bf16_t*)w13_scale_ptrs[target_gpu_tp];
+      uint8_t* w2_weight_dst = (uint8_t*)w2_weight_ptrs[target_gpu_tp];
+      ggml_bf16_t* w2_scale_dst = (ggml_bf16_t*)w2_scale_ptrs[target_gpu_tp];
+      size_t offset_in_gpu_weight = local_idx * cpu_tp_weight_bytes;
+      size_t offset_in_gpu_scale = local_idx * cpu_tp_scale_elem_count;
+
+      constexpr int NUM_WEIGHT_TASKS = 8;
+      constexpr int MIN_COLS_PER_TASK = 128;
+      int num_down_tasks = std::min(std::max(1, config_.hidden_size / MIN_COLS_PER_TASK), 32);
+      int total_tasks = NUM_WEIGHT_TASKS * 2 + num_down_tasks + 2;
+      size_t weight_chunk_size = (cpu_tp_weight_bytes + NUM_WEIGHT_TASKS - 1) / NUM_WEIGHT_TASKS;
+      weight_chunk_size = (weight_chunk_size + 63) & ~63ULL;
+
+      pool->do_work_stealing_job(
+          total_tasks, nullptr,
+          [=, this](int task_id) {
+            if (task_id < NUM_WEIGHT_TASKS) {
+              size_t start = (size_t)task_id * weight_chunk_size;
+              size_t end = std::min(start + weight_chunk_size, cpu_tp_weight_bytes);
+              if (start < end) std::memcpy(w13_weight_dst + offset_in_gpu_weight + start, gate_bb_[expert_id]->b + start, end - start);
+            } else if (task_id < NUM_WEIGHT_TASKS * 2) {
+              int chunk_idx = task_id - NUM_WEIGHT_TASKS;
+              size_t start = (size_t)chunk_idx * weight_chunk_size;
+              size_t end = std::min(start + weight_chunk_size, cpu_tp_weight_bytes);
+              if (start < end)
+                std::memcpy(w13_weight_dst + offset_in_gpu_weight + gpu_tp_weight_bytes + start,
+                            up_bb_[expert_id]->b + start, end - start);
+            } else if (task_id < NUM_WEIGHT_TASKS * 2 + num_down_tasks) {
+              int chunk_idx = task_id - NUM_WEIGHT_TASKS * 2;
+              size_t cols_per_chunk = (config_.hidden_size + num_down_tasks - 1) / num_down_tasks;
+              size_t col_start = (size_t)chunk_idx * cols_per_chunk;
+              size_t col_end = std::min(col_start + cols_per_chunk, (size_t)config_.hidden_size);
+              size_t weight_per_col = config_.intermediate_size >> 1;
+              size_t scale_per_col = config_.intermediate_size / group_size;
+              size_t gpu_weight_stride = (full_config.intermediate_size / gpu_tp_count) >> 1;
+              size_t gpu_scale_stride = (full_config.intermediate_size / gpu_tp_count) / group_size;
+              size_t gpu_weight_slice_offset = local_idx * weight_per_col;
+              size_t gpu_scale_slice_offset = local_idx * scale_per_col;
+              for (size_t col = col_start; col < col_end; col++) {
+                std::memcpy(w2_weight_dst + col * gpu_weight_stride + gpu_weight_slice_offset,
+                            down_bb_[expert_id]->b + col * weight_per_col, weight_per_col);
+                fp32_to_bf16(w2_scale_dst + col * gpu_scale_stride + gpu_scale_slice_offset,
+                             down_bb_[expert_id]->d + col * scale_per_col, scale_per_col);
+              }
+            } else if (task_id == NUM_WEIGHT_TASKS * 2 + num_down_tasks) {
+              fp32_to_bf16(w13_scale_dst + offset_in_gpu_scale, gate_bb_[expert_id]->d, cpu_tp_scale_elem_count);
+            } else {
+              fp32_to_bf16(w13_scale_dst + offset_in_gpu_scale + gpu_tp_scale_elem_count, up_bb_[expert_id]->d,
+                           cpu_tp_scale_elem_count);
+            }
+          },
+          nullptr);
+    } else {
+      int gpu_tps_per_cpu_tp = gpu_tp_count / cpu_tp_count;
+      int start_gpu_tp = tp_part_idx * gpu_tps_per_cpu_tp;
+      size_t data_per_gpu_tp_weight = cpu_tp_weight_bytes / gpu_tps_per_cpu_tp;
+      size_t data_per_gpu_tp_scale = cpu_tp_scale_elem_count / gpu_tps_per_cpu_tp;
+      constexpr int NUM_WEIGHT_TASKS = 8;
+      constexpr int MIN_COLS_PER_TASK = 128;
+      int num_down_tasks = std::min(std::max(1, config_.hidden_size / MIN_COLS_PER_TASK), 32);
+      int tasks_per_gpu_tp = NUM_WEIGHT_TASKS * 2 + num_down_tasks + 2;
+      int total_tasks = tasks_per_gpu_tp * gpu_tps_per_cpu_tp;
+      size_t weight_chunk_size = (data_per_gpu_tp_weight + NUM_WEIGHT_TASKS - 1) / NUM_WEIGHT_TASKS;
+      weight_chunk_size = (weight_chunk_size + 63) & ~63ULL;
+
+      pool->do_work_stealing_job(
+          total_tasks, nullptr,
+          [=, this, &w13_weight_ptrs, &w13_scale_ptrs, &w2_weight_ptrs, &w2_scale_ptrs](int task_id) {
+            int local_gpu_idx = task_id / tasks_per_gpu_tp;
+            int task_type = task_id % tasks_per_gpu_tp;
+            int gpu_tp_idx = start_gpu_tp + local_gpu_idx;
+            uint8_t* w13_weight_dst = (uint8_t*)w13_weight_ptrs[gpu_tp_idx];
+            ggml_bf16_t* w13_scale_dst = (ggml_bf16_t*)w13_scale_ptrs[gpu_tp_idx];
+            uint8_t* w2_weight_dst = (uint8_t*)w2_weight_ptrs[gpu_tp_idx];
+            ggml_bf16_t* w2_scale_dst = (ggml_bf16_t*)w2_scale_ptrs[gpu_tp_idx];
+            size_t cpu_offset_weight = (size_t)local_gpu_idx * data_per_gpu_tp_weight;
+            size_t cpu_offset_scale = (size_t)local_gpu_idx * data_per_gpu_tp_scale;
+            if (task_type < NUM_WEIGHT_TASKS) {
+              size_t start = (size_t)task_type * weight_chunk_size;
+              size_t end = std::min(start + weight_chunk_size, data_per_gpu_tp_weight);
+              if (start < end) std::memcpy(w13_weight_dst + start, gate_bb_[expert_id]->b + cpu_offset_weight + start, end - start);
+            } else if (task_type < NUM_WEIGHT_TASKS * 2) {
+              int chunk_idx = task_type - NUM_WEIGHT_TASKS;
+              size_t start = (size_t)chunk_idx * weight_chunk_size;
+              size_t end = std::min(start + weight_chunk_size, data_per_gpu_tp_weight);
+              if (start < end)
+                std::memcpy(w13_weight_dst + gpu_tp_weight_bytes + start,
+                            up_bb_[expert_id]->b + cpu_offset_weight + start, end - start);
+            } else if (task_type < NUM_WEIGHT_TASKS * 2 + num_down_tasks) {
+              int chunk_idx = task_type - NUM_WEIGHT_TASKS * 2;
+              size_t cols_per_chunk = (config_.hidden_size + num_down_tasks - 1) / num_down_tasks;
+              size_t col_start = (size_t)chunk_idx * cols_per_chunk;
+              size_t col_end = std::min(col_start + cols_per_chunk, (size_t)config_.hidden_size);
+              size_t weight_per_gpu_col = (config_.intermediate_size / gpu_tps_per_cpu_tp) >> 1;
+              size_t scale_per_gpu_col = (config_.intermediate_size / gpu_tps_per_cpu_tp) / group_size;
+              for (size_t col = col_start; col < col_end; col++) {
+                size_t col_offset_weight = (col * config_.intermediate_size / 2) +
+                                           (local_gpu_idx * data_per_gpu_tp_weight / config_.hidden_size);
+                size_t col_offset_scale = (col * (config_.intermediate_size / group_size)) +
+                                          (local_gpu_idx * data_per_gpu_tp_scale / config_.hidden_size);
+                std::memcpy(w2_weight_dst + col * weight_per_gpu_col, down_bb_[expert_id]->b + col_offset_weight,
+                            weight_per_gpu_col);
+                fp32_to_bf16(w2_scale_dst + col * scale_per_gpu_col, down_bb_[expert_id]->d + col_offset_scale,
+                             scale_per_gpu_col);
+              }
+            } else if (task_type == NUM_WEIGHT_TASKS * 2 + num_down_tasks) {
+              fp32_to_bf16(w13_scale_dst, gate_bb_[expert_id]->d + cpu_offset_scale, data_per_gpu_tp_scale);
+            } else {
+              fp32_to_bf16(w13_scale_dst + gpu_tp_scale_elem_count, up_bb_[expert_id]->d + cpu_offset_scale,
+                           data_per_gpu_tp_scale);
+            }
+          },
+          nullptr);
+    }
+  }
+};
+
+template <typename K>
+class TP_MOE<AVX2_RAW_INT4_MOE_TP<K>> : public TP_MOE<AVX2_MOE_BASE<K, AVX2_RAW_INT4_MOE_TP<K>>> {
+ public:
+  using Base = TP_MOE<AVX2_MOE_BASE<K, AVX2_RAW_INT4_MOE_TP<K>>>;
+  using Base::Base;
+
+  void load_weights() override {
+    auto& config = this->config;
+    auto& tps = this->tps;
+    auto pool = config.pool;
+    const uint64_t* physical_to_logical_map = (const uint64_t*)config.physical_to_logical_map;
+    bool use_per_expert_ptrs = !config.gate_projs.empty();
+    if (config.gate_projs.empty() && config.gate_scale == nullptr) {
+      throw std::runtime_error("RAWINT4 AVX2 MoE only supports packed INT4 with KGroup scales");
+    }
+
+    if (use_per_expert_ptrs) {
+      // Direct-pointer mode: inner load_weights() sets BufferB.b directly from mmap'd data.
+      // The down projection column-gather required for tp_count > 1 is NOT supported in
+      // this mode; enforce single NUMA pool (kt_threadpool_count=1).
+      if (this->tp_count > 1) {
+        throw std::runtime_error(
+            "RAWINT4 per-expert pointer mode requires kt_threadpool_count=1 "
+            "(down projection TP column-gather is unsupported with direct pointers)");
+      }
+      DO_TPS_LOAD_WEIGHTS(pool);
+    } else {
+      // Flat-buffer mode: build a TP-sliced contiguous buffer per TP partition, then
+      // call inner load_weights() which copies into BufferB.b from the flat buffer.
+      int group_size = config.quant_config.group_size;
+      pool->dispense_backend()->do_numa_job([&, this](int i) {
+        auto& tpc = tps[i]->config_;
+        size_t weight_elem_count = (size_t)tpc.intermediate_size * tpc.hidden_size;
+        size_t scales_elem_count = ((size_t)tpc.hidden_size / group_size) * tpc.intermediate_size;
+        tpc.gate_proj = new uint8_t[(tpc.expert_num * weight_elem_count) / 2];
+        tpc.up_proj = new uint8_t[(tpc.expert_num * weight_elem_count) / 2];
+        tpc.down_proj = new uint8_t[(tpc.expert_num * weight_elem_count) / 2];
+        tpc.gate_scale = new ggml_bf16_t[tpc.expert_num * scales_elem_count];
+        tpc.up_scale = new ggml_bf16_t[tpc.expert_num * scales_elem_count];
+        tpc.down_scale = new ggml_bf16_t[tpc.expert_num * scales_elem_count];
+
+        pool->get_subpool(i)->do_work_stealing_job(
+            tpc.expert_num, nullptr,
+            [&, i](int expert_id_) {
+              size_t expert_id = expert_map(physical_to_logical_map, expert_id_);
+              uint8_t* src_gate = (uint8_t*)config.gate_proj +
+                                  ((expert_id * (size_t)config.intermediate_size * config.hidden_size) >> 1);
+              uint8_t* src_up = (uint8_t*)config.up_proj +
+                                ((expert_id * (size_t)config.intermediate_size * config.hidden_size) >> 1);
+              uint8_t* src_down = (uint8_t*)config.down_proj +
+                                  ((expert_id * (size_t)config.intermediate_size * config.hidden_size) >> 1);
+              ggml_bf16_t* src_gate_scale = (ggml_bf16_t*)config.gate_scale +
+                                             expert_id * ((size_t)config.hidden_size / group_size) * config.intermediate_size;
+              ggml_bf16_t* src_up_scale = (ggml_bf16_t*)config.up_scale +
+                                           expert_id * ((size_t)config.hidden_size / group_size) * config.intermediate_size;
+              ggml_bf16_t* src_down_scale = (ggml_bf16_t*)config.down_scale +
+                                             expert_id * ((size_t)config.intermediate_size / group_size) * config.hidden_size;
+
+              std::memcpy((uint8_t*)tpc.gate_proj + ((expert_id * weight_elem_count) >> 1),
+                          src_gate + ((i * weight_elem_count) >> 1), weight_elem_count >> 1);
+              std::memcpy((uint8_t*)tpc.up_proj + ((expert_id * weight_elem_count) >> 1),
+                          src_up + ((i * weight_elem_count) >> 1), weight_elem_count >> 1);
+              std::memcpy((ggml_bf16_t*)tpc.gate_scale + expert_id * scales_elem_count,
+                          src_gate_scale + i * scales_elem_count, sizeof(ggml_bf16_t) * scales_elem_count);
+              std::memcpy((ggml_bf16_t*)tpc.up_scale + expert_id * scales_elem_count,
+                          src_up_scale + i * scales_elem_count, sizeof(ggml_bf16_t) * scales_elem_count);
+
+              for (size_t col = 0; col < (size_t)config.hidden_size; col++) {
+                std::memcpy((uint8_t*)tpc.down_proj +
+                                ((expert_id * weight_elem_count + col * tpc.intermediate_size) >> 1),
+                            src_down + ((col * config.intermediate_size + i * tpc.intermediate_size) >> 1),
+                            tpc.intermediate_size >> 1);
+                std::memcpy((ggml_bf16_t*)tpc.down_scale +
+                                (expert_id * scales_elem_count + col * (tpc.intermediate_size / group_size)),
+                            src_down_scale + (col * (config.intermediate_size / group_size) +
+                                              i * (tpc.intermediate_size / group_size)),
+                            sizeof(ggml_bf16_t) * (tpc.intermediate_size / group_size));
+              }
+            },
+            nullptr);
+        printf("AVX2 RAWINT4 TP %d load weight done.\n", i);
+      });
+
+      DO_TPS_LOAD_WEIGHTS(pool);
+
+      pool->dispense_backend()->do_numa_job([&, this](int i) {
+        auto& tpc = tps[i]->config_;
+        delete[] (uint8_t*)tpc.gate_proj;
+        delete[] (uint8_t*)tpc.up_proj;
+        delete[] (uint8_t*)tpc.down_proj;
+        delete[] (ggml_bf16_t*)tpc.gate_scale;
+        delete[] (ggml_bf16_t*)tpc.up_scale;
+        delete[] (ggml_bf16_t*)tpc.down_scale;
+      });
+    }
+
+    this->weights_loaded = true;
+  }
+
+  void write_weight_scale_to_buffer(int gpu_tp_count, int expert_id, const std::vector<uintptr_t>& w13_weight_ptrs,
+                                    const std::vector<uintptr_t>& w13_scale_ptrs,
+                                    const std::vector<uintptr_t>& w2_weight_ptrs,
+                                    const std::vector<uintptr_t>& w2_scale_ptrs) {
+    if (this->weights_loaded == false) throw std::runtime_error("Not Loaded");
+    if ((int)w13_weight_ptrs.size() != gpu_tp_count || (int)w13_scale_ptrs.size() != gpu_tp_count ||
+        (int)w2_weight_ptrs.size() != gpu_tp_count || (int)w2_scale_ptrs.size() != gpu_tp_count) {
+      throw std::runtime_error("Pointer arrays size must match gpu_tp_count");
+    }
+    this->config.pool->dispense_backend()->do_numa_job([&, this](int i) {
+      this->tps[i]->write_weights_to_buffer(gpu_tp_count, this->tp_count, expert_id, this->config, w13_weight_ptrs,
+                                            w13_scale_ptrs, w2_weight_ptrs, w2_scale_ptrs);
+    });
+  }
+};
+
+#endif  // CPUINFER_OPERATOR_AVX2_RAW_INT4_MOE_H

--- a/kt-kernel/operators/avx2/raw_int4_avxvnni-moe.hpp
+++ b/kt-kernel/operators/avx2/raw_int4_avxvnni-moe.hpp
@@ -1,0 +1,514 @@
+/**
+ * @Description  : AVX-VNNI-256 RAWINT4 MoE operator (Kimi native INT4 layout)
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * This backend consumes the same RAWINT4 source layout as the plain AVX2
+ * backend in raw_int4-moe.hpp:
+ *   weights [N, K/2] uint8  (two signed int4 values per byte, value = nibble - 8,
+ *                            low nibble = even k, high nibble = odd k)
+ *   scales  [N, K/group_size] bf16
+ *
+ * To use AVX-VNNI-256 effectively, activations are quantized on the fly to
+ * group-wise int8 (biased to uint8 for dpbusd), and the packed signed int4
+ * weights are unpacked into signed int8 [N, K] once at load time. dpbusd then
+ * does the group-wise inner product, followed by compensation (128 * weight_sum)
+ * and rescale by (a_scale * w_scale).
+ **/
+#ifndef CPUINFER_OPERATOR_AVX2_RAW_INT4_AVXVNNI_MOE_H
+#define CPUINFER_OPERATOR_AVX2_RAW_INT4_AVXVNNI_MOE_H
+
+#include <immintrin.h>
+
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <cstdint>
+#include <cstring>
+#include <limits>
+#include <memory>
+#include <stdexcept>
+
+#include "avx2_bf16_utils.hpp"
+#include "moe_base.hpp"
+
+#if defined(__GNUC__) || defined(__clang__)
+#define KT_AVXVNNI256_RAWINT4_TARGET __attribute__((target("avx2,avxvnni,fma")))
+#else
+#define KT_AVXVNNI256_RAWINT4_TARGET
+#endif
+
+namespace avxvnni_rawint4 {
+
+static constexpr int MAX_SUPPORTED_GROUP_SIZE = 256;
+
+static inline int hsum_epi32_avx2(__m256i v) {
+  __m128i lo = _mm256_castsi256_si128(v);
+  __m128i hi = _mm256_extracti128_si256(v, 1);
+  __m128i sum = _mm_add_epi32(lo, hi);
+  sum = _mm_hadd_epi32(sum, sum);
+  sum = _mm_hadd_epi32(sum, sum);
+  return _mm_cvtsi128_si32(sum);
+}
+
+// Quantize one activation group to biased uint8 for dpbusd.
+// Returns the activation scale. A return value of 0 means the group is all zero.
+static inline float quantize_activation_group_u8(const ggml_bf16_t* src, int group_size, uint8_t* dst) {
+  float absmax = 0.0f;
+
+  for (int i = 0; i < group_size; ++i) {
+    absmax = std::max(absmax, std::fabs(GGML_BF16_TO_FP32(src[i])));
+  }
+
+  if (absmax <= std::numeric_limits<float>::min()) {
+    std::memset(dst, 0x80, (size_t)group_size);
+    return 0.0f;
+  }
+
+  const float scale = absmax / 127.0f;
+  const float inv_scale = 1.0f / scale;
+  for (int i = 0; i < group_size; ++i) {
+    int q = (int)std::lrint(GGML_BF16_TO_FP32(src[i]) * inv_scale);
+    q = std::clamp(q, -127, 127);
+    dst[i] = (uint8_t)(((uint8_t)(int8_t)q) ^ 0x80);
+  }
+  return scale;
+}
+
+struct GemmKernelAVXVNNI256RawInt4 {
+  using dt = ggml_bf16_t;
+  using output_t = float;
+  static constexpr int M_STEP = 1;
+  static constexpr int N_STEP = 8;
+  static constexpr int K_STEP = 8;
+  static constexpr int N_BLOCK = 64;
+  static constexpr int K_BLOCK = 128;
+  static constexpr double ELEMENT_SIZE = 0.5;
+
+  static void config() {}
+
+  static int recommended_nth(int n) { return std::max(1, n / N_BLOCK); }
+
+  static std::pair<int, int> split_range_n(int n, int ith, int nth) { return avx2::split_range(n, ith, nth); }
+
+  struct BufferA {
+    ggml_bf16_t* data = nullptr;
+    size_t max_m = 0;
+    size_t k = 0;
+
+    BufferA() = default;
+    BufferA(size_t m, size_t k_, void* ptr) : data((ggml_bf16_t*)ptr), max_m(m), k(k_) {}
+
+    static size_t required_size(size_t m, size_t k) { return m * k * sizeof(ggml_bf16_t); }
+
+    void set_data(void* ptr) { data = (ggml_bf16_t*)ptr; }
+
+    void from_mat(int m, const ggml_bf16_t* src, int ith, int nth) {
+      if (ith == 0 && nth == 1) {
+        std::memcpy(data, src, (size_t)m * k * sizeof(ggml_bf16_t));
+      } else {
+        auto [m_start, m_end] = avx2::split_range(m, ith, nth);
+        std::memcpy(data + m_start * k, src + m_start * k,
+                    (size_t)(m_end - m_start) * k * sizeof(ggml_bf16_t));
+      }
+    }
+  };
+
+  struct BufferB {
+    int8_t* qweight_s8 = nullptr;   // [N, K] unpacked signed int8 weights
+    float* scales = nullptr;        // [N, num_groups] float32 (converted from bf16)
+    int16_t* weight_sums = nullptr; // [N, num_groups] per-group sum of unpacked int8 weights
+    int n = 0;
+    int k = 0;
+    int group_size = 128;
+    int num_groups = 0;
+
+    BufferB() = default;
+    BufferB(size_t n_, size_t k_, int gs, void* ptr) : n((int)n_), k((int)k_), group_size(gs) {
+      if (group_size <= 0 || (group_size % 32) != 0) {
+        throw std::runtime_error("AVX-VNNI RAWINT4 requires group_size to be a positive multiple of 32");
+      }
+      if (group_size > MAX_SUPPORTED_GROUP_SIZE) {
+        throw std::runtime_error("AVX-VNNI RAWINT4 requires group_size <= 256");
+      }
+      if ((k % 8) != 0 || (k % group_size) != 0) {
+        throw std::runtime_error("AVX-VNNI RAWINT4 requires k to be divisible by both 8 and group_size");
+      }
+      num_groups = k / group_size;
+      qweight_s8 = (int8_t*)ptr;
+      scales = (float*)((uint8_t*)ptr + (size_t)k * n * sizeof(int8_t));
+      weight_sums = (int16_t*)((uint8_t*)scales + (size_t)num_groups * n * sizeof(float));
+    }
+
+    static size_t required_size(size_t n, size_t k, int gs) {
+      const size_t num_groups = k / gs;
+      return k * n * sizeof(int8_t) + num_groups * n * sizeof(float) + num_groups * n * sizeof(int16_t);
+    }
+
+    // Unpack packed RAWINT4 weights [n_len, k/2] (row-major, low nibble = even k) into
+    // signed int8 [n_len, k], convert bf16 scales [n_len, num_groups] to float32,
+    // and compute int16 weight_sums [n_len, num_groups].
+    void from_raw_mat(const uint8_t* src_packed, const ggml_bf16_t* src_scales, int ith, int nth) {
+      auto [n_start, n_end] = avx2::split_range(n, ith, nth);
+      const size_t row_bytes = (size_t)k / 2;
+
+      for (int ni = n_start; ni < n_end; ++ni) {
+        const uint8_t* src_row = src_packed + (size_t)ni * row_bytes;
+        int8_t* dst_col = qweight_s8 + (size_t)ni * k;
+        const ggml_bf16_t* src_sc_row = src_scales + (size_t)ni * num_groups;
+        float* dst_sc_row = scales + (size_t)ni * num_groups;
+        int16_t* dst_ws_row = weight_sums + (size_t)ni * num_groups;
+
+        for (int g = 0; g < num_groups; ++g) {
+          const int k_base = g * group_size;
+          int sum = 0;
+          for (int kk = 0; kk < group_size; kk += 2) {
+            const uint8_t packed = src_row[(k_base + kk) / 2];
+            const int8_t v0 = (int8_t)((packed & 0x0F) - 8);         // even k
+            const int8_t v1 = (int8_t)(((packed >> 4) & 0x0F) - 8);  // odd k
+            dst_col[k_base + kk] = v0;
+            dst_col[k_base + kk + 1] = v1;
+            sum += v0 + v1;
+          }
+          dst_ws_row[g] = (int16_t)sum;
+          dst_sc_row[g] = GGML_BF16_TO_FP32(src_sc_row[g]);
+        }
+      }
+    }
+  };
+
+  struct BufferC {
+    float* data = nullptr;
+    size_t max_m = 0;
+    size_t n = 0;
+
+    BufferC() = default;
+    BufferC(size_t m, size_t n_, void* ptr) : data((float*)ptr), max_m(m), n(n_) {}
+
+    static size_t required_size(size_t m, size_t n) { return m * n * sizeof(float); }
+
+    void set_data(void* ptr) { data = (float*)ptr; }
+
+    void to_mat(int m, ggml_bf16_t* dst, int ith, int nth) {
+      auto [n_start, n_end] = avx2::split_range((int)n, ith, nth);
+      for (int mi = 0; mi < m; ++mi) {
+        float* src_row = data + mi * n;
+        ggml_bf16_t* dst_row = dst + mi * n;
+        int j = n_start;
+        for (; j + 8 <= n_end; j += 8) {
+          avx2::store_fp32_to_bf16(dst_row + j, _mm256_loadu_ps(src_row + j));
+        }
+        for (; j < n_end; ++j) {
+          dst_row[j] = GGML_FP32_TO_BF16(src_row[j]);
+        }
+      }
+    }
+  };
+};
+
+KT_AVXVNNI256_RAWINT4_TARGET
+static inline void gemm_raw_int4_avxvnni256(int m, int n, int k, GemmKernelAVXVNNI256RawInt4::BufferA& a,
+                                            GemmKernelAVXVNNI256RawInt4::BufferB& b,
+                                            GemmKernelAVXVNNI256RawInt4::BufferC& c, int ith, int nth) {
+  (void)k;
+  auto [n_start, n_end] = avx2::split_range(n, ith, nth);
+  const int group_size = b.group_size;
+  const int num_groups = b.num_groups;
+
+  alignas(32) std::array<uint8_t, MAX_SUPPORTED_GROUP_SIZE> a_u8{};
+
+  for (int mi = 0; mi < m; ++mi) {
+    const ggml_bf16_t* a_row = a.data + (size_t)mi * a.k;
+    float* c_row = c.data + (size_t)mi * n;
+    std::fill(c_row + n_start, c_row + n_end, 0.0f);
+
+    for (int g = 0; g < num_groups; ++g) {
+      const int k_base = g * group_size;
+      const float a_scale = quantize_activation_group_u8(a_row + k_base, group_size, a_u8.data());
+      if (a_scale == 0.0f) {
+        continue;
+      }
+
+      for (int ni = n_start; ni < n_end; ++ni) {
+        __m256i acc = _mm256_setzero_si256();
+        const int8_t* w_col = b.qweight_s8 + (size_t)ni * b.k + k_base;
+        for (int kk = 0; kk < group_size; kk += 32) {
+          const __m256i a_vec = _mm256_load_si256((const __m256i*)(a_u8.data() + kk));
+          const __m256i w_vec = _mm256_loadu_si256((const __m256i*)(w_col + kk));
+          acc = _mm256_dpbusd_avx_epi32(acc, a_vec, w_vec);
+        }
+
+        const int dot = hsum_epi32_avx2(acc) - 128 * (int)b.weight_sums[(size_t)ni * num_groups + g];
+        c_row[ni] += (float)dot * a_scale * b.scales[(size_t)ni * num_groups + g];
+      }
+    }
+  }
+}
+
+}  // namespace avxvnni_rawint4
+
+template <class T = avxvnni_rawint4::GemmKernelAVXVNNI256RawInt4>
+class AVXVNNI256_RAW_INT4_MOE_TP : public AVX2_MOE_BASE<T, AVXVNNI256_RAW_INT4_MOE_TP<T>> {
+  using Base = AVX2_MOE_BASE<T, AVXVNNI256_RAW_INT4_MOE_TP<T>>;
+  using Base::config_;
+  using Base::down_ba_;
+  using Base::down_bb_;
+  using Base::down_bc_;
+  using Base::gate_bb_;
+  using Base::gate_bc_;
+  using Base::gate_up_ba_;
+  using Base::m_local_num_;
+  using Base::tp_part_idx;
+  using Base::up_bb_;
+  using Base::up_bc_;
+
+ public:
+  using typename Base::input_t;
+  using typename Base::output_t;
+
+  AVXVNNI256_RAW_INT4_MOE_TP() = default;
+  AVXVNNI256_RAW_INT4_MOE_TP(GeneralMOEConfig config, int tp_part_idx_ = 0) : Base(config, tp_part_idx_) {}
+
+  void derived_init() {
+#if defined(__GNUC__) || defined(__clang__)
+    if (!__builtin_cpu_supports("avxvnni")) {
+      throw std::runtime_error("AVX-VNNI-256 RAWINT4 backend requires CPU support for avx_vnni");
+    }
+#endif
+    auto& qc = config_.quant_config;
+    if (qc.group_size == 0 || (qc.group_size % 32) != 0) {
+      throw std::runtime_error("AVX-VNNI-256 RAWINT4 requires group_size to be a positive multiple of 32");
+    }
+    if (qc.group_size > avxvnni_rawint4::MAX_SUPPORTED_GROUP_SIZE) {
+      throw std::runtime_error("AVX-VNNI-256 RAWINT4 requires group_size <= 256");
+    }
+    if (qc.zero_point) {
+      throw std::runtime_error("AVX-VNNI-256 RAWINT4 only supports signed INT4 without zero point");
+    }
+    printf("Created AVXVNNI256_RAW_INT4_MOE_TP %d at numa %d (group_size=%d)\n", tp_part_idx,
+           numa_node_of_cpu(sched_getcpu()), qc.group_size);
+  }
+
+  ~AVXVNNI256_RAW_INT4_MOE_TP() = default;
+
+  size_t buffer_a_required_size_impl(size_t m, size_t k) const { return T::BufferA::required_size(m, k); }
+  size_t buffer_b_required_size_impl(size_t n, size_t k) const {
+    return T::BufferB::required_size(n, k, config_.quant_config.group_size);
+  }
+  size_t buffer_c_required_size_impl(size_t m, size_t n) const { return T::BufferC::required_size(m, n); }
+
+  std::shared_ptr<typename T::BufferA> make_buffer_a_impl(size_t m, size_t k, void* data) const {
+    return std::make_shared<typename T::BufferA>(m, k, data);
+  }
+  std::shared_ptr<typename T::BufferB> make_buffer_b_impl(size_t n, size_t k, void* data) const {
+    return std::make_shared<typename T::BufferB>(n, k, config_.quant_config.group_size, data);
+  }
+  std::shared_ptr<typename T::BufferC> make_buffer_c_impl(size_t m, size_t n, void* data) const {
+    return std::make_shared<typename T::BufferC>(m, n, data);
+  }
+
+  void do_gate_up_gemm(bool do_up, int expert_idx, int ith, int nth, int qlen) {
+    (void)qlen;
+    int m = m_local_num_[expert_idx];
+    auto& ba = gate_up_ba_[expert_idx];
+    auto& bb = do_up ? up_bb_[expert_idx] : gate_bb_[expert_idx];
+    auto& bc = do_up ? up_bc_[expert_idx] : gate_bc_[expert_idx];
+    avxvnni_rawint4::gemm_raw_int4_avxvnni256(m, config_.intermediate_size, config_.hidden_size, *ba, *bb, *bc, ith,
+                                              nth);
+  }
+
+  void do_down_gemm(int expert_idx, int ith, int nth, int qlen) {
+    (void)qlen;
+    int m = m_local_num_[expert_idx];
+    avxvnni_rawint4::gemm_raw_int4_avxvnni256(m, config_.hidden_size, config_.intermediate_size,
+                                              *down_ba_[expert_idx], *down_bb_[expert_idx], *down_bc_[expert_idx], ith,
+                                              nth);
+  }
+
+  void load_weights() {
+    int group_size = config_.quant_config.group_size;
+    const uint64_t* physical_to_logical_map = (const uint64_t*)config_.physical_to_logical_map;
+    auto pool = config_.pool->get_subpool(tp_part_idx);
+
+    if (config_.gate_proj == nullptr || config_.gate_scale == nullptr) {
+      throw std::runtime_error("AVX-VNNI RAWINT4 MoE requires flat packed weight and bf16 scale pointers");
+    }
+
+    // Gate/Up: source per expert is packed int4 [N_tp, K/2] uint8 + bf16 scales [N_tp, K/gs].
+    {
+      int nth = T::recommended_nth(config_.intermediate_size);
+      pool->do_work_stealing_job(
+          nth * config_.expert_num, nullptr,
+          [this, nth, physical_to_logical_map, group_size](int task_id) {
+            uint64_t expert_idx = task_id / nth;
+            if (config_.should_skip_expert(expert_idx)) return;
+            uint64_t logical = expert_map(physical_to_logical_map, expert_idx);
+            int ith = task_id % nth;
+
+            const size_t weight_bytes_per_expert =
+                ((size_t)config_.intermediate_size * config_.hidden_size) / 2;
+            const size_t scale_elems_per_expert =
+                (size_t)config_.intermediate_size * (config_.hidden_size / group_size);
+
+            const uint8_t* gate_src = (const uint8_t*)config_.gate_proj + logical * weight_bytes_per_expert;
+            const uint8_t* up_src = (const uint8_t*)config_.up_proj + logical * weight_bytes_per_expert;
+            const ggml_bf16_t* gate_sc_src =
+                (const ggml_bf16_t*)config_.gate_scale + logical * scale_elems_per_expert;
+            const ggml_bf16_t* up_sc_src =
+                (const ggml_bf16_t*)config_.up_scale + logical * scale_elems_per_expert;
+
+            gate_bb_[expert_idx]->from_raw_mat(gate_src, gate_sc_src, ith, nth);
+            up_bb_[expert_idx]->from_raw_mat(up_src, up_sc_src, ith, nth);
+          },
+          nullptr);
+    }
+
+    // Down: source per expert is packed int4 [hidden_size, intermediate_size_tp/2] uint8
+    //       + bf16 scales [hidden_size, intermediate_size_tp/gs].
+    {
+      int nth = T::recommended_nth(config_.hidden_size);
+      pool->do_work_stealing_job(
+          nth * config_.expert_num, nullptr,
+          [this, nth, physical_to_logical_map, group_size](int task_id) {
+            uint64_t expert_idx = task_id / nth;
+            if (config_.should_skip_expert(expert_idx)) return;
+            uint64_t logical = expert_map(physical_to_logical_map, expert_idx);
+            int ith = task_id % nth;
+
+            const size_t weight_bytes_per_expert =
+                ((size_t)config_.hidden_size * config_.intermediate_size) / 2;
+            const size_t scale_elems_per_expert =
+                (size_t)config_.hidden_size * (config_.intermediate_size / group_size);
+
+            const uint8_t* down_src = (const uint8_t*)config_.down_proj + logical * weight_bytes_per_expert;
+            const ggml_bf16_t* down_sc_src =
+                (const ggml_bf16_t*)config_.down_scale + logical * scale_elems_per_expert;
+
+            down_bb_[expert_idx]->from_raw_mat(down_src, down_sc_src, ith, nth);
+          },
+          nullptr);
+    }
+  }
+
+  void write_weights_to_buffer(int gpu_tp_count, [[maybe_unused]] int cpu_tp_count, int expert_id,
+                               const GeneralMOEConfig& full_config, const std::vector<uintptr_t>& w13_weight_ptrs,
+                               [[maybe_unused]] const std::vector<uintptr_t>& w13_scale_ptrs,
+                               const std::vector<uintptr_t>& w2_weight_ptrs,
+                               [[maybe_unused]] const std::vector<uintptr_t>& w2_scale_ptrs) const {
+    (void)gpu_tp_count;
+    (void)expert_id;
+    (void)full_config;
+    (void)w13_weight_ptrs;
+    (void)w2_weight_ptrs;
+    throw std::runtime_error("AVX-VNNI-256 RAWINT4 write_weights_to_buffer not yet implemented");
+  }
+};
+
+template <typename K>
+class TP_MOE<AVXVNNI256_RAW_INT4_MOE_TP<K>> : public TP_MOE<AVX2_MOE_BASE<K, AVXVNNI256_RAW_INT4_MOE_TP<K>>> {
+ public:
+  using Base = TP_MOE<AVX2_MOE_BASE<K, AVXVNNI256_RAW_INT4_MOE_TP<K>>>;
+  using Base::Base;
+
+  void load_weights() override {
+    auto& config = this->config;
+    auto& tps = this->tps;
+    auto pool = config.pool;
+    const uint64_t* physical_to_logical_map = (const uint64_t*)config.physical_to_logical_map;
+
+    if (config.gate_proj == nullptr || config.gate_scale == nullptr) {
+      throw std::runtime_error("AVX-VNNI RAWINT4 MoE only supports flat packed INT4 with KGroup bf16 scales");
+    }
+
+    const int group_size = config.quant_config.group_size;
+    if (group_size == 0) {
+      throw std::runtime_error("AVX-VNNI RAWINT4 requires group_size > 0");
+    }
+
+    // Build TP-sliced flat buffers per NUMA partition (source layout mirrors raw_int4-moe.hpp).
+    pool->dispense_backend()->do_numa_job([&, this](int i) {
+      auto& tpc = tps[i]->config_;
+      size_t weight_elem_count = (size_t)tpc.intermediate_size * tpc.hidden_size;
+      size_t scales_elem_count = ((size_t)tpc.hidden_size / group_size) * tpc.intermediate_size;
+      tpc.gate_proj = new uint8_t[(tpc.expert_num * weight_elem_count) / 2];
+      tpc.up_proj = new uint8_t[(tpc.expert_num * weight_elem_count) / 2];
+      tpc.down_proj = new uint8_t[(tpc.expert_num * weight_elem_count) / 2];
+      tpc.gate_scale = new ggml_bf16_t[tpc.expert_num * scales_elem_count];
+      tpc.up_scale = new ggml_bf16_t[tpc.expert_num * scales_elem_count];
+      tpc.down_scale = new ggml_bf16_t[tpc.expert_num * scales_elem_count];
+
+      pool->get_subpool(i)->do_work_stealing_job(
+          tpc.expert_num, nullptr,
+          [&, i](int expert_id_) {
+            size_t expert_id = expert_map(physical_to_logical_map, expert_id_);
+            uint8_t* src_gate = (uint8_t*)config.gate_proj +
+                                ((expert_id * (size_t)config.intermediate_size * config.hidden_size) >> 1);
+            uint8_t* src_up = (uint8_t*)config.up_proj +
+                              ((expert_id * (size_t)config.intermediate_size * config.hidden_size) >> 1);
+            uint8_t* src_down = (uint8_t*)config.down_proj +
+                                ((expert_id * (size_t)config.intermediate_size * config.hidden_size) >> 1);
+            ggml_bf16_t* src_gate_scale = (ggml_bf16_t*)config.gate_scale +
+                                          expert_id * ((size_t)config.hidden_size / group_size) * config.intermediate_size;
+            ggml_bf16_t* src_up_scale = (ggml_bf16_t*)config.up_scale +
+                                        expert_id * ((size_t)config.hidden_size / group_size) * config.intermediate_size;
+            ggml_bf16_t* src_down_scale = (ggml_bf16_t*)config.down_scale +
+                                          expert_id * ((size_t)config.intermediate_size / group_size) * config.hidden_size;
+
+            // Gate/Up: contiguous slice along N (intermediate).
+            std::memcpy((uint8_t*)tpc.gate_proj + ((expert_id * weight_elem_count) >> 1),
+                        src_gate + ((i * weight_elem_count) >> 1), weight_elem_count >> 1);
+            std::memcpy((uint8_t*)tpc.up_proj + ((expert_id * weight_elem_count) >> 1),
+                        src_up + ((i * weight_elem_count) >> 1), weight_elem_count >> 1);
+            std::memcpy((ggml_bf16_t*)tpc.gate_scale + expert_id * scales_elem_count,
+                        src_gate_scale + i * scales_elem_count, sizeof(ggml_bf16_t) * scales_elem_count);
+            std::memcpy((ggml_bf16_t*)tpc.up_scale + expert_id * scales_elem_count,
+                        src_up_scale + i * scales_elem_count, sizeof(ggml_bf16_t) * scales_elem_count);
+
+            // Down: column-gather across N (hidden) rows for the TP-sliced K (intermediate).
+            for (size_t col = 0; col < (size_t)config.hidden_size; col++) {
+              std::memcpy((uint8_t*)tpc.down_proj +
+                              ((expert_id * weight_elem_count + col * tpc.intermediate_size) >> 1),
+                          src_down + ((col * config.intermediate_size + i * tpc.intermediate_size) >> 1),
+                          tpc.intermediate_size >> 1);
+              std::memcpy((ggml_bf16_t*)tpc.down_scale +
+                              (expert_id * scales_elem_count + col * (tpc.intermediate_size / group_size)),
+                          src_down_scale + (col * (config.intermediate_size / group_size) +
+                                            i * (tpc.intermediate_size / group_size)),
+                          sizeof(ggml_bf16_t) * (tpc.intermediate_size / group_size));
+            }
+          },
+          nullptr);
+      printf("AVX-VNNI-256 RAWINT4 TP %d load weight done.\n", i);
+    });
+
+    DO_TPS_LOAD_WEIGHTS(pool);
+
+    pool->dispense_backend()->do_numa_job([&, this](int i) {
+      auto& tpc = tps[i]->config_;
+      delete[] (uint8_t*)tpc.gate_proj;
+      delete[] (uint8_t*)tpc.up_proj;
+      delete[] (uint8_t*)tpc.down_proj;
+      delete[] (ggml_bf16_t*)tpc.gate_scale;
+      delete[] (ggml_bf16_t*)tpc.up_scale;
+      delete[] (ggml_bf16_t*)tpc.down_scale;
+    });
+
+    this->weights_loaded = true;
+  }
+
+  void write_weight_scale_to_buffer(int gpu_tp_count, int expert_id, const std::vector<uintptr_t>& w13_weight_ptrs,
+                                    const std::vector<uintptr_t>& w13_scale_ptrs,
+                                    const std::vector<uintptr_t>& w2_weight_ptrs,
+                                    const std::vector<uintptr_t>& w2_scale_ptrs) {
+    (void)gpu_tp_count;
+    (void)expert_id;
+    (void)w13_weight_ptrs;
+    (void)w13_scale_ptrs;
+    (void)w2_weight_ptrs;
+    (void)w2_scale_ptrs;
+    throw std::runtime_error("AVX-VNNI-256 RAWINT4 write_weight_scale_to_buffer not yet implemented");
+  }
+};
+
+#undef KT_AVXVNNI256_RAWINT4_TARGET
+
+#endif  // CPUINFER_OPERATOR_AVX2_RAW_INT4_AVXVNNI_MOE_H

--- a/kt-kernel/python/utils/amx.py
+++ b/kt-kernel/python/utils/amx.py
@@ -24,7 +24,9 @@ AMXFP8PerChannel_MOE = getattr(_moe_mod, "AMXFP8PerChannel_MOE", None)
 AVX2BF16_MOE = getattr(_moe_mod, "AVX2BF16_MOE", None)
 AVX2FP8_MOE = getattr(_moe_mod, "AVX2FP8_MOE", None)
 AVX2GPTQInt4_MOE = getattr(_moe_mod, "AVX2GPTQInt4_MOE", None)
+AVX2RawInt4_MOE = getattr(_moe_mod, "AVX2RawInt4_MOE", None)
 AVXVNNI256GPTQInt4_MOE = getattr(_moe_mod, "AVXVNNI256GPTQInt4_MOE", None)
+AVXVNNI256RawInt4_MOE = getattr(_moe_mod, "AVXVNNI256RawInt4_MOE", None)
 
 _HAS_AMXINT4_SUPPORT = AMXInt4_MOE is not None
 _HAS_AMXINT8_SUPPORT = AMXInt8_MOE is not None
@@ -35,8 +37,11 @@ _HAS_FP8_PERCHANNEL_SUPPORT = AMXFP8PerChannel_MOE is not None
 _HAS_AVX2_BF16_SUPPORT = AVX2BF16_MOE is not None
 _HAS_AVX2_FP8_SUPPORT = AVX2FP8_MOE is not None
 _HAS_AVX2_GPTQ_INT4_SUPPORT = AVX2GPTQInt4_MOE is not None
+_HAS_AVX2_RAWINT4_SUPPORT = AVX2RawInt4_MOE is not None
 _HAS_AVXVNNI256_GPTQ_INT4_SUPPORT = AVXVNNI256GPTQInt4_MOE is not None
+_HAS_AVXVNNI256_RAW_INT4_SUPPORT = AVXVNNI256RawInt4_MOE is not None
 _AVXVNNI256_GPTQ_INT4_MAX_GROUP_SIZE = 256
+_AVXVNNI256_RAW_INT4_MAX_GROUP_SIZE = 256
 
 
 def _host_has_cpu_flag(*flag_names: str) -> bool:
@@ -58,6 +63,12 @@ def _supports_avxvnni256_gptq_int4_group_size(group_size: Optional[int]) -> bool
     if group_size is None:
         return True
     return group_size > 0 and group_size % 32 == 0 and group_size <= _AVXVNNI256_GPTQ_INT4_MAX_GROUP_SIZE
+
+
+def _supports_avxvnni256_rawint4_group_size(group_size: Optional[int]) -> bool:
+    if group_size is None:
+        return True
+    return group_size > 0 and group_size % 32 == 0 and group_size <= _AVXVNNI256_RAW_INT4_MAX_GROUP_SIZE
 
 
 def _select_gptq_int4_backend(group_size: Optional[int] = None):
@@ -86,6 +97,42 @@ def _select_gptq_int4_backend(group_size: Optional[int] = None):
         return AVXVNNI256GPTQInt4_MOE
     if _HAS_AVX2_GPTQ_INT4_SUPPORT:
         return AVX2GPTQInt4_MOE
+    return None
+
+
+def _select_rawint4_backend(group_size: Optional[int] = None):
+    forced = os.getenv("KT_RAWINT4_BACKEND", "").strip().lower()
+    avxvnni_group_supported = _supports_avxvnni256_rawint4_group_size(group_size)
+
+    if forced == "amx":
+        if not _HAS_RAWINT4_SUPPORT:
+            raise RuntimeError("KT_RAWINT4_BACKEND=amx requested, but AMXInt4_KGroup_MOE is not compiled in.")
+        return AMXInt4_KGroup_MOE
+
+    if forced in {"avxvnni", "avxvnni256"}:
+        if not _HAS_AVXVNNI256_RAW_INT4_SUPPORT:
+            raise RuntimeError("KT_RAWINT4_BACKEND=avxvnni requested, but AVXVNNI256RawInt4_MOE is not compiled in.")
+        if not _HOST_HAS_AVX_VNNI:
+            raise RuntimeError("KT_RAWINT4_BACKEND=avxvnni requested, but the current CPU does not support avx_vnni.")
+        if not avxvnni_group_supported:
+            raise RuntimeError(
+                "KT_RAWINT4_BACKEND=avxvnni requested, but "
+                f"group_size={group_size} is unsupported. AVX-VNNI-256 RAWINT4 only supports "
+                f"positive multiples of 32 up to {_AVXVNNI256_RAW_INT4_MAX_GROUP_SIZE}."
+            )
+        return AVXVNNI256RawInt4_MOE
+
+    if forced == "avx2":
+        if not _HAS_AVX2_RAWINT4_SUPPORT:
+            raise RuntimeError("KT_RAWINT4_BACKEND=avx2 requested, but AVX2RawInt4_MOE is not compiled in.")
+        return AVX2RawInt4_MOE
+
+    if _HAS_RAWINT4_SUPPORT:
+        return AMXInt4_KGroup_MOE
+    if _HAS_AVXVNNI256_RAW_INT4_SUPPORT and _HOST_HAS_AVX_VNNI and avxvnni_group_supported:
+        return AVXVNNI256RawInt4_MOE
+    if _HAS_AVX2_RAWINT4_SUPPORT:
+        return AVX2RawInt4_MOE
     return None
 
 
@@ -412,11 +459,15 @@ class NativeMoEWrapper(BaseMoEWrapper):
         method: str = "RAWINT4",
         numa_nodes: Optional[List[int]] = None,
     ):
-        if method == "RAWINT4" and not _HAS_RAWINT4_SUPPORT:
+        if method == "RAWINT4" and not (
+            _HAS_RAWINT4_SUPPORT or _HAS_AVX2_RAWINT4_SUPPORT or _HAS_AVXVNNI256_RAW_INT4_SUPPORT
+        ):
             raise RuntimeError(
                 "RAWINT4 backend not available. Required ISA:\n"
-                "  - AVX512F + AVX512BW (VNNI optional)\n"
-                "Please recompile kt_kernel_ext with AVX512 enabled."
+                "  - AVX512F + AVX512BW (for AMX backend), or\n"
+                "  - AVX2 + FMA (for AVX2 fallback backend)\n"
+                "AVX-VNNI-256 will be selected automatically when available on the current CPU.\n"
+                "Please recompile kt_kernel_ext with AVX512 or AVX2 enabled."
             )
         if method == "FP8" and not _HAS_FP8_SUPPORT and not _HAS_AVX2_FP8_SUPPORT:
             raise RuntimeError(
@@ -589,7 +640,15 @@ class NativeMoEWrapper(BaseMoEWrapper):
             moe_config.quant_config.bits = 4
             moe_config.quant_config.group_size = group_size
             moe_config.quant_config.zero_point = False
-            self.moe = AMXInt4_KGroup_MOE(moe_config)
+            backend_cls = _select_rawint4_backend(group_size)
+            if backend_cls is None:
+                raise RuntimeError(
+                    "No RAWINT4 backend is available after runtime selection for "
+                    f"group_size={group_size}. AMX (AMXInt4_KGroup_MOE) is preferred; "
+                    f"AVX-VNNI-256 supports positive multiples of 32 up to "
+                    f"{_AVXVNNI256_RAW_INT4_MAX_GROUP_SIZE}; AVX2 (AVX2RawInt4_MOE) is used as the final fallback."
+                )
+            self.moe = backend_cls(moe_config)
         elif self.method == "FP8":
             moe_config.quant_config.bits = 8
             moe_config.quant_config.group_size = 128


### PR DESCRIPTION
## Summary

This PR adds AVX2 and AVX-VNNI RAWINT4 MoE support to `kt-kernel`.

It includes:
- new AVX2 and AVX-VNNI RAWINT4 MoE operator implementations
- Python-side RAWINT4 backend detection / selection updates
- extension bindings for the new RAWINT4 MoE backends
- English and Chinese AVX2 tutorial updates

## Why

`kt-kernel` already exposes BF16, FP8, and GPTQ INT4 AVX2 backends. This change adds RAWINT4 MoE coverage so the AVX2 path can use raw int4 weights directly.

## Validation

- verified the branch diff against `upstream/main` contains only the intended 6 files
- confirmed `kt-kernel/ext_bindings.cpp` keeps current upstream changes and only adds the RAWINT4 binding hunks
- ran `python -m py_compile kt-kernel/python/utils/amx.py`

## Notes

- full C++ build / runtime tests were not run in this workspace
