### PR TITLE
[release] Point sglang extra to sglang-kt post2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
             "accelerate-kt==1.14.0.post1",
         ],
         "sglang": [
-            "sglang-kt==0.6.1.post1",
+            "sglang-kt==0.6.1.post2",
         ],
     },
 )


### PR DESCRIPTION
## Summary
- point ktransformers[sglang] to sglang-kt==0.6.1.post2
- keep SFT extra on transformers-kt/accelerate-kt post1

## Validation
- built mixed post candidate wheels under /home/lpl/kt-v2-final/release-wheels-post1-sglangpost2-20260430
- fresh py312 LLaMA-Factory KT SFT hard command reached 4 ranks and failed only on local/offline Qwen3.5 processor file
- fresh py312 SGLang DeepSeek-V3 hard command passed /model_info and /generate
- inference-only py312 env with kt-kernel post1 + sglang-kt post2 also passed /model_info and /generate

No PyPI upload has been performed.