### PR TITLE
docs(kt-kernel): note --no-build-isolation for ROCm/vendor torch builds (#2065)

### DIFF
--- a/kt-kernel/README.md
+++ b/kt-kernel/README.md
@@ -721,6 +721,18 @@ pip install -e .
 pip install .
 ```
 
+> **ROCm / vendor-provided PyTorch users:** the default build uses pip's
+> [build isolation](https://pip.pypa.io/en/stable/reference/build-system/pyproject-toml/#build-isolation),
+> which resolves a stock CPU/CUDA `torch` from PyPI into an isolated build
+> environment. On ROCm — or any vendor torch, e.g. a Hygon DCU DTK build — this
+> shadows the ROCm/vendor `torch` you already have installed, so the kernel is
+> linked against the wrong PyTorch. Build against your in-environment torch
+> instead:
+>
+> ```bash
+> pip install . --no-build-isolation --no-deps
+> ```
+
 ## Error Troubleshooting
 
 ### CUDA Not Found


### PR DESCRIPTION
## What

Adds a note to the **Manual Installation → Build and Install** step of
`kt-kernel/README.md` warning ROCm / vendor-torch users that pip's default
build isolation shadows their installed `torch`.

## Why

Partially addresses #2065 (gap #2).

The Manual Installation section documents:

```bash
pip install .
```

but not that pip's default *build isolation* resolves a stock CPU/CUDA `torch`
from PyPI into an isolated build environment. On ROCm — or any vendor torch,
e.g. a Hygon DCU DTK build — that isolated `torch` shadows the ROCm/vendor
`torch` already installed in the environment, so the built kernel links against
the wrong PyTorch. Building with `--no-build-isolation --no-deps` makes the
build link the in-environment vendor torch, which is the fix reported in #2065.

This is a generic footgun for any ROCm / vendor-provided-torch user, not just
Hygon DCU.

## Note on the rest of #2065

Gap #1 (`libhwloc-dev` as a required build dep) is **already covered** on `main`
— `install.sh` installs it, the Manual Installation prerequisites list it, and
there is a dedicated "hwloc Not Found" troubleshooting entry — so this PR
intentionally leaves that alone and only closes the still-missing build-isolation
note. A full Hygon-DCU / `doc/en/DCU.md` writeup (also floated in the issue) is
left to the reporter, who validated that hardware path.

## Scope

Docs only — 12 added lines, no code or build changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
