### PR TITLE
[fix](cli): avoid custom path setup hang on Windows

### DIFF
--- a/kt-kernel/python/cli/main.py
+++ b/kt-kernel/python/cli/main.py
@@ -378,9 +378,9 @@ def _prompt_custom_path(console, settings) -> str:
                 console.print(f"[red]{t('setup_path_no_write')}[/red]")
         else:
             # Check if we can create it (parent writable)
-            parent = str(Path(custom_path).parent)
-            while not os.path.exists(parent) and parent != "/":
-                parent = str(Path(parent).parent)
+            from kt_kernel.cli.utils.path_utils import find_existing_parent
+
+            parent = find_existing_parent(custom_path)
 
             if os.access(parent, os.W_OK):
                 return custom_path

--- a/kt-kernel/python/cli/utils/path_utils.py
+++ b/kt-kernel/python/cli/utils/path_utils.py
@@ -1,0 +1,12 @@
+from pathlib import Path
+
+
+def find_existing_parent(path: str) -> str:
+    """Return the nearest existing parent for a path without assuming POSIX roots."""
+    parent = Path(path).parent
+    while not parent.exists():
+        next_parent = parent.parent
+        if next_parent == parent:
+            break
+        parent = next_parent
+    return str(parent)

--- a/kt-kernel/python/cli/utils/path_utils.py
+++ b/kt-kernel/python/cli/utils/path_utils.py
@@ -1,10 +1,11 @@
+import os
 from pathlib import Path
 
 
 def find_existing_parent(path: str) -> str:
     """Return the nearest existing parent for a path without assuming POSIX roots."""
     parent = Path(path).parent
-    while not parent.exists():
+    while not os.path.exists(parent):
         next_parent = parent.parent
         if next_parent == parent:
             break

--- a/kt-kernel/test/per_commit/test_main_custom_path.py
+++ b/kt-kernel/test/per_commit/test_main_custom_path.py
@@ -29,7 +29,7 @@ path_utils = _load_path_utils()
 
 
 class TestPromptCustomPath(unittest.TestCase):
-    @patch.object(path_utils.Path, "exists", return_value=False)
+    @patch.object(path_utils.os.path, "exists", return_value=False)
     def test_missing_windows_drive_root_does_not_loop_forever(self, mock_exists):
         expected_parent = Path("Z:\\models").parent
         while True:

--- a/kt-kernel/test/per_commit/test_main_custom_path.py
+++ b/kt-kernel/test/per_commit/test_main_custom_path.py
@@ -1,0 +1,48 @@
+import importlib.util
+import os
+from pathlib import Path
+import sys
+import unittest
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+from ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=1, suite="default")
+
+
+def _load_path_utils():
+    module_path = (
+        Path(__file__).resolve().parents[2]
+        / "python"
+        / "cli"
+        / "utils"
+        / "path_utils.py"
+    )
+    spec = importlib.util.spec_from_file_location("path_utils", module_path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+path_utils = _load_path_utils()
+
+
+class TestPromptCustomPath(unittest.TestCase):
+    @patch.object(path_utils.Path, "exists", return_value=False)
+    def test_missing_windows_drive_root_does_not_loop_forever(self, mock_exists):
+        expected_parent = Path("Z:\\models").parent
+        while True:
+            next_parent = expected_parent.parent
+            if next_parent == expected_parent:
+                break
+            expected_parent = next_parent
+
+        result = path_utils.find_existing_parent("Z:\\models")
+
+        self.assertEqual(result, str(expected_parent))
+        self.assertEqual(mock_exists.call_count, 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
# What does this PR do?

Fixes #2073

This PR prevents the first-run interactive setup from hanging when a Windows user enters a custom model path whose drive/root does not exist.

## What Problem This Solves

During first-run setup, `kt` asks users to choose or enter a model storage path. If the user selects a custom path that does not already exist, `_prompt_custom_path()` walks upward until it finds an existing parent directory and then checks whether that parent is writable.

The previous loop only treated `/` as the filesystem root:

```python
parent = str(Path(custom_path).parent)
while not os.path.exists(parent) and parent != "/":
    parent = str(Path(parent).parent)
```

That works for POSIX-style paths, but it does not terminate correctly for some Windows roots. For example, if a user enters a path on a missing drive such as:

```text
Z:\models
```

then `Path("Z:\\").parent` remains `Z:\`. The loop keeps assigning the same parent value again and again because `parent != "/"` stays true.

A local reproduction shows the parent path stabilizing at the Windows drive root instead of reaching `/`:

```text
['Z:\\models', 'Z:\\', 'Z:\\', 'Z:\\', 'Z:\\', 'Z:\\', 'Z:\\', 'Z:\\']
stabilized=True
```

In the real interactive setup flow, that means the CLI can appear to freeze before saving or rejecting the custom model path.

## Changes

This change moves the parent-directory walk into a small helper, `find_existing_parent()`, and makes it stop when `Path(parent).parent` no longer changes the path.

That preserves the existing behavior for normal paths:

- existing writable paths are still accepted immediately
- missing paths are still accepted only when an existing writable parent can be found
- non-writable paths still show the existing `setup_path_no_write` message
- POSIX root handling remains unchanged

The fix only changes the root-detection guard used while validating a missing custom path.

## Evidence

The regression test mocks the parent existence check as unavailable and verifies that the path walk stops at the path object's fixed point instead of continuing indefinitely:

```text
per_commit.test_main_custom_path.TestPromptCustomPath.test_missing_windows_drive_root_does_not_loop_forever ... ok
```

The new test is registered for the CPU default per-commit suite:

```text
[CIRegistry(backend=<HWBackend.CPU: 1>, filename='per_commit/test_main_custom_path.py', est_time=1, suite='default')]
```

## Possible call chain / impact

The affected setup path is:

```text
kt first-run interactive setup
  -> _show_first_run_setup(...)
    -> user selects custom model storage path
      -> _prompt_custom_path(...)
        -> parent walk for a missing custom path
```

This can affect Windows users who enter a path on a missing drive, disconnected external disk, unavailable network mount, or a mistyped drive letter.

This PR only changes custom-path validation during interactive first-run setup. It does not change model scanning, model registration, saved settings format, disk-space detection, or the later directory creation flow.

## Validation

- `D:\ZXY\Dev\Miniforge3\condabin\mamba.bat run -n prw-ktransformers-py311 python -m unittest per_commit.test_main_custom_path -v` - passed
- `D:\ZXY\Dev\Miniforge3\condabin\mamba.bat run -n prw-ktransformers-py311 python per_commit\test_main_custom_path.py -v` - passed
- `D:\ZXY\Dev\Miniforge3\condabin\mamba.bat run -n prw-ktransformers-py311 python -c "from ci.ci_register import collect_tests; print([r for r in collect_tests(['per_commit/test_main_custom_path.py'])])"` - passed
- `D:\ZXY\Dev\Miniforge3\condabin\mamba.bat run -n prw-ktransformers-py311 python -m py_compile ..\python\cli\main.py ..\python\cli\utils\path_utils.py per_commit\test_main_custom_path.py` - passed
- `git diff --check` - passed

Note: `black --check` was not run because `black` is not installed in the local `prw-ktransformers-py311` environment.

## Before submitting

- [x] Did you read the [contributor guideline](https://github.com/kvcache-ai/ktransformers/blob/main/.github/CONTRIBUTING.md)?
- [x] Did you write any new necessary tests?