### PR TITLE
[feat](kt-kernel): add AVX2/AVX-VNNI RAWINT4 MoE backend

### DIFF
--- a/doc/en/kt-kernel/AVX2-Tutorial.md
+++ b/doc/en/kt-kernel/AVX2-Tutorial.md
@@ -12,6 +12,7 @@ This tutorial explains how to run KTransformers on machines that only support AV
   - [Example: Qwen3-30B-A3B (BF16)](#example-qwen3-30b-a3b-bf16)
   - [Example: Qwen3.5-35B-A3B-FP8 (FP8)](#example-qwen35-35b-a3b-fp8-fp8)
   - [Example: Qwen3-30B-A3B-GPTQ-Int4 (GPTQ_INT4)](#example-qwen3-30b-a3b-gptq-int4-gptq_int4)
+  - [Example: Kimi-K2.5 (RAWINT4)](#example-kimi-k25-rawint4)
   - [Sending Requests](#sending-requests)
 - [Performance Tuning](#performance-tuning)
 - [FAQ](#faq)
@@ -23,6 +24,7 @@ This tutorial explains how to run KTransformers on machines that only support AV
 | `BF16` | BF16 native precision | Zero precision loss, uses BF16 weights directly |
 | `FP8` | FP8 block quantization |  |
 | `GPTQ_INT4` | INT4 GPTQ |  |
+| `RAWINT4` | Raw INT4 with BF16 scales | Used by Kimi-K2.5; weights stored in compressed SafeTensor format |
 
 
 ## Hardware Requirements
@@ -71,7 +73,7 @@ kt doctor
 
 ## Starting the Inference Server
 
-Use `--kt-method BF16`, `FP8`, or `GPTQ_INT4`. KT-Kernel will **automatically detect** the CPU and fall back to the AVX2 backend when AVX512/AMX is unavailable.
+Use `--kt-method BF16`, `FP8`, `GPTQ_INT4`, or `RAWINT4`. KT-Kernel will **automatically detect** the CPU and fall back to the AVX2 backend when AVX512/AMX is unavailable.
 
 ### Example: Qwen3-30B-A3B (BF16)
 
@@ -153,6 +155,36 @@ python -m sglang.launch_server \
   --max-total-tokens 32000 \
   --enable-mixed-chunk \
   --tensor-parallel-size 1 \
+  --disable-shared-experts-fusion
+```
+
+### Example: Kimi-K2.5 (RAWINT4)
+
+> **Note**: The following command is optimized for 4x RTX PRO 6000 Blackwell (96GB each) + AMD Threadripper PRO 5995WX (64 cores, 1 NUMA node) + 256GB RAM.
+
+```bash
+# Download the model
+huggingface-cli download moonshotai/Kimi-K2.5 --local-dir /path/to/Kimi-K2.5
+
+# Start the server
+python -m sglang.launch_server \
+  --host 0.0.0.0 --port 30000 \
+  --model /path/to/Kimi-K2.5 \
+  --kt-weight-path /path/to/Kimi-K2.5 \
+  --kt-cpuinfer 64 \
+  --kt-threadpool-count 1 \
+  --kt-num-gpu-experts 228 \
+  --kt-enable-dynamic-expert-update \
+  --kt-method RAWINT4 \
+  --attention-backend flashinfer \
+  --trust-remote-code \
+  --mem-fraction-static 0.95 \
+  --chunked-prefill-size 8192 \
+  --max-running-requests 4 \
+  --context-length 262144 \
+  --enable-mixed-chunk \
+  --tensor-parallel-size 4 \
+  --enable-p2p-check \
   --disable-shared-experts-fusion
 ```
 

--- a/doc/en/kt-kernel/AVX2-Tutorial.md
+++ b/doc/en/kt-kernel/AVX2-Tutorial.md
@@ -50,6 +50,7 @@ git submodule update --init --recursive
 On AVX512 or AMX machines, you can also manually force AVX2 compilation:
 
 ```bash
+export KT_RAWINT4_BACKEND=avx2
 export CPUINFER_CPU_INSTRUCT=AVX2
 export CPUINFER_ENABLE_AMX=OFF
 ./install.sh kt-kernel --manual

--- a/doc/zh/AVX2-Tutorial_zh.md
+++ b/doc/zh/AVX2-Tutorial_zh.md
@@ -12,6 +12,7 @@
   - [示例：Qwen3-30B-A3B (BF16)](#示例qwen3-30b-a3b-bf16)
   - [示例：Qwen3.5-35B-A3B-FP8 (FP8)](#示例qwen35-35b-a3b-fp8-fp8)
   - [示例：Qwen3-30B-A3B-GPTQ-Int4 (GPTQ_INT4)](#示例qwen3-30b-a3b-gptq-int4-gptq_int4)
+  - [示例：Kimi-K2.5 (RAWINT4)](#示例kimi-k25-rawint4)
   - [发送请求](#发送请求)
 - [性能调优](#性能调优)
 - [常见问题](#常见问题)
@@ -23,6 +24,7 @@
 | `BF16` | BF16 原精度 | 零精度损失，直接使用 BF16 权重 |
 | `FP8` | FP8 分块量化 |  |
 | `GPTQ_INT4` | INT4 GPTQ |  |
+| `RAWINT4` | Raw INT4 + BF16 缩放因子 | Kimi-K2.5 专用；权重以压缩 SafeTensor 格式存储 |
 
 
 ## 硬件要求
@@ -71,7 +73,7 @@ kt doctor
 
 ## 启动推理服务
 
-使用 `--kt-method BF16`、`FP8` 或 `GPTQ_INT4`，KT-Kernel 会**自动检测** CPU 并在缺少 AVX512/AMX 时回退到 AVX2 后端。
+使用 `--kt-method BF16`、`FP8`、`GPTQ_INT4` 或 `RAWINT4`，KT-Kernel 会**自动检测** CPU 并在缺少 AVX512/AMX 时回退到 AVX2 后端。
 
 ### 示例：Qwen3-30B-A3B (BF16)
 
@@ -155,6 +157,37 @@ python -m sglang.launch_server \
   --tensor-parallel-size 1 \
   --disable-shared-experts-fusion
 ```
+
+### 示例：Kimi-K2.5 (RAWINT4)
+
+> **说明**：以下命令针对 4x RTX PRO 6000 Blackwell（各 96GB）+ AMD Threadripper PRO 5995WX（64 核，1 NUMA 节点）+ 256GB RAM 优化。
+
+```bash
+# 下载模型
+huggingface-cli download moonshotai/Kimi-K2.5 --local-dir /path/to/Kimi-K2.5
+
+# 启动服务
+python -m sglang.launch_server \
+  --host 0.0.0.0 --port 30000 \
+  --model /path/to/Kimi-K2.5 \
+  --kt-weight-path /path/to/Kimi-K2.5 \
+  --kt-cpuinfer 64 \
+  --kt-threadpool-count 1 \
+  --kt-num-gpu-experts 228 \
+  --kt-enable-dynamic-expert-update \
+  --kt-method RAWINT4 \
+  --attention-backend flashinfer \
+  --trust-remote-code \
+  --mem-fraction-static 0.95 \
+  --chunked-prefill-size 8192 \
+  --max-running-requests 4 \
+  --context-length 262144 \
+  --enable-mixed-chunk \
+  --tensor-parallel-size 4 \
+  --enable-p2p-check \
+  --disable-shared-experts-fusion
+```
+
 
 ### 发送请求
 

--- a/doc/zh/AVX2-Tutorial_zh.md
+++ b/doc/zh/AVX2-Tutorial_zh.md
@@ -50,6 +50,7 @@ git submodule update --init --recursive
 在AVX512， AMX机器上， 也可以手动强制 AVX2 编译：
 
 ```bash
+export KT_RAWINT4_BACKEND=avx2
 export CPUINFER_CPU_INSTRUCT=AVX2
 export CPUINFER_ENABLE_AMX=OFF
 ./install.sh kt-kernel --manual

--- a/kt-kernel/ext_bindings.cpp
+++ b/kt-kernel/ext_bindings.cpp
@@ -54,8 +54,10 @@ static const bool _is_plain_ = false;
 #if defined(__x86_64__)
 #include "operators/avx2/bf16-moe.hpp"
 #include "operators/avx2/fp8-moe.hpp"
-#include "operators/avx2/gptq_int4_avxvnni-moe.hpp"
 #include "operators/avx2/gptq_int4-moe.hpp"
+#include "operators/avx2/gptq_int4_avxvnni-moe.hpp"
+#include "operators/avx2/rawint4-moe.hpp"
+#include "operators/avx2/rawint4_avxvnni-moe.hpp"
 #endif
 
 #include <pybind11/stl.h>  // std::vector/std::pair/std::string conversions
@@ -73,7 +75,6 @@ static const bool _is_plain_ = false;
 
 namespace py = pybind11;
 using namespace pybind11::literals;
-
 
 py::object to_float_ptr(uintptr_t input_ptr, int size, ggml_type type) {
   if (type < 0 || type >= GGML_TYPE_COUNT) {
@@ -473,7 +474,6 @@ void bind_moe_module(py::module_& moe_module, const char* name) {
 }
 
 PYBIND11_MODULE(kt_kernel_ext, m) {
-
   py::class_<WorkerPool>(m, "WorkerPool").def(py::init<int>());
   py::class_<WorkerPoolConfig>(m, "WorkerPoolConfig")
       .def(py::init<>())
@@ -812,8 +812,11 @@ PYBIND11_MODULE(kt_kernel_ext, m) {
   bind_moe_module<AVX2_BF16_MOE_TP<avx2::GemmKernelAVX2BF16>>(moe_module, "AVX2BF16_MOE");
   bind_moe_module<AVX2_FP8_MOE_TP<avx2::GemmKernelAVX2FP8>>(moe_module, "AVX2FP8_MOE");
   bind_moe_module<AVX2_GPTQ_INT4_MOE_TP<avx2::GemmKernelAVX2GPTQInt4>>(moe_module, "AVX2GPTQInt4_MOE");
+  bind_moe_module<AVX2_RAW_INT4_MOE_TP<avx2::GemmKernelAVX2RawInt4>>(moe_module, "AVX2RawInt4_MOE");
   bind_moe_module<AVXVNNI256_GPTQ_INT4_MOE_TP<avxvnni::GemmKernelAVXVNNI256GPTQInt4>>(moe_module,
-                                                                                        "AVXVNNI256GPTQInt4_MOE");
+                                                                                      "AVXVNNI256GPTQInt4_MOE");
+  bind_moe_module<AVXVNNI256_RAW_INT4_MOE_TP<avxvnni_rawint4::GemmKernelAVXVNNI256RawInt4>>(moe_module,
+                                                                                            "AVXVNNI256RawInt4_MOE");
 #endif
 
 #if defined(USE_MOE_KERNEL)
@@ -1001,4 +1004,3 @@ __attribute__((constructor)) static void install_handlers() {
   sigaction(SIGSEGV, &sa, nullptr);
   sigaction(SIGABRT, &sa, nullptr);
 }
-

--- a/kt-kernel/operators/avx2/rawint4-moe.hpp
+++ b/kt-kernel/operators/avx2/rawint4-moe.hpp
@@ -1,0 +1,680 @@
+/**
+ * @Description  : AVX2 RAWINT4 MoE operator for Kimi native INT4 weights
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * RAWINT4 stores signed int4 weights packed two values per byte, plus BF16
+ * K-group scales. This AVX2 backend keeps the native layout so GPU layerwise
+ * prefill can reuse the same weight buffers, and uses BF16 activations with
+ * FP32 accumulation for CPU decode.
+ **/
+#ifndef CPUINFER_OPERATOR_AVX2_RAW_INT4_MOE_H
+#define CPUINFER_OPERATOR_AVX2_RAW_INT4_MOE_H
+
+#include "avx2_bf16_gemm.hpp"
+#include "avx2_bf16_utils.hpp"
+#include "gptq_int4_dequant.hpp"
+#include "moe_base.hpp"
+
+namespace avx2 {
+
+// Local, RAWINT4-only variant of gptq_sym_dequant_8x4bit that skips the
+// per-group scale multiply. Callers fold the scale in via a single FMA after
+// the K-loop so the inner path avoids a broadcast+mul per packed int32.
+static inline __m256 rawint4_dequant_8x4bit_unscaled(uint32_t packed_weight) {
+  const __m256i shifts = _mm256_set_epi32(28, 24, 20, 16, 12, 8, 4, 0);
+  __m256i packed_v = _mm256_set1_epi32(packed_weight);
+  __m256i nibbles = _mm256_and_si256(_mm256_srlv_epi32(packed_v, shifts), _mm256_set1_epi32(0xF));
+  __m256 w = _mm256_cvtepi32_ps(nibbles);
+  return _mm256_sub_ps(w, _mm256_set1_ps(8.0f));
+}
+
+struct GemmKernelAVX2RawInt4 {
+  using dt = uint8_t;
+  using output_t = float;
+  static constexpr int M_STEP = 1;
+  static constexpr int N_STEP = 8;
+  static constexpr int K_STEP = 8;
+  static constexpr int N_BLOCK = 64;
+  static constexpr int K_BLOCK = 128;
+  static constexpr double ELEMENT_SIZE = 0.5;
+
+  static void config() {}
+
+  static int recommended_nth(int n) { return std::max(1, div_up(n, N_BLOCK)); }
+
+  static std::pair<int, int> split_range_n(int n, int ith, int nth) { return split_range(n, ith, nth); }
+
+  struct BufferA {
+    ggml_bf16_t* data = nullptr;
+    size_t max_m = 0;
+    size_t k = 0;
+
+    BufferA() = default;
+    BufferA(size_t m, size_t k_, int, void* ptr) : data((ggml_bf16_t*)ptr), max_m(m), k(k_) {}
+
+    static size_t required_size(size_t m, size_t k, int) { return m * k * sizeof(ggml_bf16_t); }
+
+    void set_data(void* ptr) { data = (ggml_bf16_t*)ptr; }
+
+    void from_mat(int m, const ggml_bf16_t* src, int ith, int nth) {
+      if (ith == 0 && nth == 1) {
+        std::memcpy(data, src, (size_t)m * k * sizeof(ggml_bf16_t));
+      } else {
+        auto [m_start, m_end] = split_range(m, ith, nth);
+        std::memcpy(data + m_start * k, src + m_start * k, (size_t)(m_end - m_start) * k * sizeof(ggml_bf16_t));
+      }
+    }
+  };
+
+  struct BufferB {
+    uint8_t* b = nullptr;
+    float* d = nullptr;
+    int n = 0;
+    int k = 0;
+    int k_group_size = 0;
+    int k_group_count = 0;
+
+    BufferB() = default;
+
+    // Full allocation: b and d packed into a single aligned block.
+    BufferB(int n_, int k_, int k_group_size_, void* ptr)
+        : b((uint8_t*)ptr), n(n_), k(k_), k_group_size(k_group_size_) {
+      if (k_group_size <= 0 || k % k_group_size != 0 || k % 8 != 0) {
+        throw std::runtime_error("RAWINT4 requires k aligned to group_size and 8");
+      }
+      k_group_count = k / k_group_size;
+      d = (float*)((uint8_t*)ptr + ((size_t)n * k / 2));
+    }
+
+    // Scale-only allocation: b points to external (mmap'd) weight data; d owns scale_ptr.
+    // Used when weights are consumed directly from safetensor mmap without copying.
+    BufferB(int n_, int k_, int k_group_size_, void* scale_ptr, std::nullptr_t /*scale_only*/)
+        : b(nullptr), n(n_), k(k_), k_group_size(k_group_size_) {
+      if (k_group_size <= 0 || k % k_group_size != 0 || k % 8 != 0) {
+        throw std::runtime_error("RAWINT4 requires k aligned to group_size and 8");
+      }
+      k_group_count = k / k_group_size;
+      d = (float*)scale_ptr;
+    }
+
+    // Full size: packed INT4 weights + float32 scales.
+    static size_t required_size(size_t n, size_t k, int k_group_size) {
+      return n * k / 2 + n * (k / k_group_size) * sizeof(float);
+    }
+
+    // Scale-only size: only float32 scales (b will point to external weight data).
+    static size_t required_size_scale_only(size_t n, size_t k, int k_group_size) {
+      return n * (k / k_group_size) * sizeof(float);
+    }
+
+    void from_raw_mat(const uint8_t* proj, int ith, int nth) {
+      if (b == nullptr) return;  // scale-only mode: b is an external pointer set later
+      auto [n_start, n_end] = split_range_n(n, ith, nth);
+      const size_t row_bytes = (size_t)k / 2;
+      std::memcpy(b + (size_t)n_start * row_bytes, proj + (size_t)n_start * row_bytes,
+                  (size_t)(n_end - n_start) * row_bytes);
+    }
+  };
+
+  struct BufferC {
+    float* data = nullptr;
+    size_t max_m = 0;
+    size_t n = 0;
+
+    BufferC() = default;
+    BufferC(size_t m, size_t n_, void* ptr) : data((float*)ptr), max_m(m), n(n_) {}
+
+    static size_t required_size(size_t m, size_t n) { return m * n * sizeof(float); }
+
+    void set_data(void* ptr) { data = (float*)ptr; }
+
+    void to_mat(int m, ggml_bf16_t* dst, int ith, int nth) {
+      auto [n_start, n_end] = split_range((int)n, ith, nth);
+      for (int mi = 0; mi < m; mi++) {
+        float* src_row = data + (size_t)mi * n;
+        ggml_bf16_t* dst_row = dst + (size_t)mi * n;
+        int j = n_start;
+        for (; j + 8 <= n_end; j += 8) {
+          store_fp32_to_bf16(dst_row + j, _mm256_loadu_ps(src_row + j));
+        }
+        for (; j < n_end; j++) {
+          dst_row[j] = GGML_FP32_TO_BF16(src_row[j]);
+        }
+      }
+    }
+  };
+};
+
+static inline void gemm_rawint4(int m, int n, int k, GemmKernelAVX2RawInt4::BufferA& a,
+                                GemmKernelAVX2RawInt4::BufferB& b, GemmKernelAVX2RawInt4::BufferC& c, int ith,
+                                int nth) {
+  auto [n_start, n_end] = split_range(n, ith, nth);
+  const int group_size = b.k_group_size;
+  const int group_count = b.k_group_count;
+  const size_t row_bytes = (size_t)k / 2;
+
+  for (int ni = n_start; ni < n_end; ni++) {
+    const uint8_t* b_row = b.b + (size_t)ni * row_bytes;
+    const float* b_scales = b.d + (size_t)ni * group_count;
+
+    // Prefetch the head of the next B row while we chew through this one.
+    // Streams the decoupled weight pages for large N without blocking.
+    if (ni + 1 < n_end) {
+      const uint8_t* b_next = b.b + (size_t)(ni + 1) * row_bytes;
+      _mm_prefetch((const char*)b_next, _MM_HINT_T0);
+      _mm_prefetch((const char*)(b_next + 64), _MM_HINT_T0);
+    }
+
+    for (int mi = 0; mi < m; mi++) {
+      const ggml_bf16_t* a_row = a.data + (size_t)mi * a.k;
+
+      // Running vector total: each group folds in via a single FMA with its
+      // scale broadcast, so we only do one horizontal reduction per (mi, ni).
+      __m256 total_acc = _mm256_setzero_ps();
+      float scalar_tail = 0.0f;
+
+      for (int g = 0; g < group_count; g++) {
+        const float scale = b_scales[g];
+        const int k_base = g * group_size;
+
+        __m256 acc1 = _mm256_setzero_ps();
+        __m256 acc2 = _mm256_setzero_ps();
+        __m256 acc3 = _mm256_setzero_ps();
+        __m256 acc4 = _mm256_setzero_ps();
+
+        int ki = 0;
+        for (; ki + 32 <= group_size; ki += 32) {
+          uint32_t p0, p1, p2, p3;
+          std::memcpy(&p0, b_row + (k_base + ki) / 2, sizeof(uint32_t));
+          std::memcpy(&p1, b_row + (k_base + ki + 8) / 2, sizeof(uint32_t));
+          std::memcpy(&p2, b_row + (k_base + ki + 16) / 2, sizeof(uint32_t));
+          std::memcpy(&p3, b_row + (k_base + ki + 24) / 2, sizeof(uint32_t));
+          acc1 = _mm256_fmadd_ps(load_bf16_to_fp32(a_row + k_base + ki), rawint4_dequant_8x4bit_unscaled(p0), acc1);
+          acc2 = _mm256_fmadd_ps(load_bf16_to_fp32(a_row + k_base + ki + 8), rawint4_dequant_8x4bit_unscaled(p1), acc2);
+          acc3 =
+              _mm256_fmadd_ps(load_bf16_to_fp32(a_row + k_base + ki + 16), rawint4_dequant_8x4bit_unscaled(p2), acc3);
+          acc4 =
+              _mm256_fmadd_ps(load_bf16_to_fp32(a_row + k_base + ki + 24), rawint4_dequant_8x4bit_unscaled(p3), acc4);
+        }
+        __m256 g_acc = _mm256_add_ps(_mm256_add_ps(acc1, acc3), _mm256_add_ps(acc2, acc4));
+
+        for (; ki + 8 <= group_size; ki += 8) {
+          uint32_t packed;
+          std::memcpy(&packed, b_row + (k_base + ki) / 2, sizeof(uint32_t));
+          g_acc =
+              _mm256_fmadd_ps(load_bf16_to_fp32(a_row + k_base + ki), rawint4_dequant_8x4bit_unscaled(packed), g_acc);
+        }
+
+        // Fold this group's unscaled accumulator into the running total with
+        // one scale-broadcast FMA — saves (group_count - 1) hsum reductions
+        // compared to reducing per group.
+        total_acc = _mm256_fmadd_ps(g_acc, _mm256_broadcast_ss(&scale), total_acc);
+
+        for (; ki < group_size; ki++) {
+          const uint8_t packed = b_row[(k_base + ki) / 2];
+          const int nibble = ((k_base + ki) & 1) ? (packed >> 4) : (packed & 0x0F);
+          scalar_tail += GGML_BF16_TO_FP32(a_row[k_base + ki]) * (float)(nibble - 8) * scale;
+        }
+      }
+
+      c.data[(size_t)mi * n + ni] = hsum_avx2(total_acc) + scalar_tail;
+    }
+  }
+}
+
+}  // namespace avx2
+
+template <class T = avx2::GemmKernelAVX2RawInt4>
+class AVX2_RAW_INT4_MOE_TP : public AVX2_MOE_BASE<T, AVX2_RAW_INT4_MOE_TP<T>> {
+  using Base = AVX2_MOE_BASE<T, AVX2_RAW_INT4_MOE_TP<T>>;
+  using Base::config_;
+  using Base::down_ba_;
+  using Base::down_bb_;
+  using Base::down_bc_;
+  using Base::gate_bb_;
+  using Base::gate_bc_;
+  using Base::gate_up_ba_;
+  using Base::m_local_num_;
+  using Base::tp_part_idx;
+  using Base::up_bb_;
+  using Base::up_bc_;
+
+ public:
+  using typename Base::input_t;
+  using typename Base::output_t;
+
+  AVX2_RAW_INT4_MOE_TP() = default;
+  AVX2_RAW_INT4_MOE_TP(GeneralMOEConfig config, int tp_part_idx_ = 0) : Base(config, tp_part_idx_) {}
+
+  void derived_init() {
+    if (config_.quant_config.group_size == 0 || config_.quant_config.zero_point) {
+      throw std::runtime_error("RAWINT4 AVX2 MoE only supports KGroup signed INT4 without zero point");
+    }
+    printf("Created AVX2_RAW_INT4_MOE_TP %d at numa %d (group_size=%d)\n", tp_part_idx,
+           numa_node_of_cpu(sched_getcpu()), config_.quant_config.group_size);
+  }
+
+  size_t buffer_a_required_size_impl(size_t m, size_t k) const {
+    return T::BufferA::required_size(m, k, config_.quant_config.group_size);
+  }
+  size_t buffer_b_required_size_impl(size_t n, size_t k) const {
+    // When per-expert source pointers are available, only allocate float32 scales.
+    // Weights will be served directly from the mmap'd safetensor data (no copy).
+    if (!config_.gate_projs.empty()) {
+      return T::BufferB::required_size_scale_only(n, k, config_.quant_config.group_size);
+    }
+    return T::BufferB::required_size(n, k, config_.quant_config.group_size);
+  }
+  size_t buffer_c_required_size_impl(size_t m, size_t n) const { return T::BufferC::required_size(m, n); }
+
+  std::shared_ptr<typename T::BufferA> make_buffer_a_impl(size_t m, size_t k, void* data) const {
+    return std::make_shared<typename T::BufferA>(m, k, config_.quant_config.group_size, data);
+  }
+  std::shared_ptr<typename T::BufferB> make_buffer_b_impl(size_t n, size_t k, void* data) const {
+    // Scale-only mode: b is nullptr here; set externally in load_weights().
+    if (!config_.gate_projs.empty()) {
+      return std::make_shared<typename T::BufferB>((int)n, (int)k, config_.quant_config.group_size, data, nullptr);
+    }
+    return std::make_shared<typename T::BufferB>((int)n, (int)k, config_.quant_config.group_size, data);
+  }
+  std::shared_ptr<typename T::BufferC> make_buffer_c_impl(size_t m, size_t n, void* data) const {
+    return std::make_shared<typename T::BufferC>(m, n, data);
+  }
+
+  void do_gate_up_gemm(bool do_up, int expert_idx, int ith, int nth, int) {
+    int m = m_local_num_[expert_idx];
+    auto& bb = do_up ? up_bb_[expert_idx] : gate_bb_[expert_idx];
+    auto& bc = do_up ? up_bc_[expert_idx] : gate_bc_[expert_idx];
+    avx2::gemm_rawint4(m, config_.intermediate_size, config_.hidden_size, *gate_up_ba_[expert_idx], *bb, *bc, ith, nth);
+  }
+
+  void do_down_gemm(int expert_idx, int ith, int nth, int) {
+    int m = m_local_num_[expert_idx];
+    avx2::gemm_rawint4(m, config_.hidden_size, config_.intermediate_size, *down_ba_[expert_idx], *down_bb_[expert_idx],
+                       *down_bc_[expert_idx], ith, nth);
+  }
+
+  void load_weights() {
+    int group_size = config_.quant_config.group_size;
+    const uint64_t* physical_to_logical_map = (const uint64_t*)config_.physical_to_logical_map;
+    auto pool = config_.pool->get_subpool(tp_part_idx);
+
+    const bool use_per_expert = !config_.gate_projs.empty();
+    if (!use_per_expert && config_.gate_proj == nullptr) {
+      throw std::runtime_error("RAWINT4 AVX2 MoE requires weight pointers");
+    }
+    if (!use_per_expert && config_.gate_scale == nullptr) {
+      throw std::runtime_error("RAWINT4 AVX2 MoE requires scale pointers");
+    }
+
+    if (use_per_expert) {
+      // Direct-pointer mode: BufferB.b is set to point into the mmap'd safetensor data
+      // (no weight copy). Only float32 scales are allocated and converted.
+      //
+      // For gate/up: source shape [intermediate_size_full, hidden_size/2] row-major.
+      //   TP partition tp_part_idx handles rows [tp_part_idx * n_per_tp, (tp_part_idx+1) * n_per_tp).
+      //   These are contiguous in memory → simple byte offset: tp_part_idx * n_per_tp * (k/2).
+      //   With kt_threadpool_count=1 (tp_part_idx=0): offset = 0.
+      //
+      // For down: source shape [hidden_size, intermediate_size_full/2] row-major.
+      //   TP partition tp_part_idx handles columns [tp_part_idx * n_per_tp/2, ...) per row.
+      //   These are NOT contiguous across rows for tp_count > 1.
+      //   This mode therefore requires kt_threadpool_count=1 (enforced in outer TP wrapper).
+      pool->do_work_stealing_job(
+          config_.expert_num, nullptr,
+          [this, physical_to_logical_map](int expert_idx) {
+            if (expert_idx < 0 || expert_idx >= config_.expert_num || gate_bb_[expert_idx] == nullptr ||
+                up_bb_[expert_idx] == nullptr || down_bb_[expert_idx] == nullptr) {
+              return;
+            }
+            uint64_t logical_expert_id = expert_map(physical_to_logical_map, expert_idx);
+            // Gate/Up row offset for this TP partition (bytes).
+            size_t gate_tp_byte_offset = (size_t)tp_part_idx * config_.intermediate_size * config_.hidden_size / 2;
+            gate_bb_[expert_idx]->b = (uint8_t*)config_.gate_projs[0][logical_expert_id] + gate_tp_byte_offset;
+            up_bb_[expert_idx]->b = (uint8_t*)config_.up_projs[0][logical_expert_id] + gate_tp_byte_offset;
+            // Down column offset (bytes per row start). Correct only for tp_count=1.
+            size_t down_tp_byte_offset = (size_t)tp_part_idx * config_.intermediate_size / 2;
+            down_bb_[expert_idx]->b = (uint8_t*)config_.down_projs[0][logical_expert_id] + down_tp_byte_offset;
+          },
+          nullptr);
+
+      // Scale conversion: BF16 → float32.
+      pool->do_work_stealing_job(
+          config_.expert_num, nullptr,
+          [this, physical_to_logical_map, group_size](int task_id) {
+            uint64_t expert_idx = task_id;
+            if (expert_idx >= (uint64_t)config_.expert_num || gate_bb_[expert_idx] == nullptr ||
+                up_bb_[expert_idx] == nullptr || down_bb_[expert_idx] == nullptr) {
+              return;
+            }
+            uint64_t logical_expert_id = expert_map(physical_to_logical_map, expert_idx);
+            size_t scale_elem_count = ((size_t)config_.hidden_size * config_.intermediate_size) / group_size;
+            // Gate/Up scale offset: rows [tp_part_idx * n_per_tp, ...) of scale[n_total, k/gs].
+            size_t gate_scale_tp_offset =
+                (size_t)tp_part_idx * config_.intermediate_size * (config_.hidden_size / group_size);
+            // Down scale offset: cols [tp_part_idx * (n_per_tp/gs), ...) per row. Correct for tp_count=1.
+            size_t down_scale_tp_offset = (size_t)tp_part_idx * (config_.intermediate_size / group_size);
+            convert_or_copy(gate_bb_[expert_idx]->d,
+                            (const ggml_bf16_t*)config_.gate_scales[0][logical_expert_id] + gate_scale_tp_offset,
+                            scale_elem_count);
+            convert_or_copy(up_bb_[expert_idx]->d,
+                            (const ggml_bf16_t*)config_.up_scales[0][logical_expert_id] + gate_scale_tp_offset,
+                            scale_elem_count);
+            convert_or_copy(down_bb_[expert_idx]->d,
+                            (const ggml_bf16_t*)config_.down_scales[0][logical_expert_id] + down_scale_tp_offset,
+                            scale_elem_count);
+          },
+          nullptr);
+    } else {
+      // Flat-buffer mode: copy TP-sliced weights from flat buffer into allocated BufferB.b.
+      int nth = T::recommended_nth(config_.intermediate_size);
+      pool->do_work_stealing_job(
+          nth * config_.expert_num, nullptr,
+          [this, nth, physical_to_logical_map](int task_id) {
+            uint64_t expert_idx = task_id / nth;
+            if (config_.should_skip_expert(expert_idx)) return;
+            uint64_t logical_expert_id = expert_map(physical_to_logical_map, expert_idx);
+            int ith = task_id % nth;
+            size_t weight_offset = ((size_t)logical_expert_id * config_.intermediate_size * config_.hidden_size) / 2;
+            gate_bb_[expert_idx]->from_raw_mat((const uint8_t*)config_.gate_proj + weight_offset, ith, nth);
+            up_bb_[expert_idx]->from_raw_mat((const uint8_t*)config_.up_proj + weight_offset, ith, nth);
+          },
+          nullptr);
+
+      int nth_down = T::recommended_nth(config_.hidden_size);
+      pool->do_work_stealing_job(
+          nth_down * config_.expert_num, nullptr,
+          [this, nth_down, physical_to_logical_map](int task_id) {
+            uint64_t expert_idx = task_id / nth_down;
+            if (config_.should_skip_expert(expert_idx)) return;
+            uint64_t logical_expert_id = expert_map(physical_to_logical_map, expert_idx);
+            int ith = task_id % nth_down;
+            size_t weight_offset = ((size_t)logical_expert_id * config_.hidden_size * config_.intermediate_size) / 2;
+            down_bb_[expert_idx]->from_raw_mat((const uint8_t*)config_.down_proj + weight_offset, ith, nth_down);
+          },
+          nullptr);
+
+      // Scale conversion in flat-buffer mode.
+      pool->do_work_stealing_job(
+          config_.expert_num, nullptr,
+          [this, physical_to_logical_map, group_size](int task_id) {
+            uint64_t expert_idx = task_id;
+            if (config_.should_skip_expert(expert_idx)) return;
+            uint64_t logical_expert_id = expert_map(physical_to_logical_map, expert_idx);
+            size_t scale_elem_count = ((size_t)config_.hidden_size * config_.intermediate_size) / group_size;
+            convert_or_copy(gate_bb_[expert_idx]->d,
+                            (ggml_bf16_t*)config_.gate_scale + logical_expert_id * scale_elem_count, scale_elem_count);
+            convert_or_copy(up_bb_[expert_idx]->d,
+                            (ggml_bf16_t*)config_.up_scale + logical_expert_id * scale_elem_count, scale_elem_count);
+            convert_or_copy(down_bb_[expert_idx]->d,
+                            (ggml_bf16_t*)config_.down_scale + logical_expert_id * scale_elem_count, scale_elem_count);
+          },
+          nullptr);
+    }
+  }
+
+  static inline void fp32_to_bf16(ggml_bf16_t* dst, const float* src, size_t count) {
+    convert_or_copy(dst, src, count);
+  }
+
+  void write_weights_to_buffer(int gpu_tp_count, int cpu_tp_count, int expert_id, const GeneralMOEConfig& full_config,
+                               const std::vector<uintptr_t>& w13_weight_ptrs,
+                               const std::vector<uintptr_t>& w13_scale_ptrs,
+                               const std::vector<uintptr_t>& w2_weight_ptrs,
+                               const std::vector<uintptr_t>& w2_scale_ptrs) const {
+    if (expert_id < 0 || expert_id >= config_.expert_num || gate_bb_[expert_id] == nullptr ||
+        up_bb_[expert_id] == nullptr || down_bb_[expert_id] == nullptr) {
+      throw std::runtime_error("RAWINT4 write_weights_to_buffer requested an expert without loaded weights");
+    }
+    const int group_size = config_.quant_config.group_size;
+    auto pool = config_.pool->get_subpool(tp_part_idx);
+
+    size_t cpu_tp_weight_elem_count = (size_t)config_.intermediate_size * config_.hidden_size;
+    size_t cpu_tp_weight_bytes = cpu_tp_weight_elem_count / 2;
+    size_t cpu_tp_scale_elem_count = cpu_tp_weight_elem_count / group_size;
+    size_t gpu_tp_weight_elem_count = (size_t)full_config.intermediate_size * full_config.hidden_size / gpu_tp_count;
+    size_t gpu_tp_weight_bytes = gpu_tp_weight_elem_count / 2;
+    size_t gpu_tp_scale_elem_count = gpu_tp_weight_elem_count / group_size;
+
+    if (cpu_tp_count >= gpu_tp_count) {
+      int target_gpu_tp = tp_part_idx / (cpu_tp_count / gpu_tp_count);
+      int local_idx = tp_part_idx % (cpu_tp_count / gpu_tp_count);
+      uint8_t* w13_weight_dst = (uint8_t*)w13_weight_ptrs[target_gpu_tp];
+      ggml_bf16_t* w13_scale_dst = (ggml_bf16_t*)w13_scale_ptrs[target_gpu_tp];
+      uint8_t* w2_weight_dst = (uint8_t*)w2_weight_ptrs[target_gpu_tp];
+      ggml_bf16_t* w2_scale_dst = (ggml_bf16_t*)w2_scale_ptrs[target_gpu_tp];
+      size_t offset_in_gpu_weight = local_idx * cpu_tp_weight_bytes;
+      size_t offset_in_gpu_scale = local_idx * cpu_tp_scale_elem_count;
+
+      constexpr int NUM_WEIGHT_TASKS = 8;
+      constexpr int MIN_COLS_PER_TASK = 128;
+      int num_down_tasks = std::min(std::max(1, config_.hidden_size / MIN_COLS_PER_TASK), 32);
+      int total_tasks = NUM_WEIGHT_TASKS * 2 + num_down_tasks + 2;
+      size_t weight_chunk_size = (cpu_tp_weight_bytes + NUM_WEIGHT_TASKS - 1) / NUM_WEIGHT_TASKS;
+      weight_chunk_size = (weight_chunk_size + 63) & ~63ULL;
+
+      pool->do_work_stealing_job(
+          total_tasks, nullptr,
+          [=, this](int task_id) {
+            if (task_id < NUM_WEIGHT_TASKS) {
+              size_t start = (size_t)task_id * weight_chunk_size;
+              size_t end = std::min(start + weight_chunk_size, cpu_tp_weight_bytes);
+              if (start < end)
+                std::memcpy(w13_weight_dst + offset_in_gpu_weight + start, gate_bb_[expert_id]->b + start, end - start);
+            } else if (task_id < NUM_WEIGHT_TASKS * 2) {
+              int chunk_idx = task_id - NUM_WEIGHT_TASKS;
+              size_t start = (size_t)chunk_idx * weight_chunk_size;
+              size_t end = std::min(start + weight_chunk_size, cpu_tp_weight_bytes);
+              if (start < end)
+                std::memcpy(w13_weight_dst + offset_in_gpu_weight + gpu_tp_weight_bytes + start,
+                            up_bb_[expert_id]->b + start, end - start);
+            } else if (task_id < NUM_WEIGHT_TASKS * 2 + num_down_tasks) {
+              int chunk_idx = task_id - NUM_WEIGHT_TASKS * 2;
+              size_t cols_per_chunk = (config_.hidden_size + num_down_tasks - 1) / num_down_tasks;
+              size_t col_start = (size_t)chunk_idx * cols_per_chunk;
+              size_t col_end = std::min(col_start + cols_per_chunk, (size_t)config_.hidden_size);
+              size_t weight_per_col = config_.intermediate_size >> 1;
+              size_t scale_per_col = config_.intermediate_size / group_size;
+              size_t gpu_weight_stride = (full_config.intermediate_size / gpu_tp_count) >> 1;
+              size_t gpu_scale_stride = (full_config.intermediate_size / gpu_tp_count) / group_size;
+              size_t gpu_weight_slice_offset = local_idx * weight_per_col;
+              size_t gpu_scale_slice_offset = local_idx * scale_per_col;
+              for (size_t col = col_start; col < col_end; col++) {
+                std::memcpy(w2_weight_dst + col * gpu_weight_stride + gpu_weight_slice_offset,
+                            down_bb_[expert_id]->b + col * weight_per_col, weight_per_col);
+                fp32_to_bf16(w2_scale_dst + col * gpu_scale_stride + gpu_scale_slice_offset,
+                             down_bb_[expert_id]->d + col * scale_per_col, scale_per_col);
+              }
+            } else if (task_id == NUM_WEIGHT_TASKS * 2 + num_down_tasks) {
+              fp32_to_bf16(w13_scale_dst + offset_in_gpu_scale, gate_bb_[expert_id]->d, cpu_tp_scale_elem_count);
+            } else {
+              fp32_to_bf16(w13_scale_dst + offset_in_gpu_scale + gpu_tp_scale_elem_count, up_bb_[expert_id]->d,
+                           cpu_tp_scale_elem_count);
+            }
+          },
+          nullptr);
+    } else {
+      int gpu_tps_per_cpu_tp = gpu_tp_count / cpu_tp_count;
+      int start_gpu_tp = tp_part_idx * gpu_tps_per_cpu_tp;
+      size_t data_per_gpu_tp_weight = cpu_tp_weight_bytes / gpu_tps_per_cpu_tp;
+      size_t data_per_gpu_tp_scale = cpu_tp_scale_elem_count / gpu_tps_per_cpu_tp;
+      constexpr int NUM_WEIGHT_TASKS = 8;
+      constexpr int MIN_COLS_PER_TASK = 128;
+      int num_down_tasks = std::min(std::max(1, config_.hidden_size / MIN_COLS_PER_TASK), 32);
+      int tasks_per_gpu_tp = NUM_WEIGHT_TASKS * 2 + num_down_tasks + 2;
+      int total_tasks = tasks_per_gpu_tp * gpu_tps_per_cpu_tp;
+      size_t weight_chunk_size = (data_per_gpu_tp_weight + NUM_WEIGHT_TASKS - 1) / NUM_WEIGHT_TASKS;
+      weight_chunk_size = (weight_chunk_size + 63) & ~63ULL;
+
+      pool->do_work_stealing_job(
+          total_tasks, nullptr,
+          [=, this, &w13_weight_ptrs, &w13_scale_ptrs, &w2_weight_ptrs, &w2_scale_ptrs](int task_id) {
+            int local_gpu_idx = task_id / tasks_per_gpu_tp;
+            int task_type = task_id % tasks_per_gpu_tp;
+            int gpu_tp_idx = start_gpu_tp + local_gpu_idx;
+            uint8_t* w13_weight_dst = (uint8_t*)w13_weight_ptrs[gpu_tp_idx];
+            ggml_bf16_t* w13_scale_dst = (ggml_bf16_t*)w13_scale_ptrs[gpu_tp_idx];
+            uint8_t* w2_weight_dst = (uint8_t*)w2_weight_ptrs[gpu_tp_idx];
+            ggml_bf16_t* w2_scale_dst = (ggml_bf16_t*)w2_scale_ptrs[gpu_tp_idx];
+            size_t cpu_offset_weight = (size_t)local_gpu_idx * data_per_gpu_tp_weight;
+            size_t cpu_offset_scale = (size_t)local_gpu_idx * data_per_gpu_tp_scale;
+            if (task_type < NUM_WEIGHT_TASKS) {
+              size_t start = (size_t)task_type * weight_chunk_size;
+              size_t end = std::min(start + weight_chunk_size, data_per_gpu_tp_weight);
+              if (start < end)
+                std::memcpy(w13_weight_dst + start, gate_bb_[expert_id]->b + cpu_offset_weight + start, end - start);
+            } else if (task_type < NUM_WEIGHT_TASKS * 2) {
+              int chunk_idx = task_type - NUM_WEIGHT_TASKS;
+              size_t start = (size_t)chunk_idx * weight_chunk_size;
+              size_t end = std::min(start + weight_chunk_size, data_per_gpu_tp_weight);
+              if (start < end)
+                std::memcpy(w13_weight_dst + gpu_tp_weight_bytes + start,
+                            up_bb_[expert_id]->b + cpu_offset_weight + start, end - start);
+            } else if (task_type < NUM_WEIGHT_TASKS * 2 + num_down_tasks) {
+              int chunk_idx = task_type - NUM_WEIGHT_TASKS * 2;
+              size_t cols_per_chunk = (config_.hidden_size + num_down_tasks - 1) / num_down_tasks;
+              size_t col_start = (size_t)chunk_idx * cols_per_chunk;
+              size_t col_end = std::min(col_start + cols_per_chunk, (size_t)config_.hidden_size);
+              size_t weight_per_gpu_col = (config_.intermediate_size / gpu_tps_per_cpu_tp) >> 1;
+              size_t scale_per_gpu_col = (config_.intermediate_size / gpu_tps_per_cpu_tp) / group_size;
+              for (size_t col = col_start; col < col_end; col++) {
+                size_t col_offset_weight = (col * config_.intermediate_size / 2) +
+                                           (local_gpu_idx * data_per_gpu_tp_weight / config_.hidden_size);
+                size_t col_offset_scale = (col * (config_.intermediate_size / group_size)) +
+                                          (local_gpu_idx * data_per_gpu_tp_scale / config_.hidden_size);
+                std::memcpy(w2_weight_dst + col * weight_per_gpu_col, down_bb_[expert_id]->b + col_offset_weight,
+                            weight_per_gpu_col);
+                fp32_to_bf16(w2_scale_dst + col * scale_per_gpu_col, down_bb_[expert_id]->d + col_offset_scale,
+                             scale_per_gpu_col);
+              }
+            } else if (task_type == NUM_WEIGHT_TASKS * 2 + num_down_tasks) {
+              fp32_to_bf16(w13_scale_dst, gate_bb_[expert_id]->d + cpu_offset_scale, data_per_gpu_tp_scale);
+            } else {
+              fp32_to_bf16(w13_scale_dst + gpu_tp_scale_elem_count, up_bb_[expert_id]->d + cpu_offset_scale,
+                           data_per_gpu_tp_scale);
+            }
+          },
+          nullptr);
+    }
+  }
+};
+
+template <typename K>
+class TP_MOE<AVX2_RAW_INT4_MOE_TP<K>> : public TP_MOE<AVX2_MOE_BASE<K, AVX2_RAW_INT4_MOE_TP<K>>> {
+ public:
+  using Base = TP_MOE<AVX2_MOE_BASE<K, AVX2_RAW_INT4_MOE_TP<K>>>;
+  using Base::Base;
+
+  void load_weights() override {
+    auto& config = this->config;
+    auto& tps = this->tps;
+    auto pool = config.pool;
+    const uint64_t* physical_to_logical_map = (const uint64_t*)config.physical_to_logical_map;
+    bool use_per_expert_ptrs = !config.gate_projs.empty();
+    if (config.gate_projs.empty() && config.gate_scale == nullptr) {
+      throw std::runtime_error("RAWINT4 AVX2 MoE only supports packed INT4 with KGroup scales");
+    }
+
+    if (use_per_expert_ptrs) {
+      // Direct-pointer mode: inner load_weights() sets BufferB.b directly from mmap'd data.
+      // The down projection column-gather required for tp_count > 1 is NOT supported in
+      // this mode; enforce single NUMA pool (kt_threadpool_count=1).
+      if (this->tp_count > 1) {
+        throw std::runtime_error(
+            "RAWINT4 per-expert pointer mode requires kt_threadpool_count=1 "
+            "(down projection TP column-gather is unsupported with direct pointers)");
+      }
+      DO_TPS_LOAD_WEIGHTS(pool);
+    } else {
+      // Flat-buffer mode: build a TP-sliced contiguous buffer per TP partition, then
+      // call inner load_weights() which copies into BufferB.b from the flat buffer.
+      int group_size = config.quant_config.group_size;
+      pool->dispense_backend()->do_numa_job([&, this](int i) {
+        auto& tpc = tps[i]->config_;
+        size_t weight_elem_count = (size_t)tpc.intermediate_size * tpc.hidden_size;
+        size_t scales_elem_count = ((size_t)tpc.hidden_size / group_size) * tpc.intermediate_size;
+        tpc.gate_proj = new uint8_t[(tpc.expert_num * weight_elem_count) / 2];
+        tpc.up_proj = new uint8_t[(tpc.expert_num * weight_elem_count) / 2];
+        tpc.down_proj = new uint8_t[(tpc.expert_num * weight_elem_count) / 2];
+        tpc.gate_scale = new ggml_bf16_t[tpc.expert_num * scales_elem_count];
+        tpc.up_scale = new ggml_bf16_t[tpc.expert_num * scales_elem_count];
+        tpc.down_scale = new ggml_bf16_t[tpc.expert_num * scales_elem_count];
+
+        pool->get_subpool(i)->do_work_stealing_job(
+            tpc.expert_num, nullptr,
+            [&, i](int expert_id_) {
+              size_t expert_id = expert_map(physical_to_logical_map, expert_id_);
+              uint8_t* src_gate = (uint8_t*)config.gate_proj +
+                                  ((expert_id * (size_t)config.intermediate_size * config.hidden_size) >> 1);
+              uint8_t* src_up =
+                  (uint8_t*)config.up_proj + ((expert_id * (size_t)config.intermediate_size * config.hidden_size) >> 1);
+              uint8_t* src_down = (uint8_t*)config.down_proj +
+                                  ((expert_id * (size_t)config.intermediate_size * config.hidden_size) >> 1);
+              ggml_bf16_t* src_gate_scale =
+                  (ggml_bf16_t*)config.gate_scale +
+                  expert_id * ((size_t)config.hidden_size / group_size) * config.intermediate_size;
+              ggml_bf16_t* src_up_scale =
+                  (ggml_bf16_t*)config.up_scale +
+                  expert_id * ((size_t)config.hidden_size / group_size) * config.intermediate_size;
+              ggml_bf16_t* src_down_scale =
+                  (ggml_bf16_t*)config.down_scale +
+                  expert_id * ((size_t)config.intermediate_size / group_size) * config.hidden_size;
+
+              std::memcpy((uint8_t*)tpc.gate_proj + ((expert_id * weight_elem_count) >> 1),
+                          src_gate + ((i * weight_elem_count) >> 1), weight_elem_count >> 1);
+              std::memcpy((uint8_t*)tpc.up_proj + ((expert_id * weight_elem_count) >> 1),
+                          src_up + ((i * weight_elem_count) >> 1), weight_elem_count >> 1);
+              std::memcpy((ggml_bf16_t*)tpc.gate_scale + expert_id * scales_elem_count,
+                          src_gate_scale + i * scales_elem_count, sizeof(ggml_bf16_t) * scales_elem_count);
+              std::memcpy((ggml_bf16_t*)tpc.up_scale + expert_id * scales_elem_count,
+                          src_up_scale + i * scales_elem_count, sizeof(ggml_bf16_t) * scales_elem_count);
+
+              for (size_t col = 0; col < (size_t)config.hidden_size; col++) {
+                std::memcpy(
+                    (uint8_t*)tpc.down_proj + ((expert_id * weight_elem_count + col * tpc.intermediate_size) >> 1),
+                    src_down + ((col * config.intermediate_size + i * tpc.intermediate_size) >> 1),
+                    tpc.intermediate_size >> 1);
+                std::memcpy((ggml_bf16_t*)tpc.down_scale +
+                                (expert_id * scales_elem_count + col * (tpc.intermediate_size / group_size)),
+                            src_down_scale + (col * (config.intermediate_size / group_size) +
+                                              i * (tpc.intermediate_size / group_size)),
+                            sizeof(ggml_bf16_t) * (tpc.intermediate_size / group_size));
+              }
+            },
+            nullptr);
+        printf("AVX2 RAWINT4 TP %d load weight done.\n", i);
+      });
+
+      DO_TPS_LOAD_WEIGHTS(pool);
+
+      pool->dispense_backend()->do_numa_job([&, this](int i) {
+        auto& tpc = tps[i]->config_;
+        delete[] (uint8_t*)tpc.gate_proj;
+        delete[] (uint8_t*)tpc.up_proj;
+        delete[] (uint8_t*)tpc.down_proj;
+        delete[] (ggml_bf16_t*)tpc.gate_scale;
+        delete[] (ggml_bf16_t*)tpc.up_scale;
+        delete[] (ggml_bf16_t*)tpc.down_scale;
+      });
+    }
+
+    this->weights_loaded = true;
+  }
+
+  void write_weight_scale_to_buffer(int gpu_tp_count, int expert_id, const std::vector<uintptr_t>& w13_weight_ptrs,
+                                    const std::vector<uintptr_t>& w13_scale_ptrs,
+                                    const std::vector<uintptr_t>& w2_weight_ptrs,
+                                    const std::vector<uintptr_t>& w2_scale_ptrs) {
+    if (this->weights_loaded == false) throw std::runtime_error("Not Loaded");
+    if ((int)w13_weight_ptrs.size() != gpu_tp_count || (int)w13_scale_ptrs.size() != gpu_tp_count ||
+        (int)w2_weight_ptrs.size() != gpu_tp_count || (int)w2_scale_ptrs.size() != gpu_tp_count) {
+      throw std::runtime_error("Pointer arrays size must match gpu_tp_count");
+    }
+    this->config.pool->dispense_backend()->do_numa_job([&, this](int i) {
+      this->tps[i]->write_weights_to_buffer(gpu_tp_count, this->tp_count, expert_id, this->config, w13_weight_ptrs,
+                                            w13_scale_ptrs, w2_weight_ptrs, w2_scale_ptrs);
+    });
+  }
+};
+
+#endif  // CPUINFER_OPERATOR_AVX2_RAW_INT4_MOE_H

--- a/kt-kernel/operators/avx2/rawint4_avxvnni-moe.hpp
+++ b/kt-kernel/operators/avx2/rawint4_avxvnni-moe.hpp
@@ -1,0 +1,510 @@
+/**
+ * @Description  : AVX-VNNI-256 RAWINT4 MoE operator (Kimi native INT4 layout)
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * This backend consumes the same RAWINT4 source layout as the plain AVX2
+ * backend in rawint4-moe.hpp:
+ *   weights [N, K/2] uint8  (two signed int4 values per byte, value = nibble - 8,
+ *                            low nibble = even k, high nibble = odd k)
+ *   scales  [N, K/group_size] bf16
+ *
+ * To use AVX-VNNI-256 effectively, activations are quantized on the fly to
+ * group-wise int8 (biased to uint8 for dpbusd), and the packed signed int4
+ * weights are unpacked into signed int8 [N, K] once at load time. dpbusd then
+ * does the group-wise inner product, followed by compensation (128 * weight_sum)
+ * and rescale by (a_scale * w_scale).
+ **/
+#ifndef CPUINFER_OPERATOR_AVX2_RAW_INT4_AVXVNNI_MOE_H
+#define CPUINFER_OPERATOR_AVX2_RAW_INT4_AVXVNNI_MOE_H
+
+#include <immintrin.h>
+
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <cstdint>
+#include <cstring>
+#include <limits>
+#include <memory>
+#include <stdexcept>
+
+#include "avx2_bf16_utils.hpp"
+#include "moe_base.hpp"
+
+#if defined(__GNUC__) || defined(__clang__)
+#define KT_AVXVNNI256_RAWINT4_TARGET __attribute__((target("avx2,avxvnni,fma")))
+#else
+#define KT_AVXVNNI256_RAWINT4_TARGET
+#endif
+
+namespace avxvnni_rawint4 {
+
+static constexpr int MAX_SUPPORTED_GROUP_SIZE = 256;
+
+static inline int hsum_epi32_avx2(__m256i v) {
+  __m128i lo = _mm256_castsi256_si128(v);
+  __m128i hi = _mm256_extracti128_si256(v, 1);
+  __m128i sum = _mm_add_epi32(lo, hi);
+  sum = _mm_hadd_epi32(sum, sum);
+  sum = _mm_hadd_epi32(sum, sum);
+  return _mm_cvtsi128_si32(sum);
+}
+
+// Quantize one activation group to biased uint8 for dpbusd.
+// Returns the activation scale. A return value of 0 means the group is all zero.
+static inline float quantize_activation_group_u8(const ggml_bf16_t* src, int group_size, uint8_t* dst) {
+  float absmax = 0.0f;
+
+  for (int i = 0; i < group_size; ++i) {
+    absmax = std::max(absmax, std::fabs(GGML_BF16_TO_FP32(src[i])));
+  }
+
+  if (absmax <= std::numeric_limits<float>::min()) {
+    std::memset(dst, 0x80, (size_t)group_size);
+    return 0.0f;
+  }
+
+  const float scale = absmax / 127.0f;
+  const float inv_scale = 1.0f / scale;
+  for (int i = 0; i < group_size; ++i) {
+    int q = (int)std::lrint(GGML_BF16_TO_FP32(src[i]) * inv_scale);
+    q = std::clamp(q, -127, 127);
+    dst[i] = (uint8_t)(((uint8_t)(int8_t)q) ^ 0x80);
+  }
+  return scale;
+}
+
+struct GemmKernelAVXVNNI256RawInt4 {
+  using dt = ggml_bf16_t;
+  using output_t = float;
+  static constexpr int M_STEP = 1;
+  static constexpr int N_STEP = 8;
+  static constexpr int K_STEP = 8;
+  static constexpr int N_BLOCK = 64;
+  static constexpr int K_BLOCK = 128;
+  static constexpr double ELEMENT_SIZE = 0.5;
+
+  static void config() {}
+
+  static int recommended_nth(int n) { return std::max(1, n / N_BLOCK); }
+
+  static std::pair<int, int> split_range_n(int n, int ith, int nth) { return avx2::split_range(n, ith, nth); }
+
+  struct BufferA {
+    ggml_bf16_t* data = nullptr;
+    size_t max_m = 0;
+    size_t k = 0;
+
+    BufferA() = default;
+    BufferA(size_t m, size_t k_, void* ptr) : data((ggml_bf16_t*)ptr), max_m(m), k(k_) {}
+
+    static size_t required_size(size_t m, size_t k) { return m * k * sizeof(ggml_bf16_t); }
+
+    void set_data(void* ptr) { data = (ggml_bf16_t*)ptr; }
+
+    void from_mat(int m, const ggml_bf16_t* src, int ith, int nth) {
+      if (ith == 0 && nth == 1) {
+        std::memcpy(data, src, (size_t)m * k * sizeof(ggml_bf16_t));
+      } else {
+        auto [m_start, m_end] = avx2::split_range(m, ith, nth);
+        std::memcpy(data + m_start * k, src + m_start * k, (size_t)(m_end - m_start) * k * sizeof(ggml_bf16_t));
+      }
+    }
+  };
+
+  struct BufferB {
+    int8_t* qweight_s8 = nullptr;    // [N, K] unpacked signed int8 weights
+    float* scales = nullptr;         // [N, num_groups] float32 (converted from bf16)
+    int16_t* weight_sums = nullptr;  // [N, num_groups] per-group sum of unpacked int8 weights
+    int n = 0;
+    int k = 0;
+    int group_size = 128;
+    int num_groups = 0;
+
+    BufferB() = default;
+    BufferB(size_t n_, size_t k_, int gs, void* ptr) : n((int)n_), k((int)k_), group_size(gs) {
+      if (group_size <= 0 || (group_size % 32) != 0) {
+        throw std::runtime_error("AVX-VNNI RAWINT4 requires group_size to be a positive multiple of 32");
+      }
+      if (group_size > MAX_SUPPORTED_GROUP_SIZE) {
+        throw std::runtime_error("AVX-VNNI RAWINT4 requires group_size <= 256");
+      }
+      if ((k % 8) != 0 || (k % group_size) != 0) {
+        throw std::runtime_error("AVX-VNNI RAWINT4 requires k to be divisible by both 8 and group_size");
+      }
+      num_groups = k / group_size;
+      qweight_s8 = (int8_t*)ptr;
+      scales = (float*)((uint8_t*)ptr + (size_t)k * n * sizeof(int8_t));
+      weight_sums = (int16_t*)((uint8_t*)scales + (size_t)num_groups * n * sizeof(float));
+    }
+
+    static size_t required_size(size_t n, size_t k, int gs) {
+      const size_t num_groups = k / gs;
+      return k * n * sizeof(int8_t) + num_groups * n * sizeof(float) + num_groups * n * sizeof(int16_t);
+    }
+
+    // Unpack packed RAWINT4 weights [n_len, k/2] (row-major, low nibble = even k) into
+    // signed int8 [n_len, k], convert bf16 scales [n_len, num_groups] to float32,
+    // and compute int16 weight_sums [n_len, num_groups].
+    void from_raw_mat(const uint8_t* src_packed, const ggml_bf16_t* src_scales, int ith, int nth) {
+      auto [n_start, n_end] = avx2::split_range(n, ith, nth);
+      const size_t row_bytes = (size_t)k / 2;
+
+      for (int ni = n_start; ni < n_end; ++ni) {
+        const uint8_t* src_row = src_packed + (size_t)ni * row_bytes;
+        int8_t* dst_col = qweight_s8 + (size_t)ni * k;
+        const ggml_bf16_t* src_sc_row = src_scales + (size_t)ni * num_groups;
+        float* dst_sc_row = scales + (size_t)ni * num_groups;
+        int16_t* dst_ws_row = weight_sums + (size_t)ni * num_groups;
+
+        for (int g = 0; g < num_groups; ++g) {
+          const int k_base = g * group_size;
+          int sum = 0;
+          for (int kk = 0; kk < group_size; kk += 2) {
+            const uint8_t packed = src_row[(k_base + kk) / 2];
+            const int8_t v0 = (int8_t)((packed & 0x0F) - 8);         // even k
+            const int8_t v1 = (int8_t)(((packed >> 4) & 0x0F) - 8);  // odd k
+            dst_col[k_base + kk] = v0;
+            dst_col[k_base + kk + 1] = v1;
+            sum += v0 + v1;
+          }
+          dst_ws_row[g] = (int16_t)sum;
+          dst_sc_row[g] = GGML_BF16_TO_FP32(src_sc_row[g]);
+        }
+      }
+    }
+  };
+
+  struct BufferC {
+    float* data = nullptr;
+    size_t max_m = 0;
+    size_t n = 0;
+
+    BufferC() = default;
+    BufferC(size_t m, size_t n_, void* ptr) : data((float*)ptr), max_m(m), n(n_) {}
+
+    static size_t required_size(size_t m, size_t n) { return m * n * sizeof(float); }
+
+    void set_data(void* ptr) { data = (float*)ptr; }
+
+    void to_mat(int m, ggml_bf16_t* dst, int ith, int nth) {
+      auto [n_start, n_end] = avx2::split_range((int)n, ith, nth);
+      for (int mi = 0; mi < m; ++mi) {
+        float* src_row = data + mi * n;
+        ggml_bf16_t* dst_row = dst + mi * n;
+        int j = n_start;
+        for (; j + 8 <= n_end; j += 8) {
+          avx2::store_fp32_to_bf16(dst_row + j, _mm256_loadu_ps(src_row + j));
+        }
+        for (; j < n_end; ++j) {
+          dst_row[j] = GGML_FP32_TO_BF16(src_row[j]);
+        }
+      }
+    }
+  };
+};
+
+KT_AVXVNNI256_RAWINT4_TARGET
+static inline void gemm_rawint4_avxvnni256(int m, int n, int k, GemmKernelAVXVNNI256RawInt4::BufferA& a,
+                                           GemmKernelAVXVNNI256RawInt4::BufferB& b,
+                                           GemmKernelAVXVNNI256RawInt4::BufferC& c, int ith, int nth) {
+  (void)k;
+  auto [n_start, n_end] = avx2::split_range(n, ith, nth);
+  const int group_size = b.group_size;
+  const int num_groups = b.num_groups;
+
+  alignas(32) std::array<uint8_t, MAX_SUPPORTED_GROUP_SIZE> a_u8{};
+
+  for (int mi = 0; mi < m; ++mi) {
+    const ggml_bf16_t* a_row = a.data + (size_t)mi * a.k;
+    float* c_row = c.data + (size_t)mi * n;
+    std::fill(c_row + n_start, c_row + n_end, 0.0f);
+
+    for (int g = 0; g < num_groups; ++g) {
+      const int k_base = g * group_size;
+      const float a_scale = quantize_activation_group_u8(a_row + k_base, group_size, a_u8.data());
+      if (a_scale == 0.0f) {
+        continue;
+      }
+
+      for (int ni = n_start; ni < n_end; ++ni) {
+        __m256i acc = _mm256_setzero_si256();
+        const int8_t* w_col = b.qweight_s8 + (size_t)ni * b.k + k_base;
+        for (int kk = 0; kk < group_size; kk += 32) {
+          const __m256i a_vec = _mm256_load_si256((const __m256i*)(a_u8.data() + kk));
+          const __m256i w_vec = _mm256_loadu_si256((const __m256i*)(w_col + kk));
+          acc = _mm256_dpbusd_avx_epi32(acc, a_vec, w_vec);
+        }
+
+        const int dot = hsum_epi32_avx2(acc) - 128 * (int)b.weight_sums[(size_t)ni * num_groups + g];
+        c_row[ni] += (float)dot * a_scale * b.scales[(size_t)ni * num_groups + g];
+      }
+    }
+  }
+}
+
+}  // namespace avxvnni_rawint4
+
+template <class T = avxvnni_rawint4::GemmKernelAVXVNNI256RawInt4>
+class AVXVNNI256_RAW_INT4_MOE_TP : public AVX2_MOE_BASE<T, AVXVNNI256_RAW_INT4_MOE_TP<T>> {
+  using Base = AVX2_MOE_BASE<T, AVXVNNI256_RAW_INT4_MOE_TP<T>>;
+  using Base::config_;
+  using Base::down_ba_;
+  using Base::down_bb_;
+  using Base::down_bc_;
+  using Base::gate_bb_;
+  using Base::gate_bc_;
+  using Base::gate_up_ba_;
+  using Base::m_local_num_;
+  using Base::tp_part_idx;
+  using Base::up_bb_;
+  using Base::up_bc_;
+
+ public:
+  using typename Base::input_t;
+  using typename Base::output_t;
+
+  AVXVNNI256_RAW_INT4_MOE_TP() = default;
+  AVXVNNI256_RAW_INT4_MOE_TP(GeneralMOEConfig config, int tp_part_idx_ = 0) : Base(config, tp_part_idx_) {}
+
+  void derived_init() {
+#if defined(__GNUC__) || defined(__clang__)
+    if (!__builtin_cpu_supports("avxvnni")) {
+      throw std::runtime_error("AVX-VNNI-256 RAWINT4 backend requires CPU support for avx_vnni");
+    }
+#endif
+    auto& qc = config_.quant_config;
+    if (qc.group_size == 0 || (qc.group_size % 32) != 0) {
+      throw std::runtime_error("AVX-VNNI-256 RAWINT4 requires group_size to be a positive multiple of 32");
+    }
+    if (qc.group_size > avxvnni_rawint4::MAX_SUPPORTED_GROUP_SIZE) {
+      throw std::runtime_error("AVX-VNNI-256 RAWINT4 requires group_size <= 256");
+    }
+    if (qc.zero_point) {
+      throw std::runtime_error("AVX-VNNI-256 RAWINT4 only supports signed INT4 without zero point");
+    }
+    printf("Created AVXVNNI256_RAW_INT4_MOE_TP %d at numa %d (group_size=%d)\n", tp_part_idx,
+           numa_node_of_cpu(sched_getcpu()), qc.group_size);
+  }
+
+  ~AVXVNNI256_RAW_INT4_MOE_TP() = default;
+
+  size_t buffer_a_required_size_impl(size_t m, size_t k) const { return T::BufferA::required_size(m, k); }
+  size_t buffer_b_required_size_impl(size_t n, size_t k) const {
+    return T::BufferB::required_size(n, k, config_.quant_config.group_size);
+  }
+  size_t buffer_c_required_size_impl(size_t m, size_t n) const { return T::BufferC::required_size(m, n); }
+
+  std::shared_ptr<typename T::BufferA> make_buffer_a_impl(size_t m, size_t k, void* data) const {
+    return std::make_shared<typename T::BufferA>(m, k, data);
+  }
+  std::shared_ptr<typename T::BufferB> make_buffer_b_impl(size_t n, size_t k, void* data) const {
+    return std::make_shared<typename T::BufferB>(n, k, config_.quant_config.group_size, data);
+  }
+  std::shared_ptr<typename T::BufferC> make_buffer_c_impl(size_t m, size_t n, void* data) const {
+    return std::make_shared<typename T::BufferC>(m, n, data);
+  }
+
+  void do_gate_up_gemm(bool do_up, int expert_idx, int ith, int nth, int qlen) {
+    (void)qlen;
+    int m = m_local_num_[expert_idx];
+    auto& ba = gate_up_ba_[expert_idx];
+    auto& bb = do_up ? up_bb_[expert_idx] : gate_bb_[expert_idx];
+    auto& bc = do_up ? up_bc_[expert_idx] : gate_bc_[expert_idx];
+    avxvnni_rawint4::gemm_rawint4_avxvnni256(m, config_.intermediate_size, config_.hidden_size, *ba, *bb, *bc, ith,
+                                             nth);
+  }
+
+  void do_down_gemm(int expert_idx, int ith, int nth, int qlen) {
+    (void)qlen;
+    int m = m_local_num_[expert_idx];
+    avxvnni_rawint4::gemm_rawint4_avxvnni256(m, config_.hidden_size, config_.intermediate_size, *down_ba_[expert_idx],
+                                             *down_bb_[expert_idx], *down_bc_[expert_idx], ith, nth);
+  }
+
+  void load_weights() {
+    int group_size = config_.quant_config.group_size;
+    const uint64_t* physical_to_logical_map = (const uint64_t*)config_.physical_to_logical_map;
+    auto pool = config_.pool->get_subpool(tp_part_idx);
+
+    if (config_.gate_proj == nullptr || config_.gate_scale == nullptr) {
+      throw std::runtime_error("AVX-VNNI RAWINT4 MoE requires flat packed weight and bf16 scale pointers");
+    }
+
+    // Gate/Up: source per expert is packed int4 [N_tp, K/2] uint8 + bf16 scales [N_tp, K/gs].
+    {
+      int nth = T::recommended_nth(config_.intermediate_size);
+      pool->do_work_stealing_job(
+          nth * config_.expert_num, nullptr,
+          [this, nth, physical_to_logical_map, group_size](int task_id) {
+            uint64_t expert_idx = task_id / nth;
+            if (config_.should_skip_expert(expert_idx)) return;
+            uint64_t logical = expert_map(physical_to_logical_map, expert_idx);
+            int ith = task_id % nth;
+
+            const size_t weight_bytes_per_expert = ((size_t)config_.intermediate_size * config_.hidden_size) / 2;
+            const size_t scale_elems_per_expert =
+                (size_t)config_.intermediate_size * (config_.hidden_size / group_size);
+
+            const uint8_t* gate_src = (const uint8_t*)config_.gate_proj + logical * weight_bytes_per_expert;
+            const uint8_t* up_src = (const uint8_t*)config_.up_proj + logical * weight_bytes_per_expert;
+            const ggml_bf16_t* gate_sc_src = (const ggml_bf16_t*)config_.gate_scale + logical * scale_elems_per_expert;
+            const ggml_bf16_t* up_sc_src = (const ggml_bf16_t*)config_.up_scale + logical * scale_elems_per_expert;
+
+            gate_bb_[expert_idx]->from_raw_mat(gate_src, gate_sc_src, ith, nth);
+            up_bb_[expert_idx]->from_raw_mat(up_src, up_sc_src, ith, nth);
+          },
+          nullptr);
+    }
+
+    // Down: source per expert is packed int4 [hidden_size, intermediate_size_tp/2] uint8
+    //       + bf16 scales [hidden_size, intermediate_size_tp/gs].
+    {
+      int nth = T::recommended_nth(config_.hidden_size);
+      pool->do_work_stealing_job(
+          nth * config_.expert_num, nullptr,
+          [this, nth, physical_to_logical_map, group_size](int task_id) {
+            uint64_t expert_idx = task_id / nth;
+            if (config_.should_skip_expert(expert_idx)) return;
+            uint64_t logical = expert_map(physical_to_logical_map, expert_idx);
+            int ith = task_id % nth;
+
+            const size_t weight_bytes_per_expert = ((size_t)config_.hidden_size * config_.intermediate_size) / 2;
+            const size_t scale_elems_per_expert =
+                (size_t)config_.hidden_size * (config_.intermediate_size / group_size);
+
+            const uint8_t* down_src = (const uint8_t*)config_.down_proj + logical * weight_bytes_per_expert;
+            const ggml_bf16_t* down_sc_src = (const ggml_bf16_t*)config_.down_scale + logical * scale_elems_per_expert;
+
+            down_bb_[expert_idx]->from_raw_mat(down_src, down_sc_src, ith, nth);
+          },
+          nullptr);
+    }
+  }
+
+  void write_weights_to_buffer(int gpu_tp_count, [[maybe_unused]] int cpu_tp_count, int expert_id,
+                               const GeneralMOEConfig& full_config, const std::vector<uintptr_t>& w13_weight_ptrs,
+                               [[maybe_unused]] const std::vector<uintptr_t>& w13_scale_ptrs,
+                               const std::vector<uintptr_t>& w2_weight_ptrs,
+                               [[maybe_unused]] const std::vector<uintptr_t>& w2_scale_ptrs) const {
+    (void)gpu_tp_count;
+    (void)expert_id;
+    (void)full_config;
+    (void)w13_weight_ptrs;
+    (void)w2_weight_ptrs;
+    throw std::runtime_error("AVX-VNNI-256 RAWINT4 write_weights_to_buffer not yet implemented");
+  }
+};
+
+template <typename K>
+class TP_MOE<AVXVNNI256_RAW_INT4_MOE_TP<K>> : public TP_MOE<AVX2_MOE_BASE<K, AVXVNNI256_RAW_INT4_MOE_TP<K>>> {
+ public:
+  using Base = TP_MOE<AVX2_MOE_BASE<K, AVXVNNI256_RAW_INT4_MOE_TP<K>>>;
+  using Base::Base;
+
+  void load_weights() override {
+    auto& config = this->config;
+    auto& tps = this->tps;
+    auto pool = config.pool;
+    const uint64_t* physical_to_logical_map = (const uint64_t*)config.physical_to_logical_map;
+
+    if (config.gate_proj == nullptr || config.gate_scale == nullptr) {
+      throw std::runtime_error("AVX-VNNI RAWINT4 MoE only supports flat packed INT4 with KGroup bf16 scales");
+    }
+
+    const int group_size = config.quant_config.group_size;
+    if (group_size == 0) {
+      throw std::runtime_error("AVX-VNNI RAWINT4 requires group_size > 0");
+    }
+
+    // Build TP-sliced flat buffers per NUMA partition (source layout mirrors rawint4-moe.hpp).
+    pool->dispense_backend()->do_numa_job([&, this](int i) {
+      auto& tpc = tps[i]->config_;
+      size_t weight_elem_count = (size_t)tpc.intermediate_size * tpc.hidden_size;
+      size_t scales_elem_count = ((size_t)tpc.hidden_size / group_size) * tpc.intermediate_size;
+      tpc.gate_proj = new uint8_t[(tpc.expert_num * weight_elem_count) / 2];
+      tpc.up_proj = new uint8_t[(tpc.expert_num * weight_elem_count) / 2];
+      tpc.down_proj = new uint8_t[(tpc.expert_num * weight_elem_count) / 2];
+      tpc.gate_scale = new ggml_bf16_t[tpc.expert_num * scales_elem_count];
+      tpc.up_scale = new ggml_bf16_t[tpc.expert_num * scales_elem_count];
+      tpc.down_scale = new ggml_bf16_t[tpc.expert_num * scales_elem_count];
+
+      pool->get_subpool(i)->do_work_stealing_job(
+          tpc.expert_num, nullptr,
+          [&, i](int expert_id_) {
+            size_t expert_id = expert_map(physical_to_logical_map, expert_id_);
+            uint8_t* src_gate =
+                (uint8_t*)config.gate_proj + ((expert_id * (size_t)config.intermediate_size * config.hidden_size) >> 1);
+            uint8_t* src_up =
+                (uint8_t*)config.up_proj + ((expert_id * (size_t)config.intermediate_size * config.hidden_size) >> 1);
+            uint8_t* src_down =
+                (uint8_t*)config.down_proj + ((expert_id * (size_t)config.intermediate_size * config.hidden_size) >> 1);
+            ggml_bf16_t* src_gate_scale =
+                (ggml_bf16_t*)config.gate_scale +
+                expert_id * ((size_t)config.hidden_size / group_size) * config.intermediate_size;
+            ggml_bf16_t* src_up_scale = (ggml_bf16_t*)config.up_scale + expert_id *
+                                                                            ((size_t)config.hidden_size / group_size) *
+                                                                            config.intermediate_size;
+            ggml_bf16_t* src_down_scale =
+                (ggml_bf16_t*)config.down_scale +
+                expert_id * ((size_t)config.intermediate_size / group_size) * config.hidden_size;
+
+            // Gate/Up: contiguous slice along N (intermediate).
+            std::memcpy((uint8_t*)tpc.gate_proj + ((expert_id * weight_elem_count) >> 1),
+                        src_gate + ((i * weight_elem_count) >> 1), weight_elem_count >> 1);
+            std::memcpy((uint8_t*)tpc.up_proj + ((expert_id * weight_elem_count) >> 1),
+                        src_up + ((i * weight_elem_count) >> 1), weight_elem_count >> 1);
+            std::memcpy((ggml_bf16_t*)tpc.gate_scale + expert_id * scales_elem_count,
+                        src_gate_scale + i * scales_elem_count, sizeof(ggml_bf16_t) * scales_elem_count);
+            std::memcpy((ggml_bf16_t*)tpc.up_scale + expert_id * scales_elem_count,
+                        src_up_scale + i * scales_elem_count, sizeof(ggml_bf16_t) * scales_elem_count);
+
+            // Down: column-gather across N (hidden) rows for the TP-sliced K (intermediate).
+            for (size_t col = 0; col < (size_t)config.hidden_size; col++) {
+              std::memcpy(
+                  (uint8_t*)tpc.down_proj + ((expert_id * weight_elem_count + col * tpc.intermediate_size) >> 1),
+                  src_down + ((col * config.intermediate_size + i * tpc.intermediate_size) >> 1),
+                  tpc.intermediate_size >> 1);
+              std::memcpy((ggml_bf16_t*)tpc.down_scale +
+                              (expert_id * scales_elem_count + col * (tpc.intermediate_size / group_size)),
+                          src_down_scale + (col * (config.intermediate_size / group_size) +
+                                            i * (tpc.intermediate_size / group_size)),
+                          sizeof(ggml_bf16_t) * (tpc.intermediate_size / group_size));
+            }
+          },
+          nullptr);
+      printf("AVX-VNNI-256 RAWINT4 TP %d load weight done.\n", i);
+    });
+
+    DO_TPS_LOAD_WEIGHTS(pool);
+
+    pool->dispense_backend()->do_numa_job([&, this](int i) {
+      auto& tpc = tps[i]->config_;
+      delete[] (uint8_t*)tpc.gate_proj;
+      delete[] (uint8_t*)tpc.up_proj;
+      delete[] (uint8_t*)tpc.down_proj;
+      delete[] (ggml_bf16_t*)tpc.gate_scale;
+      delete[] (ggml_bf16_t*)tpc.up_scale;
+      delete[] (ggml_bf16_t*)tpc.down_scale;
+    });
+
+    this->weights_loaded = true;
+  }
+
+  void write_weight_scale_to_buffer(int gpu_tp_count, int expert_id, const std::vector<uintptr_t>& w13_weight_ptrs,
+                                    const std::vector<uintptr_t>& w13_scale_ptrs,
+                                    const std::vector<uintptr_t>& w2_weight_ptrs,
+                                    const std::vector<uintptr_t>& w2_scale_ptrs) {
+    (void)gpu_tp_count;
+    (void)expert_id;
+    (void)w13_weight_ptrs;
+    (void)w13_scale_ptrs;
+    (void)w2_weight_ptrs;
+    (void)w2_scale_ptrs;
+    throw std::runtime_error("AVX-VNNI-256 RAWINT4 write_weight_scale_to_buffer not yet implemented");
+  }
+};
+
+#undef KT_AVXVNNI256_RAWINT4_TARGET
+
+#endif  // CPUINFER_OPERATOR_AVX2_RAW_INT4_AVXVNNI_MOE_H

--- a/kt-kernel/python/utils/amx.py
+++ b/kt-kernel/python/utils/amx.py
@@ -24,7 +24,9 @@ AMXFP8PerChannel_MOE = getattr(_moe_mod, "AMXFP8PerChannel_MOE", None)
 AVX2BF16_MOE = getattr(_moe_mod, "AVX2BF16_MOE", None)
 AVX2FP8_MOE = getattr(_moe_mod, "AVX2FP8_MOE", None)
 AVX2GPTQInt4_MOE = getattr(_moe_mod, "AVX2GPTQInt4_MOE", None)
+AVX2RawInt4_MOE = getattr(_moe_mod, "AVX2RawInt4_MOE", None)
 AVXVNNI256GPTQInt4_MOE = getattr(_moe_mod, "AVXVNNI256GPTQInt4_MOE", None)
+AVXVNNI256RawInt4_MOE = getattr(_moe_mod, "AVXVNNI256RawInt4_MOE", None)
 
 _HAS_AMXINT4_SUPPORT = AMXInt4_MOE is not None
 _HAS_AMXINT8_SUPPORT = AMXInt8_MOE is not None
@@ -35,8 +37,11 @@ _HAS_FP8_PERCHANNEL_SUPPORT = AMXFP8PerChannel_MOE is not None
 _HAS_AVX2_BF16_SUPPORT = AVX2BF16_MOE is not None
 _HAS_AVX2_FP8_SUPPORT = AVX2FP8_MOE is not None
 _HAS_AVX2_GPTQ_INT4_SUPPORT = AVX2GPTQInt4_MOE is not None
+_HAS_AVX2_RAWINT4_SUPPORT = AVX2RawInt4_MOE is not None
 _HAS_AVXVNNI256_GPTQ_INT4_SUPPORT = AVXVNNI256GPTQInt4_MOE is not None
+_HAS_AVXVNNI256_RAW_INT4_SUPPORT = AVXVNNI256RawInt4_MOE is not None
 _AVXVNNI256_GPTQ_INT4_MAX_GROUP_SIZE = 256
+_AVXVNNI256_RAW_INT4_MAX_GROUP_SIZE = 256
 
 
 def _host_has_cpu_flag(*flag_names: str) -> bool:
@@ -58,6 +63,12 @@ def _supports_avxvnni256_gptq_int4_group_size(group_size: Optional[int]) -> bool
     if group_size is None:
         return True
     return group_size > 0 and group_size % 32 == 0 and group_size <= _AVXVNNI256_GPTQ_INT4_MAX_GROUP_SIZE
+
+
+def _supports_avxvnni256_rawint4_group_size(group_size: Optional[int]) -> bool:
+    if group_size is None:
+        return True
+    return group_size > 0 and group_size % 32 == 0 and group_size <= _AVXVNNI256_RAW_INT4_MAX_GROUP_SIZE
 
 
 def _select_gptq_int4_backend(group_size: Optional[int] = None):
@@ -86,6 +97,42 @@ def _select_gptq_int4_backend(group_size: Optional[int] = None):
         return AVXVNNI256GPTQInt4_MOE
     if _HAS_AVX2_GPTQ_INT4_SUPPORT:
         return AVX2GPTQInt4_MOE
+    return None
+
+
+def _select_rawint4_backend(group_size: Optional[int] = None):
+    forced = os.getenv("KT_RAWINT4_BACKEND", "").strip().lower()
+    avxvnni_group_supported = _supports_avxvnni256_rawint4_group_size(group_size)
+
+    if forced == "amx":
+        if not _HAS_RAWINT4_SUPPORT:
+            raise RuntimeError("KT_RAWINT4_BACKEND=amx requested, but AMXInt4_KGroup_MOE is not compiled in.")
+        return AMXInt4_KGroup_MOE
+
+    if forced in {"avxvnni", "avxvnni256"}:
+        if not _HAS_AVXVNNI256_RAW_INT4_SUPPORT:
+            raise RuntimeError("KT_RAWINT4_BACKEND=avxvnni requested, but AVXVNNI256RawInt4_MOE is not compiled in.")
+        if not _HOST_HAS_AVX_VNNI:
+            raise RuntimeError("KT_RAWINT4_BACKEND=avxvnni requested, but the current CPU does not support avx_vnni.")
+        if not avxvnni_group_supported:
+            raise RuntimeError(
+                "KT_RAWINT4_BACKEND=avxvnni requested, but "
+                f"group_size={group_size} is unsupported. AVX-VNNI-256 RAWINT4 only supports "
+                f"positive multiples of 32 up to {_AVXVNNI256_RAW_INT4_MAX_GROUP_SIZE}."
+            )
+        return AVXVNNI256RawInt4_MOE
+
+    if forced == "avx2":
+        if not _HAS_AVX2_RAWINT4_SUPPORT:
+            raise RuntimeError("KT_RAWINT4_BACKEND=avx2 requested, but AVX2RawInt4_MOE is not compiled in.")
+        return AVX2RawInt4_MOE
+
+    if _HAS_RAWINT4_SUPPORT:
+        return AMXInt4_KGroup_MOE
+    if _HAS_AVXVNNI256_RAW_INT4_SUPPORT and _HOST_HAS_AVX_VNNI and avxvnni_group_supported:
+        return AVXVNNI256RawInt4_MOE
+    if _HAS_AVX2_RAWINT4_SUPPORT:
+        return AVX2RawInt4_MOE
     return None
 
 
@@ -412,11 +459,15 @@ class NativeMoEWrapper(BaseMoEWrapper):
         method: str = "RAWINT4",
         numa_nodes: Optional[List[int]] = None,
     ):
-        if method == "RAWINT4" and not _HAS_RAWINT4_SUPPORT:
+        if method == "RAWINT4" and not (
+            _HAS_RAWINT4_SUPPORT or _HAS_AVX2_RAWINT4_SUPPORT or _HAS_AVXVNNI256_RAW_INT4_SUPPORT
+        ):
             raise RuntimeError(
                 "RAWINT4 backend not available. Required ISA:\n"
-                "  - AVX512F + AVX512BW (VNNI optional)\n"
-                "Please recompile kt_kernel_ext with AVX512 enabled."
+                "  - AVX512F + AVX512BW (for AMX backend), or\n"
+                "  - AVX2 + FMA (for AVX2 fallback backend)\n"
+                "AVX-VNNI-256 will be selected automatically when available on the current CPU.\n"
+                "Please recompile kt_kernel_ext with AVX512 or AVX2 enabled."
             )
         if method == "FP8" and not _HAS_FP8_SUPPORT and not _HAS_AVX2_FP8_SUPPORT:
             raise RuntimeError(
@@ -589,7 +640,15 @@ class NativeMoEWrapper(BaseMoEWrapper):
             moe_config.quant_config.bits = 4
             moe_config.quant_config.group_size = group_size
             moe_config.quant_config.zero_point = False
-            self.moe = AMXInt4_KGroup_MOE(moe_config)
+            backend_cls = _select_rawint4_backend(group_size)
+            if backend_cls is None:
+                raise RuntimeError(
+                    "No RAWINT4 backend is available after runtime selection for "
+                    f"group_size={group_size}. AMX (AMXInt4_KGroup_MOE) is preferred; "
+                    f"AVX-VNNI-256 supports positive multiples of 32 up to "
+                    f"{_AVXVNNI256_RAW_INT4_MAX_GROUP_SIZE}; AVX2 (AVX2RawInt4_MOE) is used as the final fallback."
+                )
+            self.moe = backend_cls(moe_config)
         elif self.method == "FP8":
             moe_config.quant_config.bits = 8
             moe_config.quant_config.group_size = 128

--- a/kt-kernel/test/per_commit/test_moe_rawint4_accuracy.py
+++ b/kt-kernel/test/per_commit/test_moe_rawint4_accuracy.py
@@ -1,0 +1,317 @@
+#!/usr/bin/env python
+# coding=utf-8
+"""RAWINT4 MoE accuracy tests for KT-Kernel x86 backends."""
+
+import importlib.util
+import os
+import sys
+import types
+from pathlib import Path
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+from ci.ci_register import register_cpu_ci
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "python"))
+
+register_cpu_ci(est_time=120, suite="default")
+
+import pytest
+import torch
+import kt_kernel_ext
+
+KT_KERNEL_ROOT = Path(__file__).resolve().parents[2]
+
+expert_num = 8
+hidden_size = 256
+intermediate_size = 512
+num_experts_per_tok = 2
+max_len = 128
+group_size = 128
+validation_iter = 3
+CPUINFER_PARAM = 16
+
+
+def load_amx_utils():
+    pkg_root = KT_KERNEL_ROOT / "python"
+    utils_root = pkg_root / "utils"
+
+    if "kt_kernel" not in sys.modules:
+        kt_kernel_pkg = types.ModuleType("kt_kernel")
+        kt_kernel_pkg.__path__ = [str(pkg_root)]
+        kt_kernel_pkg.kt_kernel_ext = kt_kernel_ext
+        sys.modules["kt_kernel"] = kt_kernel_pkg
+
+    if "kt_kernel_ext" not in sys.modules:
+        sys.modules["kt_kernel_ext"] = kt_kernel_ext
+
+    if "kt_kernel.utils" not in sys.modules:
+        utils_pkg = types.ModuleType("kt_kernel.utils")
+        utils_pkg.__path__ = [str(utils_root)]
+        sys.modules["kt_kernel.utils"] = utils_pkg
+
+    module_specs = [
+        ("kt_kernel.experts_base", pkg_root / "experts_base.py"),
+        ("kt_kernel.utils.loader", utils_root / "loader.py"),
+        ("kt_kernel.utils.amx", utils_root / "amx.py"),
+    ]
+    for module_name, module_path in module_specs:
+        if module_name in sys.modules:
+            continue
+        spec = importlib.util.spec_from_file_location(module_name, module_path)
+        module = importlib.util.module_from_spec(spec)
+        sys.modules[module_name] = module
+        assert spec.loader is not None
+        spec.loader.exec_module(module)
+
+    return sys.modules["kt_kernel.utils.amx"]
+
+
+def rawint4_quantize(weight_bf16):
+    """Quantize [N, K] BF16 weight to RAWINT4 layout."""
+    n, k = weight_bf16.shape
+    assert k % 2 == 0
+    assert k % group_size == 0
+
+    weight_fp32 = weight_bf16.float()
+    qweight = torch.zeros((n, k // 2), dtype=torch.uint8)
+    scales = torch.zeros((n, k // group_size), dtype=torch.bfloat16)
+
+    for ni in range(n):
+        for g in range(k // group_size):
+            k_start = g * group_size
+            k_end = k_start + group_size
+            block = weight_fp32[ni, k_start:k_end]
+            amax = block.abs().max().item()
+            scale = amax / 7.0 if amax > 0 else 1.0
+            scales[ni, g] = scale
+
+            for kk in range(k_start, k_end, 2):
+                q0 = int(round(weight_fp32[ni, kk].item() / scale)) + 8
+                q1 = int(round(weight_fp32[ni, kk + 1].item() / scale)) + 8
+                q0 = max(0, min(15, q0))
+                q1 = max(0, min(15, q1))
+                qweight[ni, kk // 2] = (q1 << 4) | q0
+
+    return qweight, scales
+
+
+def rawint4_dequantize(qweight, scales, out_features, in_features):
+    """Dequantize RAWINT4 qweight/scales back to fp32 [N, K]."""
+    result = torch.zeros((out_features, in_features), dtype=torch.float32)
+    for ni in range(out_features):
+        for g in range(in_features // group_size):
+            scale = scales[ni, g].float().item()
+            k_start = g * group_size
+            k_end = k_start + group_size
+            for kk in range(k_start, k_end, 2):
+                packed = int(qweight[ni, kk // 2].item())
+                result[ni, kk] = ((packed & 0x0F) - 8) * scale
+                result[ni, kk + 1] = (((packed >> 4) & 0x0F) - 8) * scale
+    return result
+
+
+def act_fn(x):
+    return x / (1.0 + torch.exp(-x))
+
+
+def mlp_torch(input_data, gate_proj, up_proj, down_proj):
+    gate_buf = torch.mm(input_data, gate_proj.t())
+    up_buf = torch.mm(input_data, up_proj.t())
+    intermediate = act_fn(gate_buf) * up_buf
+    return torch.mm(intermediate, down_proj.t())
+
+
+def moe_torch(input_data, expert_ids, weights, gate_proj, up_proj, down_proj):
+    cnts = expert_ids.new_zeros((expert_ids.shape[0], expert_num))
+    cnts.scatter_(1, expert_ids, 1)
+    tokens_per_expert = cnts.sum(dim=0)
+    idxs = expert_ids.view(-1).argsort()
+    sorted_tokens = input_data[idxs // expert_ids.shape[1]]
+    outputs = []
+    start_idx = 0
+    for i, num_tokens in enumerate(tokens_per_expert):
+        end_idx = start_idx + num_tokens
+        if num_tokens == 0:
+            continue
+        tokens = sorted_tokens[start_idx:end_idx]
+        out = mlp_torch(tokens, gate_proj[i], up_proj[i], down_proj[i])
+        outputs.append(out)
+        start_idx = end_idx
+    outs = torch.cat(outputs, dim=0) if outputs else sorted_tokens.new_empty(0)
+    new_x = torch.empty_like(outs)
+    new_x[idxs] = outs
+    return (new_x.view(*expert_ids.shape, -1).float().mul_(weights.unsqueeze(-1)).sum(1)).to(new_x.dtype)
+
+
+def available_backends():
+    backends = []
+    if hasattr(kt_kernel_ext.moe, "AVX2RawInt4_MOE"):
+        backends.append(("AVX2RawInt4_MOE", kt_kernel_ext.moe.AVX2RawInt4_MOE, 0.12))
+
+    if hasattr(kt_kernel_ext.moe, "AVXVNNI256RawInt4_MOE"):
+        has_avx_vnni = False
+        try:
+            with open("/proc/cpuinfo", "r") as f:
+                has_avx_vnni = any(("avx_vnni" in line or "avxvnni" in line) for line in f if line.startswith("flags"))
+        except OSError:
+            has_avx_vnni = False
+        if has_avx_vnni:
+            backends.append(("AVXVNNI256RawInt4_MOE", kt_kernel_ext.moe.AVXVNNI256RawInt4_MOE, 0.20))
+    return backends
+
+
+def run_backend_accuracy_test(backend_name, backend_cls, threshold, qlen):
+    physical_to_logical_map = torch.tensor(range(expert_num), dtype=torch.int64).contiguous()
+    cpu_infer = kt_kernel_ext.CPUInfer(CPUINFER_PARAM)
+
+    with torch.inference_mode():
+        gate_bf16 = (torch.randn((expert_num, intermediate_size, hidden_size), dtype=torch.float32) / 10.0).to(
+            torch.bfloat16
+        )
+        up_bf16 = (torch.randn((expert_num, intermediate_size, hidden_size), dtype=torch.float32) / 10.0).to(
+            torch.bfloat16
+        )
+        down_bf16 = (torch.randn((expert_num, hidden_size, intermediate_size), dtype=torch.float32) / 10.0).to(
+            torch.bfloat16
+        )
+
+        gate_qw_list, gate_scale_list = [], []
+        up_qw_list, up_scale_list = [], []
+        down_qw_list, down_scale_list = [], []
+
+        for e in range(expert_num):
+            qw, sc = rawint4_quantize(gate_bf16[e])
+            gate_qw_list.append(qw)
+            gate_scale_list.append(sc)
+
+            qw, sc = rawint4_quantize(up_bf16[e])
+            up_qw_list.append(qw)
+            up_scale_list.append(sc)
+
+            qw, sc = rawint4_quantize(down_bf16[e])
+            down_qw_list.append(qw)
+            down_scale_list.append(sc)
+
+        gate_qw = torch.stack(gate_qw_list).contiguous()
+        gate_scales = torch.stack(gate_scale_list).contiguous()
+        up_qw = torch.stack(up_qw_list).contiguous()
+        up_scales = torch.stack(up_scale_list).contiguous()
+        down_qw = torch.stack(down_qw_list).contiguous()
+        down_scales = torch.stack(down_scale_list).contiguous()
+
+        gate_deq = torch.stack(
+            [
+                rawint4_dequantize(gate_qw_list[e], gate_scale_list[e], intermediate_size, hidden_size)
+                for e in range(expert_num)
+            ]
+        )
+        up_deq = torch.stack(
+            [
+                rawint4_dequantize(up_qw_list[e], up_scale_list[e], intermediate_size, hidden_size)
+                for e in range(expert_num)
+            ]
+        )
+        down_deq = torch.stack(
+            [
+                rawint4_dequantize(down_qw_list[e], down_scale_list[e], hidden_size, intermediate_size)
+                for e in range(expert_num)
+            ]
+        )
+
+        config = kt_kernel_ext.moe.MOEConfig(expert_num, num_experts_per_tok, hidden_size, intermediate_size, 0)
+        config.max_len = max_len
+        config.gate_proj = gate_qw.data_ptr()
+        config.up_proj = up_qw.data_ptr()
+        config.down_proj = down_qw.data_ptr()
+        config.gate_scale = gate_scales.data_ptr()
+        config.up_scale = up_scales.data_ptr()
+        config.down_scale = down_scales.data_ptr()
+        config.quant_config.bits = 4
+        config.quant_config.group_size = group_size
+        config.quant_config.zero_point = False
+        config.pool = cpu_infer.backend_
+
+        moe = backend_cls(config)
+        cpu_infer.submit(moe.load_weights_task(physical_to_logical_map.data_ptr()))
+        cpu_infer.sync()
+
+        print(f"\n--- {backend_name} (qlen={qlen}) ---")
+        for i in range(validation_iter):
+            expert_ids = torch.stack(
+                [torch.randperm(expert_num)[:num_experts_per_tok] for _ in range(qlen)]
+            ).contiguous()
+            weights = torch.rand((qlen, num_experts_per_tok), dtype=torch.float32).contiguous()
+            input_data = (torch.randn((qlen, hidden_size), dtype=torch.float32) / 100.0).to(torch.bfloat16).contiguous()
+            output = torch.empty((qlen, hidden_size), dtype=torch.bfloat16).contiguous()
+
+            bsz_tensor = torch.tensor([qlen], dtype=torch.int32)
+            cpu_infer.submit(
+                moe.forward_task(
+                    bsz_tensor.data_ptr(),
+                    num_experts_per_tok,
+                    expert_ids.data_ptr(),
+                    weights.data_ptr(),
+                    input_data.data_ptr(),
+                    output.data_ptr(),
+                    False,
+                )
+            )
+            cpu_infer.sync()
+
+            ref_output = moe_torch(input_data.float(), expert_ids, weights, gate_deq, up_deq, down_deq).to(
+                torch.bfloat16
+            )
+            diff = torch.mean(torch.abs(output.float() - ref_output.float())) / (
+                torch.mean(torch.abs(ref_output.float())) + 1e-8
+            )
+            print(f"  Iteration {i}: diff = {diff.item():.6f}")
+            assert diff < threshold, f"{backend_name} accuracy test failed: diff={diff.item():.6f} >= {threshold}"
+
+
+def test_rawint4_accuracy():
+    backends = available_backends()
+    if not backends:
+        print("Skipping RAWINT4 accuracy tests: no x86 RAWINT4 backend available")
+        return
+
+    for backend_name, backend_cls, threshold in backends:
+        run_backend_accuracy_test(backend_name, backend_cls, threshold, qlen=1)
+        run_backend_accuracy_test(backend_name, backend_cls, threshold, qlen=16)
+
+
+def test_rawint4_backend_selection_falls_back_to_avx2_for_large_group_size(monkeypatch):
+    amx_utils = load_amx_utils()
+    fake_amx_backend = object()
+    fake_avx2_backend = object()
+    fake_avxvnni_backend = object()
+
+    monkeypatch.setattr(amx_utils, "AMXInt4_KGroup_MOE", fake_amx_backend)
+    monkeypatch.setattr(amx_utils, "AVX2RawInt4_MOE", fake_avx2_backend)
+    monkeypatch.setattr(amx_utils, "AVXVNNI256RawInt4_MOE", fake_avxvnni_backend)
+    monkeypatch.setattr(amx_utils, "_HAS_RAWINT4_SUPPORT", False)
+    monkeypatch.setattr(amx_utils, "_HAS_AVX2_RAWINT4_SUPPORT", True)
+    monkeypatch.setattr(amx_utils, "_HAS_AVXVNNI256_RAW_INT4_SUPPORT", True)
+    monkeypatch.setattr(amx_utils, "_HOST_HAS_AVX_VNNI", True)
+    monkeypatch.delenv("KT_RAWINT4_BACKEND", raising=False)
+
+    assert amx_utils._select_rawint4_backend(512) is fake_avx2_backend
+    assert amx_utils._select_rawint4_backend(128) is fake_avxvnni_backend
+
+
+def test_rawint4_backend_selection_rejects_forced_avxvnni_with_large_group_size(monkeypatch):
+    amx_utils = load_amx_utils()
+
+    monkeypatch.setattr(amx_utils, "_HAS_AVXVNNI256_RAW_INT4_SUPPORT", True)
+    monkeypatch.setattr(amx_utils, "_HOST_HAS_AVX_VNNI", True)
+    monkeypatch.setenv("KT_RAWINT4_BACKEND", "avxvnni")
+
+    with pytest.raises(RuntimeError, match="group_size=512 is unsupported"):
+        amx_utils._select_rawint4_backend(512)
+
+
+if __name__ == "__main__":
+    print("=" * 60)
+    print("RAWINT4 MoE Accuracy Test")
+    print("=" * 60)
+    test_rawint4_accuracy()
+    print("PASSED")


### PR DESCRIPTION
# What does this PR do?

This PR adds AVX2 and AVX-VNNI RAWINT4 MoE support to kt-kernel.

It includes:

new AVX2 and AVX-VNNI RAWINT4 MoE operator implementations
Python-side RAWINT4 backend detection / selection updates
extension bindings for the new RAWINT4 MoE backends
English and Chinese AVX2 tutorial updates

## Before submitting

- [x] Did you read the [contributor guideline](https://github.com/kvcache-ai/ktransformers/blob/main/.github/CONTRIBUTING.md)?
- [x] Did you write any new necessary tests?