### PR TITLE
[fix](cli): detect SGLANG_DSV4_2604_SUBMODE conflict before launch

### DIFF
--- a/kt-kernel/python/cli/commands/doctor.py
+++ b/kt-kernel/python/cli/commands/doctor.py
@@ -438,7 +438,7 @@ def doctor(
     # 8. Potentially conflicting environment variables
     # Only surface a row when the variable is actually present; no noise otherwise.
     dsv4_submode = os.environ.get("SGLANG_DSV4_2604_SUBMODE")
-    if dsv4_submode is not None:
+    if dsv4_submode:
         checks.append(
             {
                 "name": "Env: SGLANG_DSV4_2604_SUBMODE",

--- a/kt-kernel/python/cli/commands/doctor.py
+++ b/kt-kernel/python/cli/commands/doctor.py
@@ -435,7 +435,25 @@ def doctor(
             }
         )
 
-    # 8. Environment managers
+    # 8. Potentially conflicting environment variables
+    # Only surface a row when the variable is actually present; no noise otherwise.
+    dsv4_submode = os.environ.get("SGLANG_DSV4_2604_SUBMODE")
+    if dsv4_submode is not None:
+        checks.append(
+            {
+                "name": "Env: SGLANG_DSV4_2604_SUBMODE",
+                "status": "warning" if dsv4_submode == "2604B" else "ok",
+                "value": dsv4_submode,
+                "hint": (
+                    "Intended for MXFP4 launches only. "
+                    "Causes a startup crash when kt-method is not MXFP4. Unset it if unused."
+                    if dsv4_submode == "2604B"
+                    else None
+                ),
+            }
+        )
+
+    # 9. Environment managers
     env_managers = detect_env_managers()
     docker = check_docker()
     env_list = [f"{m.name} {m.version}" for m in env_managers]

--- a/kt-kernel/python/cli/commands/run.py
+++ b/kt-kernel/python/cli/commands/run.py
@@ -506,6 +506,11 @@ def _run_impl(
     if isinstance(inference_env, dict):
         env.update({k: str(v) for k, v in inference_env.items()})
 
+    # Fail fast if a conflicting env var would crash sglang during model loading.
+    # Check against the fully-assembled env dict (shell + kt config settings) so
+    # nothing slips through regardless of where the variable was set.
+    _check_conflicting_env_vars(final_kt_method, env)
+
     # Step 5: Show configuration summary
     console.print()
     print_step("Configuration")
@@ -576,6 +581,26 @@ def _run_impl(
 
 # Dead code removed: _find_model_path() and _find_weights_path()
 # These functions were part of the old builtin model system
+
+
+def _check_conflicting_env_vars(kt_method: str, env: dict) -> None:
+    """Exit early if environment variables conflict with the chosen kt-method.
+
+    Receives the fully-assembled subprocess env dict (shell + kt config settings)
+    so that variables injected via inference.env or advanced.env are also caught.
+    Catches copy-paste mistakes such as keeping SGLANG_DSV4_2604_SUBMODE=2604B
+    in the shell after switching from a MXFP4 launch to another method.
+    """
+    dsv4_submode = env.get("SGLANG_DSV4_2604_SUBMODE", "")
+    if dsv4_submode == "2604B" and kt_method.upper() != "MXFP4":
+        print_error(
+            f"SGLANG_DSV4_2604_SUBMODE=2604B is set but kt-method is "
+            f"{kt_method!r} (not MXFP4). "
+            f"This will raise a ValueError during model loading. "
+            f"Either unset the variable (unset SGLANG_DSV4_2604_SUBMODE) "
+            f"or switch to --kt-method MXFP4."
+        )
+        raise typer.Exit(1)
 
 
 def _build_sglang_command(

--- a/kt-kernel/python/cli/commands/run.py
+++ b/kt-kernel/python/cli/commands/run.py
@@ -592,7 +592,7 @@ def _check_conflicting_env_vars(kt_method: str, env: dict) -> None:
     in the shell after switching from a MXFP4 launch to another method.
     """
     dsv4_submode = env.get("SGLANG_DSV4_2604_SUBMODE", "")
-    if dsv4_submode == "2604B" and kt_method.upper() != "MXFP4":
+    if dsv4_submode == "2604B" and (not kt_method or kt_method.upper() != "MXFP4"):
         print_error(
             f"SGLANG_DSV4_2604_SUBMODE=2604B is set but kt-method is "
             f"{kt_method!r} (not MXFP4). "


### PR DESCRIPTION
Fixes #2013

## What does this PR do?

`SGLANG_DSV4_2604_SUBMODE=2604B` is a DeepSeek-V4-Flash submode flag that
injects `swiglu_limit=10.0` into MoE layers. kt-kernel only supports this on
the MXFP4 backend. If it is left in the environment from a previous MXFP4
launch and the user switches to another method (e.g. AMXINT4), startup crashes
with a cryptic ValueError deep in model loading -- after 150+ seconds of weight
loading has already completed.

This PR adds two layers of detection inside the CLI:

- `kt run`: after the subprocess env dict is fully assembled (shell +
  `advanced.env` + `inference.env` from kt config), check for the conflict and
  exit immediately with a clear error message before sglang is ever launched.
- `kt doctor`: surface `SGLANG_DSV4_2604_SUBMODE` as a WARNING row in the
  diagnostics table whenever it is set to `2604B`, so users can catch the
  conflict proactively.

Note: users who invoke `python -m sglang.launch_server` directly are not
affected by the `kt run` guard, but the existing error message in
`experts.py` already handles that path clearly.

## Before submitting

- [x] Did you read the [contributor guideline](https://github.com/kvcache-ai/ktransformers/blob/main/.github/CONTRIBUTING.md)?
- [ ] Did you write any new necessary tests?