### PR TITLE
fix(balance_serve): bind scheduler RPC to loopback to close pre-auth …

### DIFF
--- a/archive/ktransformers/server/balance_serve/sched_rpc.py
+++ b/archive/ktransformers/server/balance_serve/sched_rpc.py
@@ -40,7 +40,14 @@ class SchedulerServer:
         self.context = zmq.Context()
         self.frontend = self.context.socket(zmq.ROUTER)
         print(f"sched zmq rpc server on port {main_args.sched_port}")
-        self.frontend.bind(f"tcp://*:{main_args.sched_port}") 
+        # Security: the scheduler RPC speaks pickle in both directions and has no
+        # authentication, so any peer that can reach this socket can achieve RCE
+        # via a crafted pickle payload. The protocol carries CUDA IPC tensor
+        # handles (mp.reductions.reduce_tensor) that are only valid on the same
+        # host, and SchedulerClient always connects to localhost, so this RPC is
+        # local-only by design. Bind to the loopback interface instead of all
+        # interfaces (tcp://*) so the pickle sink is never exposed to the network.
+        self.frontend.bind(f"tcp://127.0.0.1:{main_args.sched_port}")
 
         # 创建内部的 DEALER 套接字，用于与工作线程通信
         self.backend = self.context.socket(zmq.DEALER)


### PR DESCRIPTION
…pickle RCE

The balance_serve scheduler RPC (sched_rpc.py) binds its ZMQ ROUTER socket to tcp://*:{sched_port} and deserializes every received frame with pickle.loads. With no authentication, allowlist, or format validation, any peer that can reach the port can execute arbitrary code under the server process identity by sending a crafted pickle payload (GitHub issue #2042, Finding 1).

The scheduler RPC is local-only by design: it transports CUDA IPC tensor handles produced by mp.reductions.reduce_tensor (valid only on the same host), and SchedulerClient always connects to localhost. Binding to the loopback interface therefore removes the network attack surface without changing the wire protocol, eliminating the pre-auth remote RCE.

# What does this PR do?

Fixes # (issue)

## Before submitting

- [ ] Did you read the [contributor guideline](https://github.com/kvcache-ai/ktransformers/blob/main/.github/CONTRIBUTING.md)?
- [ ] Did you write any new necessary tests?