### PR TITLE
[fix](kt-kernel): fix double mem used by safetensor loader

### DIFF
--- a/kt-kernel/python/utils/amx.py
+++ b/kt-kernel/python/utils/amx.py
@@ -1,7 +1,11 @@
+import gc
+import logging
 import os
 import torch
 import ctypes
 from typing import List, Optional
+
+logger = logging.getLogger(__name__)
 
 # Use relative imports for package structure
 from ..experts_base import BaseMoEWrapper
@@ -394,6 +398,8 @@ class NativeMoEWrapper(BaseMoEWrapper):
     """Wrapper for RAWINT4/FP8/FP8_PERCHANNEL/BF16 experts stored in compressed SafeTensor format."""
 
     _native_loader_instance = None
+    _total_layer_count: int = 0  # Number of NativeMoEWrapper instances created
+    _load_call_count: int = 0    # Number of load_weights() calls completed
 
     def __init__(
         self,
@@ -484,6 +490,36 @@ class NativeMoEWrapper(BaseMoEWrapper):
         self.gate_scales = None
         self.up_scales = None
         self.down_scales = None
+
+        # Track total number of wrapper instances for auto-release logic
+        NativeMoEWrapper._total_layer_count += 1
+
+    @staticmethod
+    def _release_loader():
+        """Release the shared SafeTensor loader singleton and free mmap page cache.
+
+        This is called automatically when all layers have finished load_weights().
+        Counters are reset to 0 to support future hot-reload scenarios.
+        """
+        if NativeMoEWrapper._native_loader_instance is not None:
+            NativeMoEWrapper._native_loader_instance.close_all_handles()
+            NativeMoEWrapper._native_loader_instance = None
+            logger.info(
+                "[KT] Released NativeMoEWrapper loader: all safetensors file handles closed, "
+                "mmap page cache will be reclaimed by OS."
+            )
+        # Reset counters to support hot-reload
+        NativeMoEWrapper._total_layer_count = 0
+        NativeMoEWrapper._load_call_count = 0
+
+    @staticmethod
+    def force_release_loader():
+        """Forcibly release the loader singleton regardless of load completion state.
+
+        This is intended for testing and special scenarios.
+        Bypasses the auto-release counter check and immediately frees the loader.
+        """
+        NativeMoEWrapper._release_loader()
 
     def load_weights_from_tensors(
         self,
@@ -640,6 +676,12 @@ class NativeMoEWrapper(BaseMoEWrapper):
             del self.up_scales
             del self.down_scales
         t6 = time.time()
+
+        # Auto-release loader when all layers have finished loading weights.
+        # This frees the safetensors mmap page cache since C++ engine already has a deep copy.
+        NativeMoEWrapper._load_call_count += 1
+        if NativeMoEWrapper._load_call_count >= NativeMoEWrapper._total_layer_count > 0:
+            NativeMoEWrapper._release_loader()
 
         print(
             f"[NativeMoEWrapper Layer {self.layer_idx}] "

--- a/kt-kernel/python/utils/amx.py
+++ b/kt-kernel/python/utils/amx.py
@@ -398,8 +398,6 @@ class NativeMoEWrapper(BaseMoEWrapper):
     """Wrapper for RAWINT4/FP8/FP8_PERCHANNEL/BF16 experts stored in compressed SafeTensor format."""
 
     _native_loader_instance = None
-    _total_layer_count: int = 0  # Number of NativeMoEWrapper instances created
-    _load_call_count: int = 0    # Number of load_weights() calls completed
 
     def __init__(
         self,
@@ -469,19 +467,7 @@ class NativeMoEWrapper(BaseMoEWrapper):
         )
 
         if NativeMoEWrapper._native_loader_instance is None:
-            if method == "RAWINT4":
-                NativeMoEWrapper._native_loader_instance = CompressedSafeTensorLoader(weight_path)
-            elif method == "FP8":
-                NativeMoEWrapper._native_loader_instance = FP8SafeTensorLoader(weight_path)
-            elif method == "FP8_PERCHANNEL":
-                # Use FP8SafeTensorLoader with per-channel scale format
-                NativeMoEWrapper._native_loader_instance = FP8SafeTensorLoader(weight_path, scale_suffix="weight_scale")
-            elif method == "BF16":
-                NativeMoEWrapper._native_loader_instance = BF16SafeTensorLoader(weight_path)
-            elif method == "GPTQ_INT4":
-                NativeMoEWrapper._native_loader_instance = GPTQSafeTensorLoader(weight_path)
-            else:
-                raise NotImplementedError(f"Unsupported method for NativeMoEWrapper: {method}")
+            NativeMoEWrapper._native_loader_instance = NativeMoEWrapper._create_loader(method, weight_path)
         self.loader = NativeMoEWrapper._native_loader_instance
 
         self.gate_weights = None
@@ -491,26 +477,50 @@ class NativeMoEWrapper(BaseMoEWrapper):
         self.up_scales = None
         self.down_scales = None
 
-        # Track total number of wrapper instances for auto-release logic
-        NativeMoEWrapper._total_layer_count += 1
+    @staticmethod
+    def _create_loader(method: str, weight_path: str):
+        """Create a SafeTensor loader instance based on the quantization method.
+
+        Args:
+            method: Quantization method (RAWINT4, FP8, FP8_PERCHANNEL, BF16, GPTQ_INT4)
+            weight_path: Path to the safetensor files
+
+        Returns:
+            SafeTensorLoader subclass instance
+        """
+        if method == "RAWINT4":
+            return CompressedSafeTensorLoader(weight_path)
+        elif method == "FP8":
+            return FP8SafeTensorLoader(weight_path)
+        elif method == "FP8_PERCHANNEL":
+            return FP8SafeTensorLoader(weight_path, scale_suffix="weight_scale")
+        elif method == "BF16":
+            return BF16SafeTensorLoader(weight_path)
+        elif method == "GPTQ_INT4":
+            return GPTQSafeTensorLoader(weight_path)
+        else:
+            raise NotImplementedError(f"Unsupported method for NativeMoEWrapper: {method}")
 
     @staticmethod
-    def _release_loader():
+    def _release_loader(layer_idx: int = -1):
         """Release the shared SafeTensor loader singleton and free mmap page cache.
 
-        This is called automatically when all layers have finished load_weights().
-        Counters are reset to 0 to support future hot-reload scenarios.
+        Called after each layer's load_weights() completes. The C++ engine already
+        has a deep copy of the weight data (guaranteed by cpu_infer.sync()), so
+        releasing the mmap handles is safe.
         """
         if NativeMoEWrapper._native_loader_instance is not None:
             NativeMoEWrapper._native_loader_instance.close_all_handles()
             NativeMoEWrapper._native_loader_instance = None
-            logger.info(
-                "[KT] Released NativeMoEWrapper loader: all safetensors file handles closed, "
-                "mmap page cache will be reclaimed by OS."
-            )
-        # Reset counters to support hot-reload
-        NativeMoEWrapper._total_layer_count = 0
-        NativeMoEWrapper._load_call_count = 0
+            if layer_idx >= 0:
+                logger.info(
+                    "[KT] Released NativeMoEWrapper loader after layer %d: "
+                    "safetensors mmap handles freed.", layer_idx,
+                )
+            else:
+                logger.info(
+                    "[KT] Released NativeMoEWrapper loader: safetensors mmap handles freed."
+                )
 
     @staticmethod
     def force_release_loader():
@@ -532,6 +542,23 @@ class NativeMoEWrapper(BaseMoEWrapper):
 
     def load_weights(self, physical_to_logical_map_cpu: torch.Tensor):
         import time
+
+        # Recreate loader if it was released by the previous layer's load_weights().
+        # This is expected: each layer releases the loader after loading to free mmap,
+        # and the next layer recreates it on demand.
+        if NativeMoEWrapper._native_loader_instance is None:
+            t_recreate_start = time.time()
+            NativeMoEWrapper._native_loader_instance = NativeMoEWrapper._create_loader(
+                self.method, self.weight_path
+            )
+            self.loader = NativeMoEWrapper._native_loader_instance
+            t_recreate_elapsed = (time.time() - t_recreate_start) * 1000
+            logger.info(
+                "[KT] Recreated NativeMoEWrapper loader for layer %d (took %.1fms)",
+                self.layer_idx, t_recreate_elapsed,
+            )
+        else:
+            self.loader = NativeMoEWrapper._native_loader_instance
 
         t0 = time.time()
         base_key = f"model.layers.{self.layer_idx}"
@@ -677,11 +704,10 @@ class NativeMoEWrapper(BaseMoEWrapper):
             del self.down_scales
         t6 = time.time()
 
-        # Auto-release loader when all layers have finished loading weights.
-        # This frees the safetensors mmap page cache since C++ engine already has a deep copy.
-        NativeMoEWrapper._load_call_count += 1
-        if NativeMoEWrapper._load_call_count >= NativeMoEWrapper._total_layer_count > 0:
-            NativeMoEWrapper._release_loader()
+        # Release loader after each layer to free mmap page cache.
+        # C++ engine already has a deep copy (cpu_infer.sync() guarantees this),
+        # so releasing the mmap handles is safe. Next layer will recreate the loader.
+        NativeMoEWrapper._release_loader(layer_idx=self.layer_idx)
 
         print(
             f"[NativeMoEWrapper Layer {self.layer_idx}] "

--- a/kt-kernel/python/utils/loader.py
+++ b/kt-kernel/python/utils/loader.py
@@ -166,11 +166,17 @@ class SafeTensorLoader:
     def close_all_handles(self):
         """Close all file handles and clear the handle map.
 
-        Note: safetensors.safe_open doesn't have a close() method,
-        so we just clear the references and let garbage collection handle cleanup.
+        Note: safetensors.safe_open doesn't expose a close() method. Releasing
+        the mmap relies on reference counting: once file_handle_map is cleared
+        and no tensor holds a reference to the underlying mmap region, the OS
+        will reclaim the page cache. gc.collect() is called here to trigger
+        immediate reclamation rather than waiting for the next GC cycle.
         """
-        # safetensors.safe_open doesn't have close(), just clear references
+        import gc
+        # Clear all safe_open handle references; their __del__ will unmap the files
         self.file_handle_map.clear()
+        # Force immediate GC so that mmap file descriptors are released promptly
+        gc.collect()
 
     def load_experts(self, base_key: str, device: str = "cpu"):
         """

--- a/kt-kernel/test/test_native_moe_loader_auto_release.py
+++ b/kt-kernel/test/test_native_moe_loader_auto_release.py
@@ -1,8 +1,8 @@
-"""Tests for NativeMoEWrapper auto-release loader mechanism.
+"""Tests for NativeMoEWrapper layerwise mmap-release mechanism.
 
 Verifies that the SafeTensor loader singleton (_native_loader_instance) is
-automatically released after all MoE layers finish load_weights(), and that
-force_release_loader() works correctly at any point.
+released after EACH layer's load_weights() completes (not just after all layers),
+and that the loader is recreated on demand for the next layer.
 
 These tests use mocking so they can run without actual safetensors files or
 compiled kt_kernel_ext binaries.
@@ -14,74 +14,14 @@ import types
 import unittest
 from unittest.mock import MagicMock, patch
 
-# ---------------------------------------------------------------------------
-# Minimal stubs so amx.py can be imported without kt_kernel_ext compiled
-# ---------------------------------------------------------------------------
-
-def _make_kt_kernel_ext_stub():
-    """Return a minimal stub module for kt_kernel_ext."""
-    mod = types.ModuleType("kt_kernel_ext")
-    moe_mod = types.ModuleType("kt_kernel_ext.moe")
-    # MOEConfig stub
-    moe_mod.MOEConfig = MagicMock()
-    mod.moe = moe_mod
-    sys.modules["kt_kernel_ext"] = mod
-    sys.modules["kt_kernel_ext.moe"] = moe_mod
-    return mod
-
-
-def _make_base_stub():
-    """Return a minimal stub for experts_base module."""
-    experts_base = types.ModuleType("experts_base")
-
-    class BaseMoEWrapper:
-        def __init__(self, **kwargs):
-            for k, v in kwargs.items():
-                setattr(self, k, v)
-
-    experts_base.BaseMoEWrapper = BaseMoEWrapper
-    # Register under both possible import paths
-    sys.modules["experts_base"] = experts_base
-    return experts_base
-
-
-def _setup_stubs():
-    _make_kt_kernel_ext_stub()
-    _make_base_stub()
-
-
-_setup_stubs()
-
-# Add python directory to sys.path so we can import amx
-_TEST_DIR = os.path.dirname(__file__)
-_PYTHON_DIR = os.path.join(_TEST_DIR, "..", "python")
-if _PYTHON_DIR not in sys.path:
-    sys.path.insert(0, _PYTHON_DIR)
-
-
-# ---------------------------------------------------------------------------
-# Import the module under test (with mocked kt_kernel_ext)
-# ---------------------------------------------------------------------------
-
-# We need to patch the relative imports inside amx.py before importing
-with patch.dict(sys.modules, {
-    "kt_kernel_ext": sys.modules["kt_kernel_ext"],
-    "kt_kernel_ext.moe": sys.modules["kt_kernel_ext.moe"],
-}):
-    # Patch BaseMoEWrapper used by amx
-    import importlib
-    # Manually set up the package structure so relative imports work
-    utils_pkg = types.ModuleType("utils")
-    sys.modules.setdefault("utils", utils_pkg)
-
-    # We'll test NativeMoEWrapper in isolation via direct patching
-    pass
-
 
 class MockLoader:
     """Minimal mock SafeTensorLoader."""
 
+    _create_count = 0  # Track how many times a loader was created
+
     def __init__(self):
+        MockLoader._create_count += 1
         self.closed = False
         self.file_handle_map = {"dummy.safetensors": object()}
 
@@ -92,178 +32,168 @@ class MockLoader:
 
 class FakeNativeMoEWrapper:
     """
-    A simplified replica of NativeMoEWrapper that isolates the counter/release
-    logic without requiring kt_kernel_ext to be compiled.
+    A simplified replica of NativeMoEWrapper that isolates the
+    layerwise-release + recreate logic without requiring kt_kernel_ext.
     """
 
     _native_loader_instance = None
-    _total_layer_count: int = 0
-    _load_call_count: int = 0
+    # Simulate _create_loader: returns a fresh MockLoader each time
+    _create_loader_calls = 0
 
-    def __init__(self):
-        FakeNativeMoEWrapper._total_layer_count += 1
+    def __init__(self, layer_idx=0):
+        self.layer_idx = layer_idx
+        self.method = "FP8"
+        self.weight_path = "/fake/path"
+
+    def _ensure_loader(self):
+        """Simulate the loader-recreate logic at the start of load_weights."""
+        if FakeNativeMoEWrapper._native_loader_instance is None:
+            FakeNativeMoEWrapper._create_loader_calls += 1
+            FakeNativeMoEWrapper._native_loader_instance = MockLoader()
+        self.loader = FakeNativeMoEWrapper._native_loader_instance
 
     def load_weights(self):
-        """Simulate load_weights completion (counter + auto-release)."""
-        FakeNativeMoEWrapper._load_call_count += 1
-        if FakeNativeMoEWrapper._load_call_count >= FakeNativeMoEWrapper._total_layer_count > 0:
-            FakeNativeMoEWrapper._release_loader()
+        """Simulate load_weights: ensure loader → do work → release loader."""
+        self._ensure_loader()
+        # Simulate: C++ sync + del Python tensors → release
+        FakeNativeMoEWrapper._release_loader(layer_idx=self.layer_idx)
 
     @staticmethod
-    def _release_loader():
+    def _release_loader(layer_idx=-1):
         if FakeNativeMoEWrapper._native_loader_instance is not None:
             FakeNativeMoEWrapper._native_loader_instance.close_all_handles()
             FakeNativeMoEWrapper._native_loader_instance = None
-        FakeNativeMoEWrapper._total_layer_count = 0
-        FakeNativeMoEWrapper._load_call_count = 0
 
     @staticmethod
     def force_release_loader():
         FakeNativeMoEWrapper._release_loader()
 
 
-def _reset_class_state():
-    """Reset FakeNativeMoEWrapper class-level state between tests."""
+def _reset_state():
+    """Reset all test state between tests."""
     FakeNativeMoEWrapper._native_loader_instance = None
-    FakeNativeMoEWrapper._total_layer_count = 0
-    FakeNativeMoEWrapper._load_call_count = 0
+    FakeNativeMoEWrapper._create_loader_calls = 0
+    MockLoader._create_count = 0
 
 
 # ---------------------------------------------------------------------------
 # Test cases
 # ---------------------------------------------------------------------------
 
-class TestAutoReleaseAfterAllLayersLoaded(unittest.TestCase):
-    """Task 3.1 – After N layers all call load_weights, loader becomes None."""
+class TestLayerwiseRelease(unittest.TestCase):
+    """Each layer's load_weights() should release the loader afterwards."""
 
     def setUp(self):
-        _reset_class_state()
+        _reset_state()
 
     def test_single_layer_released_after_load(self):
-        loader = MockLoader()
-        FakeNativeMoEWrapper._native_loader_instance = loader
-
-        w = FakeNativeMoEWrapper()
-        self.assertIsNotNone(FakeNativeMoEWrapper._native_loader_instance)
-
+        w = FakeNativeMoEWrapper(layer_idx=0)
         w.load_weights()
-
         self.assertIsNone(FakeNativeMoEWrapper._native_loader_instance,
-                          "Loader should be None after the single layer loads its weights")
-        self.assertTrue(loader.closed, "close_all_handles() should have been called")
+                          "Loader should be None after single layer loads")
 
-    def test_multiple_layers_released_only_after_last(self):
-        N = 4
-        loader = MockLoader()
-        FakeNativeMoEWrapper._native_loader_instance = loader
-
-        wrappers = [FakeNativeMoEWrapper() for _ in range(N)]
-
-        for i, w in enumerate(wrappers):
+    def test_each_layer_releases_loader(self):
+        """After every layer's load_weights(), the loader should be None."""
+        for i in range(5):
+            w = FakeNativeMoEWrapper(layer_idx=i)
             w.load_weights()
-            if i < N - 1:
-                self.assertIsNotNone(
-                    FakeNativeMoEWrapper._native_loader_instance,
-                    f"Loader should still be alive after layer {i+1}/{N}",
-                )
-            else:
-                self.assertIsNone(
-                    FakeNativeMoEWrapper._native_loader_instance,
-                    "Loader should be released after the last layer",
-                )
+            self.assertIsNone(
+                FakeNativeMoEWrapper._native_loader_instance,
+                f"Loader should be None after layer {i} loads",
+            )
 
-        self.assertTrue(loader.closed)
+    def test_loader_recreated_for_each_layer(self):
+        """Each layer should trigger a loader recreation (since previous layer released it)."""
+        N = 4
+        for i in range(N):
+            w = FakeNativeMoEWrapper(layer_idx=i)
+            w.load_weights()
 
-    def test_counters_reset_to_zero_after_release(self):
-        loader = MockLoader()
-        FakeNativeMoEWrapper._native_loader_instance = loader
-
-        w = FakeNativeMoEWrapper()
-        w.load_weights()
-
-        self.assertEqual(FakeNativeMoEWrapper._total_layer_count, 0,
-                         "_total_layer_count should reset to 0 after release")
-        self.assertEqual(FakeNativeMoEWrapper._load_call_count, 0,
-                         "_load_call_count should reset to 0 after release")
+        # First layer uses the initial loader; layers 1..N-1 recreate it
+        # Total recreations = N - 1 (layer 0 doesn't recreate if loader pre-existed,
+        # but in this test the loader starts as None so all N layers recreate)
+        self.assertEqual(
+            FakeNativeMoEWrapper._create_loader_calls, N,
+            f"Expected {N} loader recreations for {N} layers, "
+            f"got {FakeNativeMoEWrapper._create_loader_calls}",
+        )
 
 
-class TestNoEarlyReleaseBeforeAllLayersLoaded(unittest.TestCase):
-    """Task 3.2 – Loader must NOT be released before all layers finish."""
+class TestLoaderRecreate(unittest.TestCase):
+    """Loader should be recreated when _native_loader_instance is None."""
 
     def setUp(self):
-        _reset_class_state()
+        _reset_state()
 
-    def test_loader_alive_until_last_layer(self):
-        N = 5
+    def test_first_layer_creates_loader(self):
+        w = FakeNativeMoEWrapper(layer_idx=0)
+        w.load_weights()
+        # Loader was created (then released), but the creation happened
+        self.assertGreater(FakeNativeMoEWrapper._create_loader_calls, 0)
+
+    def test_second_layer_recreates_after_first_released(self):
+        w0 = FakeNativeMoEWrapper(layer_idx=0)
+        w0.load_weights()
+        self.assertIsNone(FakeNativeMoEWrapper._native_loader_instance)
+
+        w1 = FakeNativeMoEWrapper(layer_idx=1)
+        w1.load_weights()
+        # Second layer should have recreated the loader
+        self.assertEqual(FakeNativeMoEWrapper._create_loader_calls, 2,
+                         "Both layers should recreate the loader")
+
+    def test_pre_existing_loader_not_recreated(self):
+        """If loader already exists (e.g., from __init__), it should not be recreated."""
         loader = MockLoader()
         FakeNativeMoEWrapper._native_loader_instance = loader
+        initial_create_calls = FakeNativeMoEWrapper._create_loader_calls
 
-        wrappers = [FakeNativeMoEWrapper() for _ in range(N)]
-
-        # Load N-1 layers
-        for w in wrappers[:-1]:
-            w.load_weights()
-
-        self.assertIsNotNone(
-            FakeNativeMoEWrapper._native_loader_instance,
-            "Loader must still be alive when N-1 of N layers have loaded",
-        )
-        self.assertFalse(loader.closed)
-
-        # Load last layer
-        wrappers[-1].load_weights()
-        self.assertIsNone(FakeNativeMoEWrapper._native_loader_instance)
-        self.assertTrue(loader.closed)
+        w = FakeNativeMoEWrapper(layer_idx=0)
+        w._ensure_loader()
+        # No new creation should happen
+        self.assertEqual(FakeNativeMoEWrapper._create_loader_calls, initial_create_calls)
+        self.assertIs(w.loader, loader)
 
 
 class TestForceReleaseLoader(unittest.TestCase):
-    """Task 3.3 – force_release_loader() works at any time."""
+    """force_release_loader() should work at any time."""
 
     def setUp(self):
-        _reset_class_state()
+        _reset_state()
 
     def test_force_release_before_any_load(self):
         loader = MockLoader()
         FakeNativeMoEWrapper._native_loader_instance = loader
 
-        # Create wrappers but don't call load_weights
-        FakeNativeMoEWrapper()
-        FakeNativeMoEWrapper()
-
-        self.assertIsNotNone(FakeNativeMoEWrapper._native_loader_instance)
-
-        # Force release without completing loads
         FakeNativeMoEWrapper.force_release_loader()
 
         self.assertIsNone(FakeNativeMoEWrapper._native_loader_instance)
         self.assertTrue(loader.closed)
-        self.assertEqual(FakeNativeMoEWrapper._total_layer_count, 0)
-        self.assertEqual(FakeNativeMoEWrapper._load_call_count, 0)
 
     def test_force_release_when_loader_is_none(self):
         """force_release_loader() should be safe even if loader is already None."""
         FakeNativeMoEWrapper._native_loader_instance = None
-        # Should not raise
         FakeNativeMoEWrapper.force_release_loader()
         self.assertIsNone(FakeNativeMoEWrapper._native_loader_instance)
 
     def test_force_release_mid_loading(self):
-        N = 4
         loader = MockLoader()
         FakeNativeMoEWrapper._native_loader_instance = loader
 
-        wrappers = [FakeNativeMoEWrapper() for _ in range(N)]
+        # Load first layer
+        w0 = FakeNativeMoEWrapper(layer_idx=0)
+        w0.load_weights()
+        # Loader is now released (each layer releases it)
 
-        # Only load half the layers
-        for w in wrappers[:N // 2]:
-            w.load_weights()
+        # Set a new loader manually
+        loader2 = MockLoader()
+        FakeNativeMoEWrapper._native_loader_instance = loader2
 
-        self.assertIsNotNone(FakeNativeMoEWrapper._native_loader_instance)
-
+        # Force release before next load
         FakeNativeMoEWrapper.force_release_loader()
 
         self.assertIsNone(FakeNativeMoEWrapper._native_loader_instance)
-        self.assertEqual(FakeNativeMoEWrapper._total_layer_count, 0)
+        self.assertTrue(loader2.closed)
 
 
 # ---------------------------------------------------------------------------

--- a/kt-kernel/test/test_native_moe_loader_auto_release.py
+++ b/kt-kernel/test/test_native_moe_loader_auto_release.py
@@ -1,0 +1,274 @@
+"""Tests for NativeMoEWrapper auto-release loader mechanism.
+
+Verifies that the SafeTensor loader singleton (_native_loader_instance) is
+automatically released after all MoE layers finish load_weights(), and that
+force_release_loader() works correctly at any point.
+
+These tests use mocking so they can run without actual safetensors files or
+compiled kt_kernel_ext binaries.
+"""
+
+import sys
+import os
+import types
+import unittest
+from unittest.mock import MagicMock, patch
+
+# ---------------------------------------------------------------------------
+# Minimal stubs so amx.py can be imported without kt_kernel_ext compiled
+# ---------------------------------------------------------------------------
+
+def _make_kt_kernel_ext_stub():
+    """Return a minimal stub module for kt_kernel_ext."""
+    mod = types.ModuleType("kt_kernel_ext")
+    moe_mod = types.ModuleType("kt_kernel_ext.moe")
+    # MOEConfig stub
+    moe_mod.MOEConfig = MagicMock()
+    mod.moe = moe_mod
+    sys.modules["kt_kernel_ext"] = mod
+    sys.modules["kt_kernel_ext.moe"] = moe_mod
+    return mod
+
+
+def _make_base_stub():
+    """Return a minimal stub for experts_base module."""
+    experts_base = types.ModuleType("experts_base")
+
+    class BaseMoEWrapper:
+        def __init__(self, **kwargs):
+            for k, v in kwargs.items():
+                setattr(self, k, v)
+
+    experts_base.BaseMoEWrapper = BaseMoEWrapper
+    # Register under both possible import paths
+    sys.modules["experts_base"] = experts_base
+    return experts_base
+
+
+def _setup_stubs():
+    _make_kt_kernel_ext_stub()
+    _make_base_stub()
+
+
+_setup_stubs()
+
+# Add python directory to sys.path so we can import amx
+_TEST_DIR = os.path.dirname(__file__)
+_PYTHON_DIR = os.path.join(_TEST_DIR, "..", "python")
+if _PYTHON_DIR not in sys.path:
+    sys.path.insert(0, _PYTHON_DIR)
+
+
+# ---------------------------------------------------------------------------
+# Import the module under test (with mocked kt_kernel_ext)
+# ---------------------------------------------------------------------------
+
+# We need to patch the relative imports inside amx.py before importing
+with patch.dict(sys.modules, {
+    "kt_kernel_ext": sys.modules["kt_kernel_ext"],
+    "kt_kernel_ext.moe": sys.modules["kt_kernel_ext.moe"],
+}):
+    # Patch BaseMoEWrapper used by amx
+    import importlib
+    # Manually set up the package structure so relative imports work
+    utils_pkg = types.ModuleType("utils")
+    sys.modules.setdefault("utils", utils_pkg)
+
+    # We'll test NativeMoEWrapper in isolation via direct patching
+    pass
+
+
+class MockLoader:
+    """Minimal mock SafeTensorLoader."""
+
+    def __init__(self):
+        self.closed = False
+        self.file_handle_map = {"dummy.safetensors": object()}
+
+    def close_all_handles(self):
+        self.closed = True
+        self.file_handle_map.clear()
+
+
+class FakeNativeMoEWrapper:
+    """
+    A simplified replica of NativeMoEWrapper that isolates the counter/release
+    logic without requiring kt_kernel_ext to be compiled.
+    """
+
+    _native_loader_instance = None
+    _total_layer_count: int = 0
+    _load_call_count: int = 0
+
+    def __init__(self):
+        FakeNativeMoEWrapper._total_layer_count += 1
+
+    def load_weights(self):
+        """Simulate load_weights completion (counter + auto-release)."""
+        FakeNativeMoEWrapper._load_call_count += 1
+        if FakeNativeMoEWrapper._load_call_count >= FakeNativeMoEWrapper._total_layer_count > 0:
+            FakeNativeMoEWrapper._release_loader()
+
+    @staticmethod
+    def _release_loader():
+        if FakeNativeMoEWrapper._native_loader_instance is not None:
+            FakeNativeMoEWrapper._native_loader_instance.close_all_handles()
+            FakeNativeMoEWrapper._native_loader_instance = None
+        FakeNativeMoEWrapper._total_layer_count = 0
+        FakeNativeMoEWrapper._load_call_count = 0
+
+    @staticmethod
+    def force_release_loader():
+        FakeNativeMoEWrapper._release_loader()
+
+
+def _reset_class_state():
+    """Reset FakeNativeMoEWrapper class-level state between tests."""
+    FakeNativeMoEWrapper._native_loader_instance = None
+    FakeNativeMoEWrapper._total_layer_count = 0
+    FakeNativeMoEWrapper._load_call_count = 0
+
+
+# ---------------------------------------------------------------------------
+# Test cases
+# ---------------------------------------------------------------------------
+
+class TestAutoReleaseAfterAllLayersLoaded(unittest.TestCase):
+    """Task 3.1 – After N layers all call load_weights, loader becomes None."""
+
+    def setUp(self):
+        _reset_class_state()
+
+    def test_single_layer_released_after_load(self):
+        loader = MockLoader()
+        FakeNativeMoEWrapper._native_loader_instance = loader
+
+        w = FakeNativeMoEWrapper()
+        self.assertIsNotNone(FakeNativeMoEWrapper._native_loader_instance)
+
+        w.load_weights()
+
+        self.assertIsNone(FakeNativeMoEWrapper._native_loader_instance,
+                          "Loader should be None after the single layer loads its weights")
+        self.assertTrue(loader.closed, "close_all_handles() should have been called")
+
+    def test_multiple_layers_released_only_after_last(self):
+        N = 4
+        loader = MockLoader()
+        FakeNativeMoEWrapper._native_loader_instance = loader
+
+        wrappers = [FakeNativeMoEWrapper() for _ in range(N)]
+
+        for i, w in enumerate(wrappers):
+            w.load_weights()
+            if i < N - 1:
+                self.assertIsNotNone(
+                    FakeNativeMoEWrapper._native_loader_instance,
+                    f"Loader should still be alive after layer {i+1}/{N}",
+                )
+            else:
+                self.assertIsNone(
+                    FakeNativeMoEWrapper._native_loader_instance,
+                    "Loader should be released after the last layer",
+                )
+
+        self.assertTrue(loader.closed)
+
+    def test_counters_reset_to_zero_after_release(self):
+        loader = MockLoader()
+        FakeNativeMoEWrapper._native_loader_instance = loader
+
+        w = FakeNativeMoEWrapper()
+        w.load_weights()
+
+        self.assertEqual(FakeNativeMoEWrapper._total_layer_count, 0,
+                         "_total_layer_count should reset to 0 after release")
+        self.assertEqual(FakeNativeMoEWrapper._load_call_count, 0,
+                         "_load_call_count should reset to 0 after release")
+
+
+class TestNoEarlyReleaseBeforeAllLayersLoaded(unittest.TestCase):
+    """Task 3.2 – Loader must NOT be released before all layers finish."""
+
+    def setUp(self):
+        _reset_class_state()
+
+    def test_loader_alive_until_last_layer(self):
+        N = 5
+        loader = MockLoader()
+        FakeNativeMoEWrapper._native_loader_instance = loader
+
+        wrappers = [FakeNativeMoEWrapper() for _ in range(N)]
+
+        # Load N-1 layers
+        for w in wrappers[:-1]:
+            w.load_weights()
+
+        self.assertIsNotNone(
+            FakeNativeMoEWrapper._native_loader_instance,
+            "Loader must still be alive when N-1 of N layers have loaded",
+        )
+        self.assertFalse(loader.closed)
+
+        # Load last layer
+        wrappers[-1].load_weights()
+        self.assertIsNone(FakeNativeMoEWrapper._native_loader_instance)
+        self.assertTrue(loader.closed)
+
+
+class TestForceReleaseLoader(unittest.TestCase):
+    """Task 3.3 – force_release_loader() works at any time."""
+
+    def setUp(self):
+        _reset_class_state()
+
+    def test_force_release_before_any_load(self):
+        loader = MockLoader()
+        FakeNativeMoEWrapper._native_loader_instance = loader
+
+        # Create wrappers but don't call load_weights
+        FakeNativeMoEWrapper()
+        FakeNativeMoEWrapper()
+
+        self.assertIsNotNone(FakeNativeMoEWrapper._native_loader_instance)
+
+        # Force release without completing loads
+        FakeNativeMoEWrapper.force_release_loader()
+
+        self.assertIsNone(FakeNativeMoEWrapper._native_loader_instance)
+        self.assertTrue(loader.closed)
+        self.assertEqual(FakeNativeMoEWrapper._total_layer_count, 0)
+        self.assertEqual(FakeNativeMoEWrapper._load_call_count, 0)
+
+    def test_force_release_when_loader_is_none(self):
+        """force_release_loader() should be safe even if loader is already None."""
+        FakeNativeMoEWrapper._native_loader_instance = None
+        # Should not raise
+        FakeNativeMoEWrapper.force_release_loader()
+        self.assertIsNone(FakeNativeMoEWrapper._native_loader_instance)
+
+    def test_force_release_mid_loading(self):
+        N = 4
+        loader = MockLoader()
+        FakeNativeMoEWrapper._native_loader_instance = loader
+
+        wrappers = [FakeNativeMoEWrapper() for _ in range(N)]
+
+        # Only load half the layers
+        for w in wrappers[:N // 2]:
+            w.load_weights()
+
+        self.assertIsNotNone(FakeNativeMoEWrapper._native_loader_instance)
+
+        FakeNativeMoEWrapper.force_release_loader()
+
+        self.assertIsNone(FakeNativeMoEWrapper._native_loader_instance)
+        self.assertEqual(FakeNativeMoEWrapper._total_layer_count, 0)
+
+
+# ---------------------------------------------------------------------------
+# Run directly
+# ---------------------------------------------------------------------------
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
# What does this PR do?
解决当前加载模型后内存占用翻倍的问题。
加载dpsk-v3.2为例
加载前内存占用1.2T左右
<img width="747" height="301" alt="img_v3_02116_6fb3ab4e-660d-46e7-ab76-f93f3825477g" src="https://github.com/user-attachments/assets/b9b681a8-ece5-4aec-9cee-f0f77d40db43" />
修复后内存只占用613G左右
<img width="859" height="282" alt="image" src="https://github.com/user-attachments/assets/e1864984-90a1-4e08-9ded-93d56aab63df" />

Fixes # (issue)

## Before submitting

- [ ] Did you read the [contributor guideline](https://github.com/kvcache-ai/ktransformers/blob/main/.github/CONTRIBUTING.md)?
- [ ] Did you write any new necessary tests?