### PR TITLE
[build]: flatten ktransformers package shim

### DIFF
--- a/ktransformers.py
+++ b/ktransformers.py
@@ -1,4 +1,4 @@
-"""Top-level Python package for KTransformers.
+"""Top-level Python module for KTransformers.
 
 The runtime kernels live in kt-kernel. Optional SFT support is activated
 via pip install "ktransformers[sft]" which adds transformers-kt and
@@ -13,12 +13,13 @@ from pathlib import Path
 
 def _read_repo_version() -> str:
     ns: dict[str, str] = {}
-    exec((Path(__file__).resolve().parents[1] / 'version.py').read_text(), ns)
-    return ns['__version__']
+    version_file = Path(__file__).resolve().with_name("version.py")
+    exec(version_file.read_text(), ns)
+    return ns["__version__"]
 
 
 try:
-    __version__ = version('ktransformers')
+    __version__ = version("ktransformers")
 except PackageNotFoundError:
     __version__ = _read_repo_version()
 
@@ -31,4 +32,4 @@ def has_sft_support() -> bool:
     return True
 
 
-__all__ = ['__version__', 'has_sft_support']
+__all__ = ["__version__", "has_sft_support"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,5 +19,6 @@ classifiers = [
 Homepage = "https://github.com/kvcache-ai/ktransformers"
 
 [tool.setuptools]
-# Ship a minimal top-level Python package so the distribution is importable.
-packages = ["ktransformers"]
+# Ship a minimal top-level Python module so the distribution is importable
+# without keeping a parallel source package directory at the repository root.
+py-modules = ["ktransformers"]


### PR DESCRIPTION
Message:

Flatten the minimal top-level `ktransformers` import shim from a package directory to a single `ktransformers.py` module.

Scope:
- Move `ktransformers/__init__.py` to `ktransformers.py`.
- Switch setuptools packaging from `packages = ["ktransformers"]` to `py-modules = ["ktransformers"]`.
- Keep the existing `ktransformers` distribution metadata and dependency/extras logic unchanged.

Why:
- Avoid keeping a root-level `ktransformers/` source directory next to `kt-kernel/`.
- Preserve `pip install ktransformers` and `import ktransformers` behavior.

Validation:
- Built the top-level `ktransformers` wheel locally on sapphire4 from commit `d143cf3`.
- Verified wheel contents contain `ktransformers.py` and no `ktransformers/` package directory.
- Verified METADATA keeps `kt-kernel==0.6.1`, `[sft]`, and `[sglang]` dependencies.
- Installed the wheel into a clean local venv with `--no-deps` and verified `import ktransformers`, `__version__ == 0.6.1`, distribution version `0.6.1`, and `hasattr(ktransformers, "__path__") == False`.
- No PyPI publish.
