### PR TITLE
[build] align kt-kernel torch support with v0.6.1 release

### DIFF
--- a/kt-kernel/pyproject.toml
+++ b/kt-kernel/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
 requires-python = ">=3.11"
 dependencies = [
   # Core dependencies
-  "torch>=2.0.0",
+  "torch>=2.10,<2.12",
   "safetensors>=0.4.0",
   "numpy>=1.24.0",
   "triton>=2.0.0",

--- a/kt-kernel/requirements.txt
+++ b/kt-kernel/requirements.txt
@@ -3,7 +3,7 @@
 # You can skip this file if you already have these packages installed
 
 # Core dependencies (minimum versions)
-torch>=2.0.0
+torch>=2.10,<2.12
 safetensors>=0.4.0
 numpy>=1.24.0
 triton>=2.0.0


### PR DESCRIPTION
## Summary
- align kt-kernel source metadata with the published 0.6.1 wheels
- tighten the documented torch support range to the release-tested window
- keep source installs consistent with PyPI metadata

## Details
The published `kt-kernel==0.6.1` wheels already declare `torch>=2.10,<2.12` after release validation. This PR syncs the source tree to that shipped metadata in:
- `kt-kernel/pyproject.toml`
- `kt-kernel/requirements.txt`
