### PR TITLE
[perf](kt-kernel): MXFP4 MoE add mat-mat 4×4 tile, refine mat-vec reduce

### DIFF
--- a/kt-kernel/bench/bench_fp4_moe.py
+++ b/kt-kernel/bench/bench_fp4_moe.py
@@ -1,0 +1,313 @@
+#!/usr/bin/env python
+# coding=utf-8
+"""Benchmark MXFP4 MoE kernel — V4-Flash shape, mat-vec / mat-mat 双路径覆盖。
+
+Synthesizes V4-Flash-shaped MXFP4 weights (random nibbles + bf16 group scales),
+runs the chosen backend over a list of batch sizes M, prints a throughput table.
+
+Routing modes (决定是否触发 mat-mat 路径):
+    balanced     —— 每 token randperm(EXPERT_NUM)[:TOP_K]; 平均 per-expert m ≈
+                    M*top_k/expert_num. V4 真实路由分布. 大 batch (M=1024) 才
+                    平均触发 mat-mat (per-expert m ≥ 4).
+    concentrated —— 所有 M token 共用同一组 top_k expert; per-expert m = M.
+                    M=4 立即触发 mat-mat —— 用来直观放大 mat-mat 性能优势.
+
+Usage:
+    python bench/bench_fp4_moe.py --backend v1
+    python bench/bench_fp4_moe.py --backend v1 --routing concentrated
+    python bench/bench_fp4_moe.py --all --routing concentrated   # 所有可用 backend 对比
+
+`--backend` 是预留扩展点; 当前编译只绑定 v1 (AMXFP4_KGroup_MOE)。要选 v2/v3
+需要 ext_bindings 里加新绑定。`--all` 会自动检测哪些 backend 可用。
+"""
+import argparse
+import json
+import os
+import platform
+import subprocess
+import sys
+import time
+
+import torch
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "build"))
+from kt_kernel import kt_kernel_ext  # noqa: E402
+
+# ----- V4-Flash MoE shape -----
+HIDDEN = 4096
+INTER = 2048
+EXPERT_NUM = 256
+TOP_K = 6
+K_GROUP_SIZE = 32
+
+# ----- bench knobs -----
+# M=1024 时平均 per-expert m ≈ M*6/256 = 24, balanced 路由也能触发 mat-mat。
+DEFAULT_M_LIST = [1, 4, 16, 64, 256, 1024]
+WARMUP_ITER = 200
+TEST_ITER = 2000
+
+# ----- WorkerPool: 2 NUMA × 40 thread (matches bench_k2_moe_amx.py) -----
+WORKER_NUMA = 2
+WORKER_THREADS_PER_NUMA = 40
+
+# ----- Backend registry: name → kt_kernel_ext.moe class (None = not bound) -----
+BACKENDS = {
+    "v1": getattr(kt_kernel_ext.moe, "AMXFP4_KGroup_MOE", None),
+    # 预留扩展点; 加新 backend 时在 ext_bindings 绑定后这里加一行即可。
+    "v2": getattr(kt_kernel_ext.moe, "AMXFP4_KGroup_MOE_V2", None),
+}
+
+# OCP MXFP4 (E2M1) codepoints — same order as the kernel's LUT.
+E2M1_VALUES = torch.tensor(
+    [0.0, 0.5, 1.0, 1.5, 2.0, 3.0, 4.0, 6.0,
+     -0.0, -0.5, -1.0, -1.5, -2.0, -3.0, -4.0, -6.0],
+    dtype=torch.float32,
+)
+
+
+def quantize_mxfp4_tensor(weights: torch.Tensor, group_size: int):
+    """[E, N, K] fp32/bf16 → packed nibbles uint8 [E, N, K/2] + bf16 scales [E, N, K/gs]."""
+    w = weights.to(torch.float32)
+    e, rows, cols = w.shape
+    assert cols % group_size == 0 and cols % 2 == 0
+    reshaped = w.view(e, rows, cols // group_size, group_size)
+    max_abs = reshaped.abs().amax(dim=-1, keepdim=True).clamp(min=1e-8)
+    scales = (max_abs / 6.0).squeeze(-1)
+    normalized = reshaped / scales.unsqueeze(-1)
+    distances = torch.abs(normalized.unsqueeze(-1) - E2M1_VALUES.view(1, 1, 1, 1, 16))
+    nibbles = distances.argmin(dim=-1).to(torch.uint8).view(e, rows, cols // 2, 2)
+    lo = nibbles[..., 0]
+    hi = nibbles[..., 1]
+    packed = ((hi << 4) | lo).contiguous()  # uint8 [E, N, K/2]
+    scales = scales.to(torch.bfloat16).contiguous()  # bf16 [E, N, K/gs]
+    return packed, scales
+
+
+def build_synth_weights():
+    torch.manual_seed(0)
+    gate = torch.randn((EXPERT_NUM, INTER, HIDDEN), dtype=torch.float32) / 100
+    up = torch.randn((EXPERT_NUM, INTER, HIDDEN), dtype=torch.float32) / 100
+    down = torch.randn((EXPERT_NUM, HIDDEN, INTER), dtype=torch.float32) / 100
+    gw, gs = quantize_mxfp4_tensor(gate, K_GROUP_SIZE)
+    uw, us = quantize_mxfp4_tensor(up, K_GROUP_SIZE)
+    dw, ds = quantize_mxfp4_tensor(down, K_GROUP_SIZE)
+    return {
+        "gate_w": gw, "up_w": uw, "down_w": dw,
+        "gate_s": gs, "up_s": us, "down_s": ds,
+    }
+
+
+def build_moe(backend: str, weights, cpu_infer):
+    cls = BACKENDS.get(backend)
+    if cls is None:
+        raise RuntimeError(
+            f"backend={backend} not bound in this build. Available: "
+            f"{[k for k, v in BACKENDS.items() if v is not None]}"
+        )
+    cfg = kt_kernel_ext.moe.MOEConfig(EXPERT_NUM, TOP_K, HIDDEN, INTER, 0)
+    cfg.max_len = max(DEFAULT_M_LIST)
+    cfg.pool = cpu_infer.backend_
+    cfg.quant_config.bits = 4
+    cfg.quant_config.group_size = K_GROUP_SIZE
+    cfg.quant_config.zero_point = False
+    cfg.gate_projs = [[t.data_ptr() for t in weights["gate_w"]]]
+    cfg.up_projs = [[t.data_ptr() for t in weights["up_w"]]]
+    cfg.down_projs = [[t.data_ptr() for t in weights["down_w"]]]
+    cfg.gate_scales = [[t.data_ptr() for t in weights["gate_s"]]]
+    cfg.up_scales = [[t.data_ptr() for t in weights["up_s"]]]
+    cfg.down_scales = [[t.data_ptr() for t in weights["down_s"]]]
+    moe = cls(cfg)
+    p2l = torch.arange(EXPERT_NUM, dtype=torch.int64).contiguous()
+    cpu_infer.submit(moe.load_weights_task(p2l.data_ptr()))
+    cpu_infer.sync()
+    return moe
+
+
+def make_expert_ids(M: int, routing: str) -> torch.Tensor:
+    """[M, TOP_K] int64 (kernel forward_binding casts to const int64_t*)."""
+    if routing == "concentrated":
+        # 所有 M token 共用同组 top_k expert → per-expert m = M
+        hot = torch.randperm(EXPERT_NUM)[:TOP_K]
+        return hot.unsqueeze(0).expand(M, TOP_K).contiguous().to(torch.int64)
+    # balanced: 每 token 独立 randperm
+    return torch.stack(
+        [torch.randperm(EXPERT_NUM)[:TOP_K] for _ in range(M)]
+    ).to(torch.int64).contiguous()
+
+
+def bench_one_m(moe, cpu_infer, M: int, routing: str):
+    bsz = torch.tensor([M], dtype=torch.int32)
+    expert_ids = make_expert_ids(M, routing)
+    routing_w = torch.rand((M, TOP_K), dtype=torch.float32).contiguous()
+    x = (torch.randn((M, HIDDEN), dtype=torch.bfloat16) / 100).contiguous()
+    y = torch.empty((M, HIDDEN), dtype=torch.bfloat16).contiguous()
+
+    for _ in range(WARMUP_ITER):
+        cpu_infer.submit(moe.forward_task(
+            bsz.data_ptr(), TOP_K, expert_ids.data_ptr(),
+            routing_w.data_ptr(), x.data_ptr(), y.data_ptr(), False))
+        cpu_infer.sync()
+
+    start = time.perf_counter()
+    for _ in range(TEST_ITER):
+        cpu_infer.submit(moe.forward_task(
+            bsz.data_ptr(), TOP_K, expert_ids.data_ptr(),
+            routing_w.data_ptr(), x.data_ptr(), y.data_ptr(), False))
+        cpu_infer.sync()
+    total = time.perf_counter() - start
+
+    per_iter_us = total / TEST_ITER * 1e6
+    tok_per_s = M * TEST_ITER / total
+    unique_e = int(torch.unique(expert_ids).numel())
+    avg_m_per_expert = float(M * TOP_K) / max(unique_e, 1)
+    return {
+        "M": M, "iters": TEST_ITER, "total_s": total,
+        "per_iter_us": per_iter_us, "tokens_per_s": tok_per_s,
+        "unique_experts": unique_e, "avg_m_per_expert": avg_m_per_expert,
+    }
+
+
+def run_backend(backend: str, weights, cpu_infer, m_list, routing):
+    print(f"\n[bench-fp4] backend={backend} routing={routing}")
+    moe = build_moe(backend, weights, cpu_infer)
+    rows = []
+    for M in m_list:
+        r = bench_one_m(moe, cpu_infer, M, routing)
+        rows.append(r)
+        print(f"  M={M:>5}  avg_m/expert={r['avg_m_per_expert']:>6.1f}  "
+              f"per-iter={r['per_iter_us']:>9.1f} us  tok/s={r['tokens_per_s']:>9.1f}")
+    return rows
+
+
+def print_single_table(backend, rows, routing):
+    print(f"\n=== Summary ({backend}, routing={routing}) ===")
+    print(f"{'M':>5}  {'avg_m':>6}  {'per-iter us':>12}  {'tok/s':>10}")
+    for r in rows:
+        print(f"{r['M']:>5}  {r['avg_m_per_expert']:>6.1f}  "
+              f"{r['per_iter_us']:>12.1f}  {r['tokens_per_s']:>10.1f}")
+
+
+def print_compare_table(all_rows: dict, routing: str):
+    backends = list(all_rows.keys())
+    if len(backends) < 2:
+        print_single_table(backends[0], all_rows[backends[0]], routing)
+        return
+    base = backends[0]
+    print(f"\n=== {' vs '.join(backends)} (routing={routing}, base={base}) ===")
+    header = f"{'M':>5}  {'avg_m':>6}"
+    for be in backends:
+        header += f"  {be + ' us':>10}"
+    for be in backends[1:]:
+        header += f"  {be + '/' + base:>8}"
+    print(header)
+    n_rows = len(all_rows[base])
+    for i in range(n_rows):
+        line = f"{all_rows[base][i]['M']:>5}  {all_rows[base][i]['avg_m_per_expert']:>6.1f}"
+        for be in backends:
+            line += f"  {all_rows[be][i]['per_iter_us']:>10.1f}"
+        for be in backends[1:]:
+            ratio = all_rows[be][i]['per_iter_us'] / all_rows[base][i]['per_iter_us']
+            line += f"  {ratio:>8.3f}"
+        print(line)
+
+
+def get_git_commit():
+    try:
+        commit = subprocess.check_output(["git", "rev-parse", "HEAD"]).decode().strip()
+        dirty = bool(subprocess.check_output(["git", "status", "--porcelain"]).decode().strip())
+        return {"commit": commit, "dirty": dirty}
+    except Exception as e:
+        return {"commit": None, "error": str(e)}
+
+
+def get_system_info():
+    info = {"node": platform.node(), "system": platform.system()}
+    cpu_model = None
+    try:
+        with open("/proc/cpuinfo") as f:
+            for line in f:
+                if "model name" in line:
+                    cpu_model = line.split(":", 1)[1].strip()
+                    break
+    except Exception:
+        pass
+    info["cpu"] = cpu_model
+    info["cpu_cores"] = os.cpu_count()
+    return info
+
+
+def main():
+    p = argparse.ArgumentParser()
+    p.add_argument("--backend", choices=list(BACKENDS.keys()), default="v1",
+                   help="单 backend 模式（被 --all 覆盖）。当前可用: "
+                        + ",".join(k for k, v in BACKENDS.items() if v is not None))
+    p.add_argument("--all", action="store_true",
+                   help="跑所有已绑定的 backend 并打印对比表（自动跳过未绑定的）")
+    p.add_argument("--routing", choices=["balanced", "concentrated"], default="balanced",
+                   help="balanced=每 token randperm (V4 真实); "
+                        "concentrated=所有 token 共用同组 top_k (per-expert m=M, 放大 mat-mat)")
+    p.add_argument("--m-list", type=str, default=None,
+                   help=f"Comma-separated M values, default: {','.join(map(str, DEFAULT_M_LIST))}")
+    p.add_argument("--numa", type=int, default=WORKER_NUMA)
+    p.add_argument("--threads-per-numa", type=int, default=WORKER_THREADS_PER_NUMA)
+    args = p.parse_args()
+
+    m_list = [int(x) for x in args.m_list.split(",")] if args.m_list else DEFAULT_M_LIST
+
+    if args.all:
+        backends = [k for k, v in BACKENDS.items() if v is not None]
+        if not backends:
+            raise RuntimeError("No MXFP4 backend bound in this build.")
+        print(f"[bench-fp4] --all: detected backends = {backends}")
+    else:
+        if BACKENDS.get(args.backend) is None:
+            raise RuntimeError(
+                f"backend={args.backend} not bound. Available: "
+                f"{[k for k, v in BACKENDS.items() if v is not None]}"
+            )
+        backends = [args.backend]
+
+    print(f"[bench-fp4] shape=H{HIDDEN}/I{INTER}/E{EXPERT_NUM}/k{TOP_K}/gs{K_GROUP_SIZE}  routing={args.routing}")
+    print(f"[bench-fp4] WorkerPool: numa={args.numa} threads_per_numa={args.threads_per_numa}")
+    print(f"[bench-fp4] m_list: {m_list}")
+
+    wp = kt_kernel_ext.WorkerPoolConfig()
+    wp.subpool_count = args.numa
+    wp.subpool_numa_map = list(range(args.numa))
+    wp.subpool_thread_count = [args.threads_per_numa] * args.numa
+    cpu_infer = kt_kernel_ext.CPUInfer(wp)
+
+    print("[bench-fp4] synthesizing MXFP4 weights …")
+    weights = build_synth_weights()
+
+    all_rows = {}
+    for be in backends:
+        all_rows[be] = run_backend(be, weights, cpu_infer, m_list, args.routing)
+
+    if len(backends) > 1:
+        print_compare_table(all_rows, args.routing)
+    else:
+        print_single_table(backends[0], all_rows[backends[0]], args.routing)
+
+    # JSONL log
+    out_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), "bench_fp4_moe.jsonl")
+    ts = time.strftime("%Y-%m-%d %H:%M:%S", time.localtime())
+    git = get_git_commit()
+    sys_info = get_system_info()
+    with open(out_path, "a") as f:
+        for be, rows in all_rows.items():
+            record = {
+                "backend": be,
+                "routing": args.routing,
+                "shape": {"hidden": HIDDEN, "inter": INTER, "expert_num": EXPERT_NUM,
+                          "top_k": TOP_K, "k_group_size": K_GROUP_SIZE},
+                "worker_pool": {"numa": args.numa, "threads_per_numa": args.threads_per_numa},
+                "rows": rows,
+                "git": git, "system": sys_info, "timestamp": ts,
+            }
+            f.write(json.dumps(record) + "\n")
+    print(f"\n[bench-fp4] appended {len(backends)} record(s) → {out_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/kt-kernel/examples/test_fp4_moe_amx.py
+++ b/kt-kernel/examples/test_fp4_moe_amx.py
@@ -17,12 +17,17 @@ max_len = 25600
 expert_num = 16
 num_experts_per_tok = 8
 
-qlen = 1
 layer_num = 1
 CPUInfer = kt_kernel_ext.CPUInfer(40)
-validation_iter = 10
+validation_iter = 3
 k_group_size = 32
 debug_print_count = 16
+
+# Forward dispatch in do_gate_up_gemm uses `qlen > 4 * expert_num / top_k`
+# (= 8 with these constants), so qlen=1 hits mat-vec and qlen=32 hits the
+# mat-mat 4×4 register tile (per-expert avg m = qlen*top_k/expert_num = 16).
+QLEN_LIST = [1, 32]
+DISPATCH_THRESHOLD = 4 * expert_num / num_experts_per_tok
 
 physical_to_logical_map = torch.tensor(data=range(expert_num), device="cpu", dtype=torch.int64).contiguous()
 
@@ -263,10 +268,11 @@ def build_moes_from_quantized_data(quant_data: Dict[str, torch.Tensor]):
     return moes
 
 
-def run_case(pattern: str) -> Dict[str, float]:
+def run_case(pattern: str, qlen: int) -> Dict[str, float]:
     print("\n" + "=" * 70)
     desc = WEIGHT_PATTERNS[pattern][0]
-    print(f"Running case: {pattern} -> {desc}")
+    path = "mat-vec" if qlen <= DISPATCH_THRESHOLD else "mat-mat"
+    print(f"Running case: {pattern} -> {desc}  (qlen={qlen}, path={path})")
     print("=" * 70)
 
     quant_data = prepare_mxfp4_quantized_weights(pattern)
@@ -328,14 +334,20 @@ def run_case(pattern: str) -> Dict[str, float]:
 
 def run_fp4_moe_test():
     summary_rows = []
-    for case_name in WEIGHT_PATTERNS.keys():
-        results = run_case(case_name)
-        summary_rows.append(results)
+    for qlen in QLEN_LIST:
+        path = "mat-vec" if qlen <= DISPATCH_THRESHOLD else "mat-mat"
+        print(f"\n##### qlen={qlen}  path={path} #####")
+        for case_name in WEIGHT_PATTERNS.keys():
+            results = run_case(case_name, qlen)
+            results["qlen"] = qlen
+            results["path"] = path
+            summary_rows.append(results)
 
     print("\n=== Case vs. Relative Error Summary ===")
-    print(f"{'Case':<20} {'Mean':>10} {'Max':>10} {'Min':>10}")
+    print(f"{'Case':<20} {'qlen':>5} {'path':<8} {'Mean':>10} {'Max':>10} {'Min':>10}")
     for row in summary_rows:
-        print(f"{row['case']:<20} {row['mean']*100:9.2f}% {row['max']*100:9.2f}% {row['min']*100:9.2f}%")
+        print(f"{row['case']:<20} {row['qlen']:>5} {row['path']:<8} "
+              f"{row['mean']*100:9.2f}% {row['max']*100:9.2f}% {row['min']*100:9.2f}%")
 
 
 if __name__ == "__main__":

--- a/kt-kernel/operators/amx/fp4-moe.hpp
+++ b/kt-kernel/operators/amx/fp4-moe.hpp
@@ -54,7 +54,7 @@ struct GemmKernel224MXFP4SmallKGroup {
 
   // Convert 16 packed FP4 bytes (32 values = 1 k_group) → 32 BF16 values (__m512i)
   // Output column order: [BF16(lo[0]),BF16(hi[0]), ..., BF16(lo[15]),BF16(hi[15])]
-  static inline __m512i mxfp4_to_bf16_32(__m128i packed) {
+  __attribute__((always_inline)) static inline __m512i mxfp4_to_bf16_32(__m128i packed) {
     __m128i lo_mask = _mm_set1_epi8(0x0F);
     __m128i lo = _mm_and_si128(packed, lo_mask);
     __m128i hi = _mm_and_si128(_mm_srli_epi16(packed, 4), lo_mask);
@@ -90,30 +90,200 @@ struct GemmKernel224MXFP4SmallKGroup {
   using BufferB = BufferBInt4KGroupImpl<GemmKernel224MXFP4SmallKGroup>;  // nibble-packed FP4
   using BufferC = BufferCReduceImpl<GemmKernel224MXFP4SmallKGroup>;      // FP32 reduce
 
-  // AVX512 kernel: BF16 activation × MXFP4 weight → FP32
-  // Follows integer_mat_vec_kgroup pattern but with dpbf16_ps and weight-only scale
-  static inline void fp4_mat_vec_kgroup(int m, int n, int k, int k_group_size, BufferA* ba, BufferB* bb, BufferC* bc,
-                                        int ith, int nth) {
+  // 4 个 zmm 的 horizontal reduce → 4 个连续 fp32。
+  // 4 次 reduce_add_ps 之间无依赖，编译器/CPU 可并行调度。
+  __attribute__((always_inline)) static inline void
+  reduce4(__m512 s0, __m512 s1, __m512 s2, __m512 s3, float* dst) {
+    dst[0] = _mm512_reduce_add_ps(s0);
+    dst[1] = _mm512_reduce_add_ps(s1);
+    dst[2] = _mm512_reduce_add_ps(s2);
+    dst[3] = _mm512_reduce_add_ps(s3);
+  }
+
+  // mat-vec: M 个独立 token，N 维 4 行一组累加，摊销 horizontal reduce。
+  static void fp4_mat_vec_kgroup(int m, int n, int k, int k_group_size, BufferA* ba, BufferB* bb, BufferC* bc,
+                                 int ith, int nth) {
     auto [n_start, n_end] = split_range_n(n, ith, nth);
-    for (int m_begin = 0; m_begin < m; m_begin++) {
-      float* c = bc->get_submat(m, n, m_begin, n_start);
-      __m512bh* a_bf16 = (__m512bh*)ba->get_submat(m, k, m_begin, 0);
+    if (n_start >= n_end) return;
+    const int kg_count = k / 32;
 
-      for (int n_block_begin = n_start; n_block_begin < n_end; n_block_begin++) {
-        __m128i* b_row = (__m128i*)bb->get_submat(n, k, n_block_begin, 0);
-        float* bs = (float*)bb->get_scale(n, n_block_begin, k, 0);
+    for (int m_idx = 0; m_idx < m; m_idx++) {
+      float* c_row = bc->get_submat(m, n, m_idx, n_start);
+      __m512bh* a_row = (__m512bh*)ba->get_submat(m, k, m_idx, 0);
 
-        __m512 sum = _mm512_setzero_ps();
+      int n_pos = n_start;
+      // 主循环: N 维 4 行一组
+      for (; n_pos + 4 <= n_end; n_pos += 4) {
+        __m128i* w0 = (__m128i*)bb->get_submat(n, k, n_pos + 0, 0);
+        __m128i* w1 = (__m128i*)bb->get_submat(n, k, n_pos + 1, 0);
+        __m128i* w2 = (__m128i*)bb->get_submat(n, k, n_pos + 2, 0);
+        __m128i* w3 = (__m128i*)bb->get_submat(n, k, n_pos + 3, 0);
+        const float* s0 = bb->get_scale(n, n_pos + 0, k, 0);
+        const float* s1 = bb->get_scale(n, n_pos + 1, k, 0);
+        const float* s2 = bb->get_scale(n, n_pos + 2, k, 0);
+        const float* s3 = bb->get_scale(n, n_pos + 3, k, 0);
 
-        // Each iteration: 1 k_group = 32 K elements
-        for (int k_block = 0; k_block < k / 32; k_block++) {
-          __m512 w_scale = _mm512_set1_ps(bs[k_block]);
-          __m512bh a_val = a_bf16[k_block];
-          __m512i w_bf16 = mxfp4_to_bf16_32(b_row[k_block]);
-          sum = _mm512_fmadd_ps(w_scale, _mm512_dpbf16_ps(_mm512_setzero_ps(), a_val, (__m512bh)w_bf16), sum);
+        __m512 acc0 = _mm512_setzero_ps();
+        __m512 acc1 = _mm512_setzero_ps();
+        __m512 acc2 = _mm512_setzero_ps();
+        __m512 acc3 = _mm512_setzero_ps();
+
+        for (int g = 0; g < kg_count; g++) {
+          const __m512bh a  = a_row[g];
+          const __m512bh d0 = (__m512bh)mxfp4_to_bf16_32(w0[g]);
+          const __m512bh d1 = (__m512bh)mxfp4_to_bf16_32(w1[g]);
+          const __m512bh d2 = (__m512bh)mxfp4_to_bf16_32(w2[g]);
+          const __m512bh d3 = (__m512bh)mxfp4_to_bf16_32(w3[g]);
+          acc0 = _mm512_fmadd_ps(_mm512_set1_ps(s0[g]),
+                                 _mm512_dpbf16_ps(_mm512_setzero_ps(), a, d0), acc0);
+          acc1 = _mm512_fmadd_ps(_mm512_set1_ps(s1[g]),
+                                 _mm512_dpbf16_ps(_mm512_setzero_ps(), a, d1), acc1);
+          acc2 = _mm512_fmadd_ps(_mm512_set1_ps(s2[g]),
+                                 _mm512_dpbf16_ps(_mm512_setzero_ps(), a, d2), acc2);
+          acc3 = _mm512_fmadd_ps(_mm512_set1_ps(s3[g]),
+                                 _mm512_dpbf16_ps(_mm512_setzero_ps(), a, d3), acc3);
         }
+        reduce4(acc0, acc1, acc2, acc3, c_row + (n_pos - n_start));
+      }
+      // N 尾巴: N % 4 != 0 时单行 fallback
+      for (; n_pos < n_end; n_pos++) {
+        __m128i* w = (__m128i*)bb->get_submat(n, k, n_pos, 0);
+        const float* s = bb->get_scale(n, n_pos, k, 0);
+        __m512 acc = _mm512_setzero_ps();
+        for (int g = 0; g < kg_count; g++) {
+          const __m512bh a = a_row[g];
+          const __m512bh d = (__m512bh)mxfp4_to_bf16_32(w[g]);
+          acc = _mm512_fmadd_ps(_mm512_set1_ps(s[g]),
+                                _mm512_dpbf16_ps(_mm512_setzero_ps(), a, d), acc);
+        }
+        c_row[n_pos - n_start] = _mm512_reduce_add_ps(acc);
+      }
+    }
+  }
 
-        c[n_block_begin - n_start] = _mm512_reduce_add_ps(sum);
+  // mat-mat: 4×4 register tile (M_TILE=4, N_TILE=4 → 16 累加器)。
+  // 每 K-group 解码 4 行 N 一次, 被 4 个 token 共享 → PSHUFB 解码开销 / 4。
+  // M / N 尾巴回退到 mat-vec 单 token 内层 (V4 chunked-prefill 16/32/64 整数倍, 极少触发)。
+  static void fp4_mat_mat_kgroup(int m, int n, int k, int k_group_size, BufferA* ba, BufferB* bb, BufferC* bc,
+                                 int ith, int nth) {
+    auto [n_start, n_end] = split_range_n(n, ith, nth);
+    if (n_start >= n_end) return;
+    const int kg_count = k / 32;
+    constexpr int MB = 4;
+    constexpr int NB = 4;
+
+    int m_pos = 0;
+    for (; m_pos + MB <= m; m_pos += MB) {
+      __m512bh* a_rows[MB] = {
+          (__m512bh*)ba->get_submat(m, k, m_pos + 0, 0),
+          (__m512bh*)ba->get_submat(m, k, m_pos + 1, 0),
+          (__m512bh*)ba->get_submat(m, k, m_pos + 2, 0),
+          (__m512bh*)ba->get_submat(m, k, m_pos + 3, 0),
+      };
+
+      int n_pos = n_start;
+      for (; n_pos + NB <= n_end; n_pos += NB) {
+        __m128i* w0 = (__m128i*)bb->get_submat(n, k, n_pos + 0, 0);
+        __m128i* w1 = (__m128i*)bb->get_submat(n, k, n_pos + 1, 0);
+        __m128i* w2 = (__m128i*)bb->get_submat(n, k, n_pos + 2, 0);
+        __m128i* w3 = (__m128i*)bb->get_submat(n, k, n_pos + 3, 0);
+        const float* s0 = bb->get_scale(n, n_pos + 0, k, 0);
+        const float* s1 = bb->get_scale(n, n_pos + 1, k, 0);
+        const float* s2 = bb->get_scale(n, n_pos + 2, k, 0);
+        const float* s3 = bb->get_scale(n, n_pos + 3, k, 0);
+
+        __m512 acc[MB][NB];
+        for (int i = 0; i < MB; i++)
+          for (int j = 0; j < NB; j++) acc[i][j] = _mm512_setzero_ps();
+
+        for (int g = 0; g < kg_count; g++) {
+          // 4 行权重解码一次, MB 个 token 共享
+          const __m512bh d0 = (__m512bh)mxfp4_to_bf16_32(w0[g]);
+          const __m512bh d1 = (__m512bh)mxfp4_to_bf16_32(w1[g]);
+          const __m512bh d2 = (__m512bh)mxfp4_to_bf16_32(w2[g]);
+          const __m512bh d3 = (__m512bh)mxfp4_to_bf16_32(w3[g]);
+          const __m512  sv0 = _mm512_set1_ps(s0[g]);
+          const __m512  sv1 = _mm512_set1_ps(s1[g]);
+          const __m512  sv2 = _mm512_set1_ps(s2[g]);
+          const __m512  sv3 = _mm512_set1_ps(s3[g]);
+
+          #define V_FMA_ROW(M_I) do { \
+              const __m512bh a = a_rows[M_I][g]; \
+              acc[M_I][0] = _mm512_fmadd_ps(sv0, _mm512_dpbf16_ps(_mm512_setzero_ps(), a, d0), acc[M_I][0]); \
+              acc[M_I][1] = _mm512_fmadd_ps(sv1, _mm512_dpbf16_ps(_mm512_setzero_ps(), a, d1), acc[M_I][1]); \
+              acc[M_I][2] = _mm512_fmadd_ps(sv2, _mm512_dpbf16_ps(_mm512_setzero_ps(), a, d2), acc[M_I][2]); \
+              acc[M_I][3] = _mm512_fmadd_ps(sv3, _mm512_dpbf16_ps(_mm512_setzero_ps(), a, d3), acc[M_I][3]); \
+          } while (0)
+          V_FMA_ROW(0);
+          V_FMA_ROW(1);
+          V_FMA_ROW(2);
+          V_FMA_ROW(3);
+          #undef V_FMA_ROW
+        }
+        for (int i = 0; i < MB; i++) {
+          float* c_row = bc->get_submat(m, n, m_pos + i, n_start);
+          reduce4(acc[i][0], acc[i][1], acc[i][2], acc[i][3], c_row + (n_pos - n_start));
+        }
+      }
+      // N 尾巴: 单 N 列 × MB token (V4 不触发)
+      for (; n_pos < n_end; n_pos++) {
+        __m128i* w = (__m128i*)bb->get_submat(n, k, n_pos, 0);
+        const float* s = bb->get_scale(n, n_pos, k, 0);
+        for (int i = 0; i < MB; i++) {
+          float* c_row = bc->get_submat(m, n, m_pos + i, n_start);
+          __m512 acc = _mm512_setzero_ps();
+          for (int g = 0; g < kg_count; g++) {
+            acc = _mm512_fmadd_ps(_mm512_set1_ps(s[g]),
+                                  _mm512_dpbf16_ps(_mm512_setzero_ps(),
+                                                   a_rows[i][g],
+                                                   (__m512bh)mxfp4_to_bf16_32(w[g])),
+                                  acc);
+          }
+          c_row[n_pos - n_start] = _mm512_reduce_add_ps(acc);
+        }
+      }
+    }
+    // M 尾巴: M 不是 MB 倍数时余下 token, 退回单 token mat-vec 内层 (V4 不触发)
+    for (int mi = m_pos; mi < m; mi++) {
+      float* c_row = bc->get_submat(m, n, mi, n_start);
+      __m512bh* a_row = (__m512bh*)ba->get_submat(m, k, mi, 0);
+      int n_pos = n_start;
+      for (; n_pos + 4 <= n_end; n_pos += 4) {
+        __m128i* w0 = (__m128i*)bb->get_submat(n, k, n_pos + 0, 0);
+        __m128i* w1 = (__m128i*)bb->get_submat(n, k, n_pos + 1, 0);
+        __m128i* w2 = (__m128i*)bb->get_submat(n, k, n_pos + 2, 0);
+        __m128i* w3 = (__m128i*)bb->get_submat(n, k, n_pos + 3, 0);
+        const float* s0 = bb->get_scale(n, n_pos + 0, k, 0);
+        const float* s1 = bb->get_scale(n, n_pos + 1, k, 0);
+        const float* s2 = bb->get_scale(n, n_pos + 2, k, 0);
+        const float* s3 = bb->get_scale(n, n_pos + 3, k, 0);
+        __m512 a0 = _mm512_setzero_ps(), a1 = _mm512_setzero_ps(),
+               a2 = _mm512_setzero_ps(), a3 = _mm512_setzero_ps();
+        for (int g = 0; g < kg_count; g++) {
+          const __m512bh a = a_row[g];
+          a0 = _mm512_fmadd_ps(_mm512_set1_ps(s0[g]),
+                               _mm512_dpbf16_ps(_mm512_setzero_ps(), a, (__m512bh)mxfp4_to_bf16_32(w0[g])), a0);
+          a1 = _mm512_fmadd_ps(_mm512_set1_ps(s1[g]),
+                               _mm512_dpbf16_ps(_mm512_setzero_ps(), a, (__m512bh)mxfp4_to_bf16_32(w1[g])), a1);
+          a2 = _mm512_fmadd_ps(_mm512_set1_ps(s2[g]),
+                               _mm512_dpbf16_ps(_mm512_setzero_ps(), a, (__m512bh)mxfp4_to_bf16_32(w2[g])), a2);
+          a3 = _mm512_fmadd_ps(_mm512_set1_ps(s3[g]),
+                               _mm512_dpbf16_ps(_mm512_setzero_ps(), a, (__m512bh)mxfp4_to_bf16_32(w3[g])), a3);
+        }
+        reduce4(a0, a1, a2, a3, c_row + (n_pos - n_start));
+      }
+      for (; n_pos < n_end; n_pos++) {
+        __m128i* w = (__m128i*)bb->get_submat(n, k, n_pos, 0);
+        const float* s = bb->get_scale(n, n_pos, k, 0);
+        __m512 acc = _mm512_setzero_ps();
+        for (int g = 0; g < kg_count; g++) {
+          acc = _mm512_fmadd_ps(_mm512_set1_ps(s[g]),
+                                _mm512_dpbf16_ps(_mm512_setzero_ps(),
+                                                 a_row[g],
+                                                 (__m512bh)mxfp4_to_bf16_32(w[g])),
+                                acc);
+        }
+        c_row[n_pos - n_start] = _mm512_reduce_add_ps(acc);
       }
     }
   }
@@ -131,7 +301,7 @@ inline void mat_mul_kgroup(int m, int n, int k, int k_group_size,
                            std::shared_ptr<GemmKernel224MXFP4SmallKGroup::BufferA> ba,
                            std::shared_ptr<GemmKernel224MXFP4SmallKGroup::BufferB> bb,
                            std::shared_ptr<GemmKernel224MXFP4SmallKGroup::BufferC> bc, int ith, int nth) {
-  GemmKernel224MXFP4SmallKGroup::fp4_mat_vec_kgroup(m, n, k, k_group_size, ba.get(), bb.get(), bc.get(), ith, nth);
+  GemmKernel224MXFP4SmallKGroup::fp4_mat_mat_kgroup(m, n, k, k_group_size, ba.get(), bb.get(), bc.get(), ith, nth);
 }
 
 }  // namespace amx


### PR DESCRIPTION
区分了mat-mat 和 mat-vec的实现， 在avx512下， mat-mat采用4*4 register tile。当单个expert拿到>=4个token时，触发mat-mat，相比mat-vec加速2~3x。
