### PR TITLE
[fix(docker)]: build fine-tune env from source instead of the unpublished release wheel

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -29,12 +29,12 @@ ARG UBUNTU_MIRROR
 ARG GITHUB_ARTIFACTORY=github.com
 ARG FLASHINFER_VERSION=0.5.3
 
-# ktransformers wheel version (cu128torch28 for CUDA 12.8 + PyTorch 2.8)
-ARG KTRANSFORMERS_VERSION=0.5.3
-ARG KTRANSFORMERS_WHEEL=ktransformers-0.5.3+cu128torch28fancy-cp312-cp312-linux_x86_64.whl
+# ktransformers is installed from the cloned source tree (see below); no
+# prebuilt wheel is downloaded because the release assets are not published.
 
-# flash_attn wheel for fine-tune env
-ARG FLASH_ATTN_WHEEL=flash_attn-2.8.3+cu12torch2.8cxx11abiTRUE-cp312-cp312-linux_x86_64.whl
+# flash_attn wheel for fine-tune env (torch 2.9 build to match the torch pin below
+# and the torch==2.9.1 requirement of kt-kernel pulled in by ktransformers[sft])
+ARG FLASH_ATTN_WHEEL=flash_attn-2.8.3+cu12torch2.9cxx11abiTRUE-cp312-cp312-linux_x86_64.whl
 
 ENV DEBIAN_FRONTEND=noninteractive \
     CUDA_HOME=/usr/local/cuda \
@@ -198,8 +198,6 @@ ARG HOPPER_SBO
 ARG HOPPER_SBO_DEEPEP_COMMIT
 ARG DEEPEP_COMMIT
 ARG GITHUB_ARTIFACTORY
-ARG KTRANSFORMERS_VERSION
-ARG KTRANSFORMERS_WHEEL
 ARG FLASH_ATTN_WHEEL
 ARG FUNCTIONALITY=sft
 
@@ -223,11 +221,11 @@ RUN git clone --depth 1 https://${GITHUB_ARTIFACTORY}/kvcache-ai/ktransformers.g
         git clone --depth 1 https://${GITHUB_ARTIFACTORY}/hiyouga/LLaMA-Factory.git /workspace/LLaMA-Factory; \
     fi
 
-# Download ktransformers wheel and flash_attn wheel for fine-tune env (sft mode only)
+# Download flash_attn wheel for fine-tune env (sft mode only).
+# ktransformers itself is installed from the cloned source tree (see below);
+# the prebuilt release wheel is no longer published as a release asset.
 RUN if [ "$FUNCTIONALITY" = "sft" ]; then \
-        curl --retry 3 --retry-delay 2 -fsSL -o /workspace/${KTRANSFORMERS_WHEEL} \
-            https://${GITHUB_ARTIFACTORY}/kvcache-ai/ktransformers/releases/download/v${KTRANSFORMERS_VERSION}/${KTRANSFORMERS_WHEEL} \
-        && curl --retry 3 --retry-delay 2 -fsSL -o /workspace/${FLASH_ATTN_WHEEL} \
+        curl --retry 3 --retry-delay 2 -fsSL -o /workspace/${FLASH_ATTN_WHEEL} \
             https://${GITHUB_ARTIFACTORY}/Dao-AILab/flash-attention/releases/download/v2.8.3/${FLASH_ATTN_WHEEL}; \
     fi
 
@@ -342,9 +340,9 @@ RUN --mount=type=cache,target=/root/.cache/pip \
             12.9.1) CUINDEX=129 ;; \
             13.0.1) CUINDEX=130 ;; \
         esac \
-        && /opt/miniconda3/envs/fine-tune/bin/pip install --upgrade pip setuptools wheel hatchling \
+        && /opt/miniconda3/envs/fine-tune/bin/pip install --upgrade pip setuptools wheel hatchling editables \
         && /opt/miniconda3/envs/fine-tune/bin/pip install \
-            torch==2.8.0 \
+            torch==2.9.1 \
             torchvision \
             torchaudio \
             --extra-index-url https://download.pytorch.org/whl/cu${CUINDEX}; \
@@ -357,10 +355,10 @@ RUN --mount=type=cache,target=/root/.cache/pip \
         && /opt/miniconda3/envs/fine-tune/bin/pip install -e ".[torch,metrics]" --no-build-isolation; \
     fi
 
-# Install ktransformers wheel in fine-tune env
+# Install ktransformers (with sft extras) from the cloned source in fine-tune env
 RUN --mount=type=cache,target=/root/.cache/pip \
     if [ "$FUNCTIONALITY" = "sft" ]; then \
-        /opt/miniconda3/envs/fine-tune/bin/pip install /workspace/${KTRANSFORMERS_WHEEL}; \
+        /opt/miniconda3/envs/fine-tune/bin/pip install "/workspace/ktransformers[sft]"; \
     fi
 
 # Install flash_attn wheel in fine-tune env
@@ -385,7 +383,7 @@ RUN --mount=type=cache,target=/root/.cache/pip \
 
 # Clean up downloaded wheels
 RUN if [ "$FUNCTIONALITY" = "sft" ]; then \
