### PR TITLE
docs(deepseek-v4-flash): pin apache-tvm-ffi<0.1.12 to avoid tilelang TVM FFI registration clash (#2045)

### DIFF
--- a/doc/en/DeepSeek-V4-Flash.md
+++ b/doc/en/DeepSeek-V4-Flash.md
@@ -67,7 +67,9 @@ This tutorial demonstrates how to run **DeepSeek-V4-Flash** model inference usin
    ```bash
    pip install tilelang "apache-tvm-ffi<0.1.12"
    ```
-   `sglang-kt`'s pyproject does not declare `tilelang` as a dependency, so `pip install ./python[all]` will not pull it in. Validated with `tilelang==0.1.8`. Constrain `apache-tvm-ffi<0.1.12`: the standalone `apache-tvm-ffi` 0.1.12 wheel collides with the TVM FFI runtime bundled inside `tilelang`, so importing `tilelang` aborts with `TypeAttr __ffi_repr__ is already registered for type index 130` and the SGLang scheduler dies on startup. `apache-tvm-ffi==0.1.11` does not register the conflicting attribute and starts cleanly; pin until the upstream duplicate-registration fix lands.
+   `sglang-kt`'s pyproject does not declare `tilelang` as a dependency, so `pip install ./python[all]` will not pull it in. Validated with `tilelang==0.1.8`.
+
+   > **Note:** Constrain `apache-tvm-ffi<0.1.12`. The standalone `apache-tvm-ffi` 0.1.12 wheel collides with the TVM FFI runtime bundled inside `tilelang`, so importing `tilelang` aborts with `TypeAttr __ffi_repr__ is already registered for type index 130` and the SGLang scheduler dies on startup. `apache-tvm-ffi==0.1.11` does not register the conflicting attribute and starts cleanly; pin until the upstream duplicate-registration fix lands.
 
 
 ## Step 1: Download Model Weights

--- a/doc/en/DeepSeek-V4-Flash.md
+++ b/doc/en/DeepSeek-V4-Flash.md
@@ -65,9 +65,9 @@ This tutorial demonstrates how to run **DeepSeek-V4-Flash** model inference usin
 
 5. **tilelang** (manual install — required for the NSA sparse-MLA tilelang indexer path used on non-Hopper GPUs):
    ```bash
-   pip install tilelang
+   pip install tilelang "apache-tvm-ffi<0.1.12"
    ```
-   `sglang-kt`'s pyproject does not declare `tilelang` as a dependency, so `pip install ./python[all]` will not pull it in. Validated with `tilelang==0.1.8`.
+   `sglang-kt`'s pyproject does not declare `tilelang` as a dependency, so `pip install ./python[all]` will not pull it in. Validated with `tilelang==0.1.8`. Constrain `apache-tvm-ffi<0.1.12`: the standalone `apache-tvm-ffi` 0.1.12 wheel collides with the TVM FFI runtime bundled inside `tilelang`, so importing `tilelang` aborts with `TypeAttr __ffi_repr__ is already registered for type index 130` and the SGLang scheduler dies on startup. `apache-tvm-ffi==0.1.11` does not register the conflicting attribute and starts cleanly; pin until the upstream duplicate-registration fix lands.
 
 
 ## Step 1: Download Model Weights


### PR DESCRIPTION
## What

The DeepSeek-V4-Flash setup guide's `tilelang` prerequisite (step 5) installs with a bare `pip install tilelang`. On a fresh environment this pulls the latest standalone `apache-tvm-ffi` wheel (0.1.12), which collides with the TVM FFI runtime bundled inside `tilelang`. Importing `tilelang` then aborts the SGLang scheduler at startup:

```
terminate called after throwing an instance of 'tvm::ffi::Error'
  what():  TypeAttr `__ffi_repr__` is already registered for type index 130. ...
Fatal Python error: Aborted
[...] Rank 0 scheduler is dead.
```

`apache-tvm-ffi==0.1.11` does not register the conflicting attribute and starts cleanly.

## Change

Doc-only. Updates the step-5 install command to constrain the conflicting package and adds an explanatory note, matching the same pin-and-explain convention already used in this guide for `flashinfer`, `transformers==4.57.1`, and `tilelang==0.1.8`:

```bash
pip install tilelang "apache-tvm-ffi<0.1.12"
```

## Why a constraint and not `==0.1.11`

`<0.1.12` excludes the known-bad release while still allowing any future upstream version that fixes the duplicate registration, consistent with the "pin until the upstream fix lands" framing the guide already uses for the `transformers` workaround.

Fixes #2045.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
