### PR TITLE
[build]: bump v0.6.1 post1 package metadata

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,11 +19,11 @@ setup(
     ],
     extras_require={
         "sft": [
-            "transformers-kt==5.6.0",
-            "accelerate-kt==1.14.0",
+            "transformers-kt==5.6.0.post1",
+            "accelerate-kt==1.14.0.post1",
         ],
         "sglang": [
-            "sglang-kt>=0.5.3",
+            "sglang-kt==0.6.1.post1",
         ],
     },
 )

--- a/version.py
+++ b/version.py
@@ -3,4 +3,4 @@ KTransformers version information.
 Shared across the top-level package and kt-kernel.
 """
 
-__version__ = "0.6.1"
+__version__ = "0.6.1.post1"


### PR DESCRIPTION
Bump ktransformers/kt-kernel to 0.6.1.post1 and point SFT/SGLang extras at the post1 companion packages.