### PR TITLE
[fix]: add guard for SFT MoE and remove guard for AMX FP4 MoE on AVX512F+BW

### DIFF
--- a/kt-kernel/ext_bindings.cpp
+++ b/kt-kernel/ext_bindings.cpp
@@ -789,10 +789,9 @@ PYBIND11_MODULE(kt_kernel_ext, m) {
   bind_moe_module<AMX_BF16_MOE_TP<amx::GemmKernel224BF16>>(moe_module, "AMXBF16_MOE");
   bind_moe_module<AMX_FP8_MOE_TP<amx::GemmKernel224FP8>>(moe_module, "AMXFP8_MOE");
   bind_moe_module<AMX_FP8_PERCHANNEL_MOE_TP<amx::GemmKernel224FP8PerChannel>>(moe_module, "AMXFP8PerChannel_MOE");
-#endif
-#if defined(__AVX512BF16__)
   bind_moe_module<AMX_FP4_MOE_TP<amx::GemmKernel224MXFP4SmallKGroup>>(moe_module, "AMXFP4_KGroup_MOE");
 #endif
+#if defined(__AVX512BF16__)
   // SFT MoE with LoRA support (BF16, INT8, INT4, AWQ, K2)
   bind_moe_sft_module<AMX_SFT_MOE_TP<amx::GemmKernel224BF>>(moe_module, "AMXBF16_SFT_MOE");
   bind_moe_sft_module<AMX_SFT_MOE_TP<amx::GemmKernel224Int8>>(moe_module, "AMXInt8_SFT_MOE");
@@ -812,6 +811,7 @@ PYBIND11_MODULE(kt_kernel_ext, m) {
   //     moe_module, "AMXInt4_1KGroup_SFT_MOE_SkipLoRA");
   // bind_moe_sft_module<AMX_SFT_MOE_TP<amx::GemmKernel224Int4SmallKGroup, AMX_K2_MOE_TP, true>>(
   //     moe_module, "AMXInt4_KGroup_SFT_MOE_SkipLoRA");
+#endif
 #endif
 // AVX2 backends — available on all x86_64 (no AMX/AVX512 requirement)
 #if defined(__x86_64__)


### PR DESCRIPTION
# What does this PR do?

Currently, building `kt-kernel` fails on AVX512 CPUs without AVX512-BF16 due to the use of BF16 intrinsics without fallbacks in the LoRA SFT kernels (e.g. `_mm512_cvtne2ps_pbh`), which currently aren't guarded behind AVX512-BF16.  Furthermore, the current guards in `ext_bindings.cpp` require AVX512-BF16 for MXFP4 support. However, the only BF16 intrinsic used in the MXFP4 kernels, `_mm512_dpbf16_ps`, already has a fallback for AVX512F+BW implemented, so these work on AVX512F+BW CPUs out of the box without additional porting needed.

Accordingly, this PR guards the SFT modules behind the AVX512BF16 flag, and removes the AVX512BF16 guard on the MXFP4 kernels (relaxing it to all AVX512F CPUs). This now builds on a machine with 2x Xeon Platinum 8175m (Skylake-SP, AVX512F+BW but no VBMI, VNNI, nor BF16) and an RTX 5090. I tested running DeepSeek V4 Flash via the MXFP4 AMX backend, which seems to work fine (~18 tokens per second). I also ran the tests under `kt-kernel/examples/test_fp4_moe_amx.py`, which yields the following:

```
=== Case vs. Relative Error Summary ===
Case                  qlen path           Mean        Max        Min
uniform_scale            1 mat-vec       0.52%      0.61%      0.43%
alternating_scale        1 mat-vec       1.88%      5.65%      0.00%
ramp_scale               1 mat-vec       0.35%      0.53%      0.00%
random                   1 mat-vec       0.59%      0.59%      0.59%
uniform_scale           32 mat-mat       0.19%      0.21%      0.16%
alternating_scale       32 mat-mat       0.57%      0.78%      0.30%
ramp_scale              32 mat-mat       0.29%      0.38%      0.19%
random                  32 mat-mat       0.58%      0.58%      0.58%
```

## Before submitting

- [x] Did you read the [contributor guideline](https://github.com/kvcache-ai/ktransformers/blob/main/.github/CONTRIBUTING.md)?
- [ ] Did you write any new necessary tests?