### PR TITLE
[fix](kt-kernel): CudaGraph replay fix and MoE startup log

### DIFF
--- a/kt-kernel/cpu_backend/cpuinfer.h
+++ b/kt-kernel/cpu_backend/cpuinfer.h
@@ -103,7 +103,6 @@ class CPUInfer {
   static void sync_(void* sync_args) {
     SyncArgs* args = (SyncArgs*)sync_args;
     args->cpuinfer->task_queue_->sync(args->allow_n_pending);
-    delete args;
   }
 
   void sync(size_t allow_n_pending = 0) {

--- a/kt-kernel/operators/amx/bf16-moe.hpp
+++ b/kt-kernel/operators/amx/bf16-moe.hpp
@@ -54,7 +54,11 @@ class AMX_BF16_MOE_TP : public AMX_MOE_BASE<T, AMX_BF16_MOE_TP<T>> {
 
   void derived_init() {
     // BF16 has no quantization, no need to check quant_config
-    printf("Created AMX_BF16_MOE_TP %d at numa %d\n", tp_part_idx, numa_node_of_cpu(sched_getcpu()));
+    // Backend reflects the compile-time GEMM path: AMX tiles when __AMXBF16__ etc. are
+    // defined, otherwise the AVX512-BF16 fallback in amx_raw_kernels.hpp::float_mat_vec.
+    constexpr const char* backend = amx::AMX_AVAILABLE ? "AMX" : "AVX512-BF16";
+    printf("Created BF16_MOE_TP %d at numa %d (backend=%s)\n", tp_part_idx,
+           numa_node_of_cpu(sched_getcpu()), backend);
   }
 
   ~AMX_BF16_MOE_TP() = default;

--- a/kt-kernel/operators/amx/fp8-moe.hpp
+++ b/kt-kernel/operators/amx/fp8-moe.hpp
@@ -55,7 +55,11 @@ class AMX_FP8_MOE_TP : public AMX_MOE_BASE<T, AMX_FP8_MOE_TP<T>> {
     if (quant_config.group_size == 0 || quant_config.zero_point) {
       throw std::runtime_error("KT-Kernel fp8 MoE only support block-wise FP8");
     }
-    printf("Created AMX_FP8_MOE_TP %d at numa %d\n", tp_part_idx, numa_node_of_cpu(sched_getcpu()));
+    // Backend reflects the compile-time GEMM path: AMX tiles when __AMXBF16__ etc. are
+    // defined, otherwise the AVX512-BF16 fallback in amx_raw_kernels.hpp::float_mat_vec_kgroup.
+    constexpr const char* backend = amx::AMX_AVAILABLE ? "AMX" : "AVX512-BF16";
+    printf("Created FP8_MOE_TP %d at numa %d (backend=%s)\n", tp_part_idx,
+           numa_node_of_cpu(sched_getcpu()), backend);
   }
 
   ~AMX_FP8_MOE_TP() = default;

--- a/kt-kernel/operators/amx/fp8-perchannel-moe.hpp
+++ b/kt-kernel/operators/amx/fp8-perchannel-moe.hpp
@@ -54,7 +54,11 @@ class AMX_FP8_PERCHANNEL_MOE_TP : public AMX_MOE_BASE<T, AMX_FP8_PERCHANNEL_MOE_
     if (!quant_config.per_channel) {
       throw std::runtime_error("KT-Kernel FP8 Per-Channel MoE requires per_channel=true");
     }
-    printf("Created AMX_FP8_PERCHANNEL_MOE_TP %d at numa %d\n", tp_part_idx, numa_node_of_cpu(sched_getcpu()));
+    // Backend reflects the compile-time GEMM path: AMX tiles when __AMXBF16__ etc. are
+    // defined, otherwise the AVX512-BF16 fallback in amx_raw_kernels.hpp::float_mat_vec.
+    constexpr const char* backend = amx::AMX_AVAILABLE ? "AMX" : "AVX512-BF16";
+    printf("Created FP8_PERCHANNEL_MOE_TP %d at numa %d (backend=%s)\n", tp_part_idx,
+           numa_node_of_cpu(sched_getcpu()), backend);
   }
 
   ~AMX_FP8_PERCHANNEL_MOE_TP() = default;


### PR DESCRIPTION
# What does this PR do?
1.The AMX_*_MOE_TP classes dispatch at compile time via float_mat_vec / float_mat_vec_kgroup in amx_raw_kernels.hpp:

    if constexpr (amx_or_avx && AMX_AVAILABLE) {
      K::amx_kernel(...);
    } else {
      K::avx_kernel_4(...);   // pure AVX512-BF16 (_mm512_dpbf16_ps)
    }

When the build does not define __AMX*__ / HAVE_AMX, the same classes still run, but on the AVX512-BF16 fallback rather than AMX tiles. The existing "Created AMX_BF16_MOE_TP / AMX_FP8_MOE_TP / AMX_FP8_PERCHANNEL_MOE_TP" startup log made this look like AMX was mandatory, which has caused user confusion on AVX-512-only hosts.

Drop the AMX_ prefix from the printed message and append the actual backend resolved at compile time (AMX or AVX512-BF16). Class names and ABI are unchanged.

2. revert "delete args" in cpu_infer.h to avoid cuda-graph replay error.