### PR TITLE
release: bump version to 0.6.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@
 KTransformers is a research project focused on efficient inference and fine-tuning of large language models through CPU-GPU heterogeneous computing. The project now exposes two user-facing capabilities from the kt-kernel source tree: [Inference](./kt-kernel/README.md) and [SFT](./doc/en/SFT/KTransformers-Fine-Tuning_Quick-Start.md).
 
 ## 🔥 Updates
+* **June 21, 2026**: MiniMax-M3 Day0 Support! ([Tutorial](./doc/en/kt-kernel/MiniMax-M3-Tutorial.md))
 * **June 17, 2026**: GLM-5.2 Day0 Support! ([Tutorial](./doc/en/kt-kernel/GLM-5.2-Tutorial.md))
 * **May 6, 2026**: KTransformers at [GOSIM Paris 2026](https://paris2026.gosim.org/zh/schedule/) — "Agentic AI on Edge" track. We'll present KT's inference performance on consumer hardware.
 * **May 02, 2026**: DeepSeek-V4-Flash Support! ([Tutorial](./doc/en/DeepSeek-V4-Flash.md))

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
             "accelerate-kt==1.14.0.post1",
         ],
         "sglang": [
-            "sglang-kt==0.6.2.post3",
+            "sglang-kt==0.6.3",
         ],
     },
 )

--- a/version.py
+++ b/version.py
@@ -3,4 +3,4 @@ KTransformers version information.
 Shared across the top-level package and kt-kernel.
 """
 
-__version__ = "0.6.2.post3"
+__version__ = "0.6.3"


### PR DESCRIPTION
## Summary
- Bump version from `0.6.2.post3` to `0.6.3` (`version.py`, `setup.py`)
- Add MiniMax-M3 Day0 Support entry to README (`🔥 Updates`)
- Align `sglang-kt` dependency to `0.6.3`

## Test plan
- [ ] Verify `pip install ktransformers==0.6.3` resolves correctly after wheel publish
- [ ] Confirm README renders M3 tutorial link

🤖 Generated with [Claude Code](https://claude.com/claude-code)