### PR TITLE
[fix](kt-kernel): enable -mavx512vl for AVX512_VBMI/BF16 multi-variant builds

### DIFF
--- a/kt-kernel/CMakeLists.txt
+++ b/kt-kernel/CMakeLists.txt
@@ -291,6 +291,14 @@ elseif(CMAKE_OSX_ARCHITECTURES STREQUAL "x86_64" OR CMAKE_GENERATOR_PLATFORM_LWR
         if(LLAMA_AVX512_BF16)
             list(APPEND ARCH_FLAGS -mavx512bf16)
         endif()
+        # AVX512_VL+BW is required by operators/amx/la/avx_kernels.hpp
+        # (_mm256_maskz_loadu_epi16 family). BW is already in LLAMA_AVX512;
+        # VL is only added by LLAMA_AVX512_FANCY_SIMD, which the
+        # multi-variant build path never enables. Pull it in here whenever
+        # a variant that uses this code path is active.
+        if(LLAMA_AVX512_VBMI OR LLAMA_AVX512_BF16)
+            list(APPEND ARCH_FLAGS -mavx512vl)
+        endif()
     endif()
 elseif(${CMAKE_SYSTEM_PROCESSOR} MATCHES "ppc64")
     message(STATUS "PowerPC detected")

--- a/kt-kernel/CMakeLists.txt
+++ b/kt-kernel/CMakeLists.txt
@@ -272,7 +272,13 @@ elseif(CMAKE_OSX_ARCHITECTURES STREQUAL "x86_64" OR CMAKE_GENERATOR_PLATFORM_LWR
             list(APPEND ARCH_FLAGS -mavx2 -mfma -msse3 -mf16c)
         endif()
         if(LLAMA_AVX512)
-            list(APPEND ARCH_FLAGS -mavx512f -mavx512bw -mavx512dq -mfma -mf16c -msse3)
+            # AVX512_VL is required by operators/amx/la/avx_kernels.hpp (pulled in
+            # via ext_bindings.cpp -> operators/amx/sft_moe.hpp), which uses the
+            # 256-bit mask intrinsics (_mm256_maskz_loadu_epi16 family). Keep it
+            # in the base block alongside BW/DQ so every AVX512 variant that
+            # includes that header builds, not just VBMI/BF16. This excludes no
+            # hardware the block did not already exclude: KNL/KNM lack BW/DQ.
+            list(APPEND ARCH_FLAGS -mavx512f -mavx512bw -mavx512dq -mavx512vl -mfma -mf16c -msse3)
         endif()
         if(LLAMA_AVX512_VBMI)
             list(APPEND ARCH_FLAGS -mavx512vbmi)
@@ -290,14 +296,6 @@ elseif(CMAKE_OSX_ARCHITECTURES STREQUAL "x86_64" OR CMAKE_GENERATOR_PLATFORM_LWR
         endif()
         if(LLAMA_AVX512_BF16)
             list(APPEND ARCH_FLAGS -mavx512bf16)
-        endif()
-        # AVX512_VL+BW is required by operators/amx/la/avx_kernels.hpp
-        # (_mm256_maskz_loadu_epi16 family). BW is already in LLAMA_AVX512;
-        # VL is only added by LLAMA_AVX512_FANCY_SIMD, which the
-        # multi-variant build path never enables. Pull it in here whenever
-        # a variant that uses this code path is active.
-        if(LLAMA_AVX512_VBMI OR LLAMA_AVX512_BF16)
-            list(APPEND ARCH_FLAGS -mavx512vl)
         endif()
     endif()
 elseif(${CMAKE_SYSTEM_PROCESSOR} MATCHES "ppc64")

--- a/kt-kernel/CMakeLists.txt
+++ b/kt-kernel/CMakeLists.txt
@@ -272,12 +272,6 @@ elseif(CMAKE_OSX_ARCHITECTURES STREQUAL "x86_64" OR CMAKE_GENERATOR_PLATFORM_LWR
             list(APPEND ARCH_FLAGS -mavx2 -mfma -msse3 -mf16c)
         endif()
         if(LLAMA_AVX512)
-            # AVX512_VL is required by operators/amx/la/avx_kernels.hpp (pulled in
-            # via ext_bindings.cpp -> operators/amx/sft_moe.hpp), which uses the
-            # 256-bit mask intrinsics (_mm256_maskz_loadu_epi16 family). Keep it
-            # in the base block alongside BW/DQ so every AVX512 variant that
-            # includes that header builds, not just VBMI/BF16. This excludes no
-            # hardware the block did not already exclude: KNL/KNM lack BW/DQ.
             list(APPEND ARCH_FLAGS -mavx512f -mavx512bw -mavx512dq -mavx512vl -mfma -mf16c -msse3)
         endif()
         if(LLAMA_AVX512_VBMI)


### PR DESCRIPTION
> ## Update (2026-05-25, after review)
>
> Per @gemini-code-assist's suggestion, `-mavx512vl` now lives in the base
> `LLAMA_AVX512` block and the narrow `VBMI OR BF16` guard is removed
> (commit `1887a50`). Rebuilding all six variants confirms the `avx512_base`,
> `avx512_vnni` and `amx` variants were indeed missing VL and now carry it
> (`avx512_vbmi`/`avx512_bf16` come out byte-identical). This excludes no
> hardware the base block did not already exclude — KNL/KNM lack the BW/DQ that
> the block already mandates. The "Proposed fix" diff below shows the original
> narrow patch; the latest commit supersedes it.

---

# kt-kernel: multi-variant build misses `-mavx512vl` for AVX512_VBMI / AVX512_BF16 variants

**Status:** Private draft — not yet submitted upstream.
**Target:** [kvcache-ai/ktransformers](https://github.com/kvcache-ai/ktransformers), `kt-kernel/` subproject.
**Discovered while building from source at commit:** `95e20f9` (master, 2026-05-17 check-out).
**Type:** Bug fix.

---

## Summary

When building `kt-kernel` with `CPUINFER_BUILD_ALL_VARIANTS=1`, the
`AVX512_VBMI` and `AVX512_BF16` variants fail to compile with a
`target specific option mismatch` error on intrinsics such as
`_mm256_maskz_loadu_epi16` and `_mm256_mask_storeu_epi16`.

Root cause: the only place in `kt-kernel/CMakeLists.txt` that adds
`-mavx512vl` to `ARCH_FLAGS` is the `LLAMA_AVX512_FANCY_SIMD` branch,
which the multi-variant build path in `setup.py` never enables. The
affected source file (`operators/amx/la/avx_kernels.hpp`) uses
AVX512 VL+BW intrinsics, so its inclusion in the higher variants
fails on any compiler that strictly checks target features (verified
with GCC 14.2/14.3).

A two-line CMake guard fixes this: enable `-mavx512vl` whenever a
variant that pulls in the VL-using code path is active.

---

## Steps to reproduce

On any Linux x86_64 build host with GCC >= 13 (verified with conda-forge
gcc 14.3.0 on Debian 13 / LMDE 7, host CPU AMD EPYC 9654):

```bash
git clone https://github.com/kvcache-ai/ktransformers
cd ktransformers/kt-kernel

# Activate a Python env with build-time deps (cmake, pybind11, etc.)
# Build CUDA toolkit must be available (conda-forge or system).

CPUINFER_BUILD_ALL_VARIANTS=1 CPUINFER_VERBOSE=1 \
    python -m pip install . --no-deps
```

The build proceeds through `AVX2`, `AVX512_BASE`, and `AVX512_VNNI`
variants, then fails when starting the `AVX512_VBMI` variant.

## Expected behavior

All 6 variants build successfully (per the multi-variant block in
`setup.py:259-425`):

- `_kt_kernel_ext_avx2.cpython-*.so`
- `_kt_kernel_ext_avx512_base.cpython-*.so`
- `_kt_kernel_ext_avx512_vnni.cpython-*.so`
- `_kt_kernel_ext_avx512_vbmi.cpython-*.so`
- `_kt_kernel_ext_avx512_bf16.cpython-*.so`
- `_kt_kernel_ext_amx.cpython-*.so`

## Actual behavior

Compile fails on the AVX512_VBMI variant. Excerpt from the build log:

```
======================================================================
Building AVX512_VBMI variant (AVX512F+VNNI+VBMI)
======================================================================
...
In file included from .../ext_bindings.cpp:22,
                 from .../operators/amx/sft_moe.hpp:...:
/usr/lib/gcc/x86_64-linux-gnu/14/include/avx512vlbwintrin.h:385:1:
  error: inlining failed in call to 'always_inline'
  '__m256i _mm256_maskz_loadu_epi16(__mmask16, const void*)':
  target specific option mismatch
  385 | _mm256_maskz_loadu_epi16 (__mmask16 __U, void const *__P)
      | ^~~~~~~~~~~~~~~~~~~~~~~~

/usr/lib/gcc/x86_64-linux-gnu/14/include/avx512vlbwintrin.h:4005:1:
  error: inlining failed in call to 'always_inline'
  'void _mm256_mask_storeu_epi16(void*, __mmask16, __m256i)':
  target specific option mismatch
  4005 | _mm256_mask_storeu_epi16 (void *__P, __mmask16 __U, __m256i __A)
       | ^~~~~~~~~~~~~~~~~~~~~~~~
```

The `AVX512_BF16` variant fails identically immediately after.

## Root cause

The intrinsics `_mm256_maskz_loadu_epi16` and `_mm256_mask_storeu_epi16`
require both `AVX512_BW` (Byte/Word) and `AVX512_VL` (Vector Length)
to be enabled at the compiler level.

In `kt-kernel/CMakeLists.txt`, the GCC/Clang branch sets:

- `LLAMA_AVX512=ON` → adds `-mavx512f -mavx512bw -mavx512dq -mfma -mf16c -msse3` (line 275)
- `LLAMA_AVX512_VBMI=ON` → adds `-mavx512vbmi` (line 278)
- `LLAMA_AVX512_VNNI=ON` → adds `-mavx512vnni` (line 281)
- `LLAMA_AVX512_BF16=ON` → adds `-mavx512bf16` (line 292)
- `LLAMA_AVX512_FANCY_SIMD=ON` → adds `-mavx512vl -mavx512bw -mavx512dq -mavx512vnni -mavx512vpopcntdq` (lines 283-289)

`AVX512_BW` is therefore enabled by the base `LLAMA_AVX512` option, but
**`AVX512_VL` is only enabled by `LLAMA_AVX512_FANCY_SIMD`**.

The multi-variant build (`setup.py::build_multi_variants`, lines
259-425) sets per-variant environment variables:

```python
{
    "name": "avx512_vbmi",
    "env": {
        "CPUINFER_ENABLE_AVX512": "ON",
        "CPUINFER_ENABLE_AVX512_VNNI": "ON",
        "CPUINFER_ENABLE_AVX512_VBMI": "ON",
        "CPUINFER_ENABLE_AVX512_BF16": "OFF",
        "CPUINFER_ENABLE_AMX": "OFF",
    },
},
```

These are forwarded to CMake by `_build_single_variant_impl`
(setup.py:442+), which calls `_forward_bool_env(...)` for each. There
is no `CPUINFER_ENABLE_AVX512_FANCY_SIMD` mapping and the multi-variant
loop never sets `-DLLAMA_AVX512_FANCY_SIMD=ON`. As a result,
`-mavx512vl` is never passed for the VBMI/BF16/AMX variants.

Meanwhile, `operators/amx/la/avx_kernels.hpp:1171` defines
`avx::lora_fp32_bf16_fused_add_transposed`, which uses
`_mm256_maskz_loadu_epi16` / `_mm256_mask_storeu_epi16`. This file is
included indirectly via `ext_bindings.cpp:22 → operators/amx/sft_moe.hpp`,
and it gets compiled into the higher-tier variants. GCC then refuses
the intrinsics because the active `-m` flags don't enable `AVX512_VL`.

## Proposed fix

Add a minimal CMake guard that enables `-mavx512vl` whenever a variant
that pulls in this code path is active. AVX512_VL is universally
available on every CPU that supports VBMI or BF16 (Ice Lake / Tiger
Lake / Zen 4 / Sapphire Rapids and newer), so this does not exclude
any real-world hardware.

```diff
--- a/kt-kernel/CMakeLists.txt
+++ b/kt-kernel/CMakeLists.txt
@@ -291,6 +291,13 @@ elseif(CMAKE_OSX_ARCHITECTURES STREQUAL "x86_64" OR CMAKE_GENERATOR_PLATFORM_LWR
         if(LLAMA_AVX512_BF16)
             list(APPEND ARCH_FLAGS -mavx512bf16)
         endif()
+        # AVX512_VL is required by operators/amx/la/avx_kernels.hpp (included
+        # via ext_bindings.cpp -> operators/amx/sft_moe.hpp) which uses
+        # _mm256_maskz_loadu_epi16 and similar intrinsics. AVX512_BW is
+        # already enabled by LLAMA_AVX512, but AVX512_VL is otherwise only
+        # added by LLAMA_AVX512_FANCY_SIMD, which the multi-variant build
+        # (CPUINFER_BUILD_ALL_VARIANTS=1) never sets.
+        if(LLAMA_AVX512_VBMI OR LLAMA_AVX512_BF16)
+            list(APPEND ARCH_FLAGS -mavx512vl)
+        endif()
     endif()
 elseif(${CMAKE_SYSTEM_PROCESSOR} MATCHES "ppc64")
     message(STATUS "PowerPC detected")
```

## Verification

After applying the patch:

```bash
CPUINFER_FORCE_REBUILD=1 CPUINFER_BUILD_ALL_VARIANTS=1 CPUINFER_VERBOSE=1 \
    python -m pip install . --no-deps
```

Expected output ends with `✓ All 6 variants built successfully!` and
the resulting `.so` files appear in `<site-packages>/kt_kernel/`:

```
_kt_kernel_ext_amx.cpython-313-x86_64-linux-gnu.so          (5.7 MB)
_kt_kernel_ext_avx2.cpython-313-x86_64-linux-gnu.so         (3.3 MB)
_kt_kernel_ext_avx512_base.cpython-313-x86_64-linux-gnu.so  (4.3 MB)
_kt_kernel_ext_avx512_bf16.cpython-313-x86_64-linux-gnu.so  (5.7 MB)
_kt_kernel_ext_avx512_vbmi.cpython-313-x86_64-linux-gnu.so  (4.3 MB)
_kt_kernel_ext_avx512_vnni.cpython-313-x86_64-linux-gnu.so  (4.3 MB)
```

Runtime check (CPU dispatcher picks the highest applicable variant for
the host):

```bash
python -c "import kt_kernel; print(kt_kernel.__cpu_variant__)"
# On AMD EPYC 9654 (Zen 4): avx512_bf16
# On Intel Sapphire Rapids+: amx
# On Cascade Lake:            avx512_vnni
# ...
```

## Impact

Affects everyone building `kt-kernel` with
`CPUINFER_BUILD_ALL_VARIANTS=1` on a stricter modern compiler (GCC 13+,
clang 16+). Single-variant builds that go through the historical
`FANCY` profile (which does set `LLAMA_AVX512_FANCY_SIMD=ON`,
setup.py:106) are unaffected.

This matters in practice because the documented way to produce a
distribution-friendly build with runtime CPU detection is exactly
`CPUINFER_BUILD_ALL_VARIANTS=1` — that is the path that currently
breaks.

## Backwards compatibility

- The guard only fires inside the GCC/Clang branch of the existing
  AVX512 setup. The MSVC branch (`if(LLAMA_AVX512)` at line 223) is
  untouched.
- Adding `-mavx512vl` has no effect on CPUs that already enable it
  through other flags (idempotent).
- VL is implied by every CPU that has VBMI/BF16 in shipping hardware,
  so there is no realistic platform on which this would exclude a
  user.

## Tests

`kt-kernel` does not ship a CI matrix that covers
`CPUINFER_BUILD_ALL_VARIANTS=1` on GCC 13+, which is why this slipped
through. Suggested follow-up: add at least one CI job that runs
`CPUINFER_BUILD_ALL_VARIANTS=1` on Ubuntu 24.04 (GCC 13.x default) to
prevent regression.

## Related

- `kt-kernel/setup.py:106` — `FANCY` build-profile string, the only
  current way to get `LLAMA_AVX512_FANCY_SIMD=ON`.
- `kt-kernel/setup.py:259-425` — `build_multi_variants()`.
- `kt-kernel/setup.py:442+` — `_build_single_variant_impl()`, where
  `CPUINFER_ENABLE_*` are forwarded to `-DLLAMA_*`.
- `kt-kernel/CMakeLists.txt:283-289` — the `LLAMA_AVX512_FANCY_SIMD`
  block, the existing single source of `-mavx512vl`.
- `kt-kernel/operators/amx/la/avx_kernels.hpp:1171` —
  `lora_fp32_bf16_fused_add_transposed`, the function that triggers
  the failure.

