### PR TITLE
[fix](cli): detect bound ports before launch

### DIFF
--- a/kt-kernel/python/cli/utils/port_checker.py
+++ b/kt-kernel/python/cli/utils/port_checker.py
@@ -17,22 +17,12 @@ def is_port_available(host: str, port: int) -> bool:
         True if port is available, False if occupied
     """
     try:
-        # Try to bind to the port
-        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-        sock.settimeout(1)
+        bind_host = "" if host == "0.0.0.0" else host
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+            sock.bind((bind_host, port))
+        return True
 
-        # Use SO_REUSEADDR to allow binding to recently closed ports
-        sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-
-        # Try to bind
-        result = sock.connect_ex((host if host != "0.0.0.0" else "127.0.0.1", port))
-        sock.close()
-
-        # If connect_ex returns 0, port is occupied
-        # If it returns error (non-zero), port is available
-        return result != 0
-
-    except Exception:
+    except OSError:
         # If any error occurs, assume port is not available
         return False
 

--- a/kt-kernel/python/cli/utils/port_checker.py
+++ b/kt-kernel/python/cli/utils/port_checker.py
@@ -3,6 +3,7 @@ Port availability checking utilities.
 """
 
 import socket
+import sys
 from typing import Tuple
 
 
@@ -19,6 +20,8 @@ def is_port_available(host: str, port: int) -> bool:
     try:
         bind_host = "" if host == "0.0.0.0" else host
         with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+            if sys.platform != "win32":
+                sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
             sock.bind((bind_host, port))
         return True
 

--- a/kt-kernel/test/per_commit/test_port_checker.py
+++ b/kt-kernel/test/per_commit/test_port_checker.py
@@ -2,6 +2,7 @@ import importlib.util
 import socket
 from pathlib import Path
 import unittest
+from unittest.mock import MagicMock, patch
 
 from ci.ci_register import register_cpu_ci
 
@@ -27,6 +28,17 @@ class TestPortChecker(unittest.TestCase):
             self.assertEqual(port_checker.find_available_port("127.0.0.1", port, max_attempts=1), (False, port))
         finally:
             holder.close()
