### PR TITLE
docs(v4-flash): pin transformers==4.57.1 in tutorial prerequisites

### DIFF
--- a/doc/en/DeepSeek-V4-Flash.md
+++ b/doc/en/DeepSeek-V4-Flash.md
@@ -53,7 +53,13 @@ This tutorial demonstrates how to run **DeepSeek-V4-Flash** model inference usin
    ```bash
    pip install --upgrade flashinfer-python flashinfer-cubin
    ```
-   This upgrade is required (even though `sglang-kt` pins `flashinfer_python==0.6.3`) because V4-Flash's MXFP4 MoE module imports `mxfp8_quantize`, `trtllm_fp4_block_scale_routed_moe`, etc., which only exist in flashinfer ≥ 0.6.9; 
+   This upgrade is required (even though `sglang-kt` pins `flashinfer_python==0.6.3`) because V4-Flash's MXFP4 MoE module imports `mxfp8_quantize`, `trtllm_fp4_block_scale_routed_moe`, etc., which only exist in flashinfer ≥ 0.6.9.
+
+4. **transformers==4.57.1** (V4-Flash is incompatible with the 5.x series):
+   ```bash
+   pip install "transformers==4.57.1"
+   ```
+   `transformers` 5.x adds default-valued fields to `PretrainedConfig` that make `DeepSeekV4Config`'s dataclass declaration raise `TypeError: non-default argument 'quantization_config' follows default argument` at import time. `sglang-kt`'s pyproject does not pin `transformers`, so a fresh `pip install` will pull the latest 5.x and break server startup; pinning explicitly to `4.57.1` is required until the upstream fix lands.
 
 
 ## Step 1: Download Model Weights


### PR DESCRIPTION
## Summary

V4-Flash is incompatible with the `transformers` 5.x series. Add a
Prerequisite #4 to `doc/en/DeepSeek-V4-Flash.md` documenting the explicit
`pip install transformers==4.57.1` step alongside the existing flashinfer
override.

## Why

`transformers` 5.x adds default-valued fields to `PretrainedConfig` that
make `DeepSeekV4Config`'s dataclass declaration crash at import time with:

\`\`\`
TypeError: non-default argument 'quantization_config' follows default argument
\`\`\`

`sglang-kt`'s pyproject does not pin `transformers`, so a fresh
\`pip install sglang-kt\` will pull the latest 5.x and break server startup.

## Repro

Fresh venv (Python 3.10 or 3.11):

\`\`\`bash
python -m venv /tmp/v_repro && source /tmp/v_repro/bin/activate
pip install sglang-kt          # pip resolves transformers to 5.7.0
python -c "from sglang.srt.configs.deepseek_v4 import DeepSeekV4Config"
# -> TypeError: non-default argument 'quantization_config' follows default argument

pip install "transformers==4.57.1"
python -c "from sglang.srt.configs.deepseek_v4 import DeepSeekV4Config; print('OK')"
# -> OK
\`\`\`

Same traceback also reproduced independently on a separate consumer-Blackwell
host (Python 3.11 / conda env).

## Followup (out of scope for this PR)

Pinning `transformers` properly belongs in `sglang-kt`'s pyproject so a
fresh \`pip install\` does the right thing without the user having to read
the tutorial. Tracking that as a sglang-kt followup.