### PR TITLE
[fix] Add runtime AMX BF16 check 

### DIFF
--- a/kt-kernel/python/utils/amx.py
+++ b/kt-kernel/python/utils/amx.py
@@ -769,7 +769,7 @@ class NativeMoEWrapper(BaseMoEWrapper):
         elif self.method == "BF16":
             # BF16 has no quantization config needed
             # Prefer AMX backend, fall back to AVX2
-            if _HAS_BF16_SUPPORT:
+            if _HAS_BF16_SUPPORT and _host_has_cpu_flag("amx_bf16"):  
                 self.moe = AMXBF16_MOE(moe_config)
             else:
                 self.moe = AVX2BF16_MOE(moe_config)


### PR DESCRIPTION
                                                                                                                                                                                        
  ## Description                                                                                                                                                                                            
                                                                                                                                                                                                            
  -kt-method BF16 crashes with SIGILL on CPUs without AMX (e.g. Xeon Gold 6230, Cascade Lake)                                                                                                               
  because AMXBF16_MOE is selected based only on compile-time _HAS_BF16_SUPPORT, without                                                                                                                  checking runtime CPU support.                                                                                                                                                                             
                                                                                                                                                                                                            
  ## Change                                                                                                                                                                                                 
                                                                                                                                                                                                            
  Add _host_has_cpu_flag("amx_bf16") runtime check in amx.py:772, so that BF16 inference                                                                                                                    
  falls back to AVX2BF16_MOE on pre-Sapphire Rapids CPUs. This matches the same pattern                                                                                                                   
  already used by _select_gptq_int4_backend().

# What does this PR do?

Fixes # (issue)

## Before submitting

- [ ] Did you read the [contributor guideline](https://github.com/kvcache-ai/ktransformers/blob/main/.github/CONTRIBUTING.md)?
- [ ] Did you write any new necessary tests?