+
+    def test_non_windows_bind_check_uses_reuseaddr(self):
+        sock = MagicMock()
+        sock.__enter__.return_value = sock
+
+        with patch.object(port_checker.sys, "platform", "linux"):
+            with patch.object(port_checker.socket, "socket", return_value=sock):
+                self.assertTrue(port_checker.is_port_available("127.0.0.1", 12345))
+
+        sock.setsockopt.assert_called_once_with(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        sock.bind.assert_called_once_with(("127.0.0.1", 12345))
 
 
 if __name__ == "__main__":

--- a/kt-kernel/test/per_commit/test_port_checker.py
+++ b/kt-kernel/test/per_commit/test_port_checker.py
@@ -1,0 +1,33 @@
+import importlib.util
+import socket
+from pathlib import Path
+import unittest
+
+from ci.ci_register import register_cpu_ci
+
+
+register_cpu_ci(est_time=0.1, suite="default")
+
+
+PORT_CHECKER_PATH = Path(__file__).resolve().parents[2] / "python" / "cli" / "utils" / "port_checker.py"
+SPEC = importlib.util.spec_from_file_location("port_checker", PORT_CHECKER_PATH)
+assert SPEC is not None and SPEC.loader is not None
+port_checker = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(port_checker)
+
+
+class TestPortChecker(unittest.TestCase):
+    def test_bound_port_is_not_available_before_listen(self):
+        holder = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        try:
+            holder.bind(("127.0.0.1", 0))
+            port = holder.getsockname()[1]
+
+            self.assertFalse(port_checker.is_port_available("127.0.0.1", port))
+            self.assertEqual(port_checker.find_available_port("127.0.0.1", port, max_attempts=1), (False, port))
+        finally:
+            holder.close()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
﻿# What does this PR do?

Fixes the kt-kernel CLI port availability check so it tests whether the server can actually bind the requested host/port, instead of probing whether a client can connect to it.

Fixes #2072

## What Problem This Solves

`kt run` uses the interactive setup flow to choose and persist server launch settings. The host/port validation happens before the configuration is saved or reused, so the helper needs to answer the same question the later server launch will ask: **can this process bind the requested local address?**

The affected path is:

```text
kt run interactive setup
  -> kt_kernel.cli.utils.run_interactive.configure_host_and_port(...)
    -> kt_kernel.cli.utils.port_checker.is_port_available(...)
    -> kt_kernel.cli.utils.port_checker.find_available_port(...)
```

There are two user-visible entry points into the same helper:

```text
new interactive config
  -> configure_host_and_port()
  -> check user-entered host/port
  -> print "Port <port> is available" or suggest another port

saved run config
  -> reuse saved_host / saved_port
  -> check saved port before launch
  -> keep it or prompt for a replacement
```

Before this change, `is_port_available()` used `socket.connect_ex()` to decide whether the port was available. That checks **client reachability**: whether a client can connect to a server that is already listening at the target address. The CLI needs **server bindability**: whether the launch process can reserve that local host/port with `bind()`.

Those two checks differ in an important edge case. Another process can already hold a port by calling `bind()` without calling `listen()` yet. In that state:

```text
other process: bind("127.0.0.1", port) succeeds and keeps the port reserved
client probe : connect_ex("127.0.0.1", port) fails because nothing is listening
old helper   : treats the failed connection as "available"
server launch: later bind("127.0.0.1", port) fails because the port is already reserved
```

That means the CLI can print that a port is available, save or suggest that port, and only fail later when the actual server launch tries to bind it. The validation step is therefore checking the wrong side of the socket lifecycle.

## Change

- Replace the `connect_ex()` reachability probe with a short-lived `bind()` check.
- Keep the existing `0.0.0.0` handling by binding through the wildcard host.
- Set `SO_REUSEADDR` only on non-Windows platforms so Linux/macOS checks match typical server reuse behavior without introducing Windows false positives.
- Add focused CPU tests for the bound-but-not-listening false positive and the non-Windows `SO_REUSEADDR` branch.

## Evidence

The regression test covers the exact false-positive shape:

```python
holder = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
holder.bind(("127.0.0.1", 0))
port = holder.getsockname()[1]

self.assertFalse(port_checker.is_port_available("127.0.0.1", port))
self.assertEqual(
    port_checker.find_available_port("127.0.0.1", port, max_attempts=1),
    (False, port),
)
```

The reviewer-requested platform branch is also covered with a mocked Linux platform check:

```python
with patch.object(port_checker.sys, "platform", "linux"):
    with patch.object(port_checker.socket, "socket", return_value=sock):
        self.assertTrue(port_checker.is_port_available("127.0.0.1", 12345))

sock.setsockopt.assert_called_once_with(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
```

Post-fix local behavior proof:

```text
{'case': 'bound_without_listen', 'available': False, 'suggested_same': (False, 57452)}
```

## Possible call chain / impact

Affected interactive paths:

```text
kt-kernel/python/cli/utils/run_interactive.py
  -> configure_host_and_port()
    -> is_port_available(host, port)
    -> find_available_port(host, port + 1, max_attempts=100)

saved run config path
  -> saved_host / saved_port
  -> is_port_available(saved_host, saved_port)
  -> find_available_port(saved_host, saved_port + 1, max_attempts=100)
```

This PR only changes the CLI helper used to decide whether a TCP server port can be bound. It does not change model loading, SGLang launch arguments, network serving behavior after a port is selected, or non-CLI kernel code.

## Validation

- `mamba run -n prw-ktransformers-py311 python -m unittest per_commit.test_port_checker -v` from `kt-kernel/test` - passed, 2 tests
- Local post-fix behavior proof for a bound-but-not-listening socket - passed
- `git diff --check` - passed

I also attempted `mamba run -n prw-ktransformers-py311 python run_suite.py --hw cpu --suite default` from `kt-kernel/test`; on this Windows environment it stops before the suite because the runner invokes `python3`, which is not available here (`test_basic_cpu.py` exits 9009). The focused regression tests above run successfully with the same Python 3.11 conda environment.

## Before submitting

- [x] Did you read the [contributor guideline](https://github.com/kvcache-ai/ktransformers/blob/main/.github/CONTRIBUTING.md)?
- [x] Did you write any new necessary tests?
