### PR TITLE
fix: normalize compressed RAWINT4 weights

### DIFF
--- a/doc/en/ROCm.md
+++ b/doc/en/ROCm.md
@@ -42,6 +42,44 @@ pip3 install packaging ninja cpufeature numpy
 
 > **Tip:** For other ROCm versions, visit [PyTorch Previous Versions](https://pytorch.org/get-started/previous-versions/)
 
+### Hygon DCU / DTK Notes
+
+Hygon DCU uses a ROCm-compatible DTK stack. For DCU systems, use the Hygon DCU
+PyTorch environment that matches your DTK release instead of installing the
+generic PyPI `torch` package or the official AMD ROCm wheel.
+
+For example, a reported working `gfx936` setup uses a Hygon DCU PyTorch image
+from the SourceFind/Hygon developer image portal:
+
+https://sourcefind.cn/#/image/dcu/pytorch
+
+The reported environment provides:
+
+- DTK 26.04, typically under `/opt/dtk`
+- PyTorch `2.5.1+das.opt1.dtk2604`
+- Python 3.10
+
+Before building, verify that the DCU PyTorch package is active:
+
+```bash
+python -c "import torch; print(torch.__version__); print(torch.version.hip); print(torch.__file__)"
+```
+
+Then build `kt-kernel` without letting pip replace the vendor PyTorch package:
+
+```bash
+export CPUINFER_USE_ROCM=1
+export PYTORCH_ROCM_ARCH=gfx936
+export ROCM_PATH=/opt/dtk  # change this if DTK is installed elsewhere
+
+cd kt-kernel
+pip install . --no-build-isolation --no-deps
+```
+
+> **Tip:** Keep `--no-deps` when building in a vendor PyTorch environment. A
+> plain `pip install .` may resolve `kt-kernel`'s normal `torch` dependency and
+> shadow or replace the installed DCU PyTorch package with a generic torch wheel.
+
 ### 4. Build ktransformers
 
 ```bash

--- a/kt-kernel/python/utils/loader.py
+++ b/kt-kernel/python/utils/loader.py
@@ -679,6 +679,49 @@ class BF16SafeTensorLoader(SafeTensorLoader):
 class CompressedSafeTensorLoader(SafeTensorLoader):
     """Loader for compressed SafeTensor layouts (RAWINT4 weights)."""
 
+    @staticmethod
+    def _normalize_rawint4_weight(weight_tensor, scale_tensor, shape_tensor=None, key: str = "weight_packed"):
+        """Return byte-packed uint8 RAWINT4 weights expected by kt_kernel_ext."""
+        if weight_tensor.dtype == torch.int32:
+            # compressed-tensors pack-quantized stores 8 int4 values per int32.
+            # The RAWINT4 kernels consume the same bytes as uint8, two int4 values per byte.
+            rows, int32_cols = weight_tensor.shape
+            weight_tensor = weight_tensor.contiguous().view(torch.uint8).view(rows, int32_cols * 4).contiguous()
+        elif weight_tensor.dtype == torch.uint8:
+            weight_tensor = weight_tensor.contiguous()
+        else:
+            raise TypeError(f"{key} must be torch.uint8 or torch.int32, got {weight_tensor.dtype}")
+
+        if shape_tensor is None:
+            return weight_tensor
+
+        shape_values = shape_tensor.detach().cpu().tolist()
+        if len(shape_values) != 2:
+            raise ValueError(f"{key}.weight_shape must contain [out_features, in_features], got {shape_values}")
+
+        out_features, in_features = (int(shape_values[0]), int(shape_values[1]))
+        if out_features <= 0 or in_features <= 0:
+            return weight_tensor
+
+        if in_features % 2 != 0:
+            return weight_tensor
+
+        expected_weight_shape = (out_features, in_features // 2)
+        if tuple(weight_tensor.shape) != expected_weight_shape:
+            return weight_tensor
+
+        if scale_tensor.dim() != 2 or scale_tensor.shape[0] != out_features or scale_tensor.shape[1] <= 0:
+            raise ValueError(
+                f"{key} scale shape {tuple(scale_tensor.shape)} is incompatible with weight_shape={shape_values}"
+            )
+
+        if in_features % int(scale_tensor.shape[1]) != 0:
+            raise ValueError(
+                f"{key} in_features={in_features} is not divisible by scale columns={scale_tensor.shape[1]}"
+            )
+
+        return weight_tensor
+
     def load_experts(self, base_key: str, device: str = "cpu"):
         """Load raw expert weights stored in compressed safetensor format."""
 
@@ -703,6 +746,7 @@ class CompressedSafeTensorLoader(SafeTensorLoader):
             for exp_id in range(expert_idx):
                 weight_key = f"{experts_prefix}.{exp_id}.{proj_name}_proj.weight_packed"
                 scale_key = f"{experts_prefix}.{exp_id}.{proj_name}_proj.weight_scale"
+                shape_key = f"{experts_prefix}.{exp_id}.{proj_name}_proj.weight_shape"
 
                 if not self.has_tensor(weight_key):
                     raise KeyError(f"Missing tensor: {weight_key}")
@@ -711,6 +755,8 @@ class CompressedSafeTensorLoader(SafeTensorLoader):
 
                 weight_tensor = self.load_tensor(weight_key, device).contiguous()
                 scale_tensor = self.load_tensor(scale_key, device).contiguous()
+                shape_tensor = self.load_tensor(shape_key, "cpu") if self.has_tensor(shape_key) else None
+                weight_tensor = self._normalize_rawint4_weight(weight_tensor, scale_tensor, shape_tensor, weight_key)
 
                 weight_entries.append(weight_tensor)
                 scale_entries.append(scale_tensor)

--- a/kt-kernel/test/per_commit/test_moe_rawint4_accuracy.py
+++ b/kt-kernel/test/per_commit/test_moe_rawint4_accuracy.py
@@ -110,6 +110,13 @@ def rawint4_dequantize(qweight, scales, out_features, in_features):
     return result
 
 
+def pack_rawint4_uint8_as_int32(qweight):
+    """Pack byte RAWINT4 layout into compressed-tensors int32 storage."""
+    assert qweight.dtype == torch.uint8
+    assert qweight.shape[1] % 4 == 0
+    return qweight.contiguous().view(torch.int32).contiguous()
+
+
 def act_fn(x):
     return x / (1.0 + torch.exp(-x))
 
@@ -277,6 +284,77 @@ def test_rawint4_accuracy():
     for backend_name, backend_cls, threshold in backends:
         run_backend_accuracy_test(backend_name, backend_cls, threshold, qlen=1)
         run_backend_accuracy_test(backend_name, backend_cls, threshold, qlen=16)
+
+
+def test_compressed_loader_normalizes_int32_pack_quantized_weights():
+    load_amx_utils()
+    loader_mod = sys.modules["kt_kernel.utils.loader"]
+
+    weight_bf16 = (torch.randn((intermediate_size, hidden_size), dtype=torch.float32) / 10.0).to(torch.bfloat16)
+    qweight, scales = rawint4_quantize(weight_bf16)
+    packed_int32 = pack_rawint4_uint8_as_int32(qweight)
+    weight_shape = torch.tensor([intermediate_size, hidden_size], dtype=torch.int32)
+
+    normalized = loader_mod.CompressedSafeTensorLoader._normalize_rawint4_weight(
+        packed_int32, scales, weight_shape, "test.weight_packed"
+    )
+
+    assert normalized.dtype == torch.uint8
+    assert normalized.shape == qweight.shape
+    assert torch.equal(normalized, qweight)
+
+
+def test_compressed_loader_accepts_uint8_rawint4_weights():
+    load_amx_utils()
+    loader_mod = sys.modules["kt_kernel.utils.loader"]
+
+    weight_bf16 = (torch.randn((intermediate_size, hidden_size), dtype=torch.float32) / 10.0).to(torch.bfloat16)
+    qweight, scales = rawint4_quantize(weight_bf16)
+    weight_shape = torch.tensor([intermediate_size, hidden_size], dtype=torch.int32)
+
+    normalized = loader_mod.CompressedSafeTensorLoader._normalize_rawint4_weight(
+        qweight, scales, weight_shape, "test.weight_packed"
+    )
+
+    assert normalized.dtype == torch.uint8
+    assert normalized.shape == qweight.shape
+    assert torch.equal(normalized, qweight)
+
+
+def test_compressed_loader_ignores_invalid_weight_shape_metadata():
+    load_amx_utils()
+    loader_mod = sys.modules["kt_kernel.utils.loader"]
+
+    weight_bf16 = (torch.randn((intermediate_size, hidden_size), dtype=torch.float32) / 10.0).to(torch.bfloat16)
+    qweight, scales = rawint4_quantize(weight_bf16)
+    packed_int32 = pack_rawint4_uint8_as_int32(qweight)
+    invalid_shape = torch.tensor([-1752796263, -1707567530], dtype=torch.int32)
+
+    normalized = loader_mod.CompressedSafeTensorLoader._normalize_rawint4_weight(
+        packed_int32, scales, invalid_shape, "test.weight_packed"
+    )
+
+    assert normalized.dtype == torch.uint8
+    assert normalized.shape == qweight.shape
+    assert torch.equal(normalized, qweight)
+
+
+def test_compressed_loader_ignores_odd_weight_shape_metadata():
+    load_amx_utils()
+    loader_mod = sys.modules["kt_kernel.utils.loader"]
+
+    weight_bf16 = (torch.randn((intermediate_size, hidden_size), dtype=torch.float32) / 10.0).to(torch.bfloat16)
+    qweight, scales = rawint4_quantize(weight_bf16)
+    packed_int32 = pack_rawint4_uint8_as_int32(qweight)
+    invalid_shape = torch.tensor([241597647, 1216029047], dtype=torch.int32)
+
+    normalized = loader_mod.CompressedSafeTensorLoader._normalize_rawint4_weight(
+        packed_int32, scales, invalid_shape, "test.weight_packed"
+    )
+
+    assert normalized.dtype == torch.uint8
+    assert normalized.shape == qweight.shape
+    assert torch.equal(normalized, qweight)
 
 
 def test_rawint4_backend_selection_falls_back_to_avx2_for_large_group_size(monkeypatch):


### PR DESCRIPTION
## Summary

Fixes #2067.

This patch lets `CompressedSafeTensorLoader` accept compressed-tensors RAWINT4 expert weights when `weight_packed` is stored as `torch.int32`.

The loader normalizes the int32 pack-quantized layout to the byte-packed `torch.uint8` layout expected by `kt_kernel_ext`, while preserving the existing uint8 path.

## Why

Some compressed-tensors RAWINT4 files store eight int4 values per int32. The RAWINT4 kernels consume the same bytes as uint8, two int4 values per byte. Without normalization, the loader can pass an incompatible dtype/layout to the runtime.

This was found while validating RAWINT4 MoE serving with Kimi-K2.7-Code on a DCU test system.

## Tests

- `git diff --check HEAD~1 HEAD`
- `python3 -m py_compile kt-kernel/python/utils/loader.py kt-kernel/test/per_commit/test_moe_rawint4_accuracy.py`

The patch also adds per-commit coverage for:

- int32 pack-quantized RAWINT4 normalization
- uint8 RAWINT4 pass-through
- invalid/odd `weight_shape` metadata fallback behavior
