### PR TITLE
[release]: 0.6.2.post2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
             "accelerate-kt==1.14.0.post1",
         ],
         "sglang": [
-            "sglang-kt==0.6.2.post1",
+            "sglang-kt==0.6.2.post2",
         ],
     },
 )

--- a/version.py
+++ b/version.py
@@ -3,4 +3,4 @@ KTransformers version information.
 Shared across the top-level package and kt-kernel.
 """
 
-__version__ = "0.6.2.post1"
+__version__ = "0.6.2.post2"


### PR DESCRIPTION
## Summary

Cuts ktransformers **0.6.2.post2**. Bumps the `sglang` submodule from `c9edb75e0` → `43ed1ec77` and pins `sglang-kt==0.6.2.post2`.

## sglang-kt changes since 0.6.2.post1

- `6ac4f82e8` fix(v4-flash): bundle V4-2604B SwiGLU clamp + hybrid SWA chunked-prefill hang fix (sglang-kt #44)
  - Applies the SwiGLU clamp on the triton-kernels GPU MoE path so V4-2604B (`swiglu_limit=10.0`) doesn't drift on GPU prefill.
  - Fixes the hybrid SWA chunked-prefill KV-pool leak/hang that fired whenever a prompt spanned multiple chunks and the request then went idle.
- `43ed1ec77` refactor(dsv4): isolate DeepSeek V4 Flash behind plugin registries (sglang-kt #47)
  - Moves the DSV4-specific surface (model registration, MoE kernel selection, kt-EP wrapper hooks) behind plugin registries so the base sglang code paths stay V4-agnostic.

## Files changed

- `third_party/sglang` — pointer bump only
- `version.py` — `0.6.2.post1` → `0.6.2.post2`
- `setup.py` — `sglang-kt==0.6.2.post1` → `sglang-kt==0.6.2.post2`

## Test plan

- [ ] `pip install ktransformers[sglang]==0.6.2.post2` resolves the matching `sglang-kt` and `kt-kernel` wheels
- [ ] V4-Flash hybrid run with multi-chunk prefill (`--chunked-prefill-size` < prompt length) finishes cleanly without `token_to_kv_pool_allocator memory leak`
- [ ] V4-2604B GPU prefill output remains coherent (SwiGLU clamp active)