-        rm -f /workspace/${KTRANSFORMERS_WHEEL} /workspace/${FLASH_ATTN_WHEEL}; \
+        rm -f /workspace/${FLASH_ATTN_WHEEL}; \
     fi
 
 # Initialize conda for bash

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -355,10 +355,16 @@ RUN --mount=type=cache,target=/root/.cache/pip \
         && /opt/miniconda3/envs/fine-tune/bin/pip install -e ".[torch,metrics]" --no-build-isolation; \
     fi
 
-# Install ktransformers (with sft extras) from the cloned source in fine-tune env
+# Build and install the local kt-kernel into the fine-tune env (same as the serve
+# env), then install ktransformers (with sft extras) from the cloned source. Building
+# kt-kernel from source first means the locally checked-out C++ kernels are used, and
+# pip does not fall back to a PyPI kt-kernel (which may not exist for an unreleased version).
 RUN --mount=type=cache,target=/root/.cache/pip \
     if [ "$FUNCTIONALITY" = "sft" ]; then \
-        /opt/miniconda3/envs/fine-tune/bin/pip install "/workspace/ktransformers[sft]"; \
+        . /opt/miniconda3/etc/profile.d/conda.sh && conda activate fine-tune \
+        && cd /workspace/ktransformers/kt-kernel \
+        && CPUINFER_BUILD_ALL_VARIANTS=1 ./install.sh build \
+        && pip install "/workspace/ktransformers[sft]"; \
     fi
 
 # Install flash_attn wheel in fine-tune env


### PR DESCRIPTION
# What does this PR do?

Fixes #1762.

The `docker/Dockerfile` sft build downloads a prebuilt ktransformers wheel:

```
https://github.com/kvcache-ai/ktransformers/releases/download/v0.5.3/ktransformers-0.5.3+cu128torch28fancy-cp312-cp312-linux_x86_64.whl
```

No ktransformers release (v0.5.0 through v0.6.2) publishes wheel assets, so that URL returns 404 and `curl -fsSL` aborts the build.

On current main the top-level `ktransformers` package is a thin metapackage (`kt-kernel` plus `[sft]` extras), and the repo is already cloned into the image. This installs it from that source instead of the missing wheel, and aligns the fine-tune env with the dependencies current `kt-kernel` pins.

## Changes

- Remove the `KTRANSFORMERS_VERSION` / `KTRANSFORMERS_WHEEL` ARGs and the dead wheel download.
- Build the local `kt-kernel` from source in the fine-tune env (same as the serve env), then install `ktransformers[sft]` from the cloned `/workspace/ktransformers`. This uses the checked-out C++ kernels and avoids pip falling back to a PyPI `kt-kernel` that may not exist for an unreleased version.
- Bump the fine-tune env to `torch==2.9.1`, which is what `kt-kernel` (pulled in by `[sft]`) pins.
- Switch `FLASH_ATTN_WHEEL` to the matching `torch2.9` build from the same `v2.8.3` release.
- Add `editables` to the build tools, required by the editable `--no-build-isolation` install of LLaMA-Factory.
- Drop the removed wheel from the cleanup step.

## What was tested

Replicated the fine-tune env dependency resolution in a `nvidia/cuda:12.8.1-cudnn-devel-ubuntu24.04` container (CUDA 12.8, Python 3.12), running the same commands in the same order as the Dockerfile fine-tune stage:

- `torch==2.9.1` (cu128), then `LLaMA-Factory[torch,metrics]`, then `ktransformers[sft]`, then the flash_attn torch2.9 wheel.
- All install with exit code 0. torch stays at `2.9.1+cu128` after every step (no silent up/downgrade).
- `kt_kernel`, `llamafactory`, `transformers` (transformers-kt 5.6.0), and `accelerate` (accelerate-kt 1.14.0) import.
- `pip check` reports no broken requirements.

This confirms the torch/flash_attn/`editables` alignment and that `ktransformers[sft]` plus LLaMA-Factory coexist under torch 2.9.1. In that run `kt-kernel` came from PyPI as a stand-in for dependency resolution.

## What was not tested

- A full `docker build` of this Dockerfile was not run. The base image (`docker.1ms.run`) and the tsinghua conda/pip mirrors are not reachable from the test machine, and the single `framework` stage also compiles DeepEP, kt-kernel (all CPU variants), and sglang for the serve env, which this PR does not touch.
- The local `kt-kernel` source build in the fine-tune env (`CPUINFER_BUILD_ALL_VARIANTS=1 ./install.sh build`) was not run here. It mirrors the existing serve-env build step exactly, but it is a heavy C++/CUDA compile that was not executed in this verification.
- The `editables` addition depends on the hatchling version resolved at build time. It was required to reproduce a clean editable install here; it is harmless if the mirror-resolved hatchling would not have needed it.

## Before submitting

- [x] Read the contributor guideline.
- [ ] Did you write any new necessary tests? No automated test added; a Dockerfile change is verified by reproducing the install sequence as described above.
