### PR TITLE
[fix](cli): parse configured SGLang arg strings

### DIFF
--- a/kt-kernel/python/cli/commands/run.py
+++ b/kt-kernel/python/cli/commands/run.py
@@ -5,6 +5,7 @@ Starts the model inference server using SGLang + kt-kernel.
 """
 
 import os
+import shlex
 import subprocess
 import sys
 from pathlib import Path
@@ -758,6 +759,10 @@ def _build_sglang_command(
     # Add extra args from settings
     extra_args = settings.get("advanced.sglang_args", [])
     if extra_args:
+        if isinstance(extra_args, str):
+            extra_args = shlex.split(extra_args)
+        elif not isinstance(extra_args, list) or not all(isinstance(arg, str) for arg in extra_args):
+            raise click.BadParameter("advanced.sglang_args must be a string or a list of strings")
         cmd.extend(extra_args)
 
     # Add extra CLI args (user-provided options not defined in kt CLI)

--- a/kt-kernel/python/cli/commands/run.py
+++ b/kt-kernel/python/cli/commands/run.py
@@ -760,7 +760,10 @@ def _build_sglang_command(
     extra_args = settings.get("advanced.sglang_args", [])
     if extra_args:
         if isinstance(extra_args, str):
-            extra_args = shlex.split(extra_args)
+            try:
+                extra_args = shlex.split(extra_args)
+            except ValueError as e:
+                raise click.BadParameter(f"Failed to parse advanced.sglang_args: {e}") from e
         elif not isinstance(extra_args, list) or not all(isinstance(arg, str) for arg in extra_args):
             raise click.BadParameter("advanced.sglang_args must be a string or a list of strings")
         cmd.extend(extra_args)

--- a/kt-kernel/test/per_commit/test_run_sglang_args.py
+++ b/kt-kernel/test/per_commit/test_run_sglang_args.py
@@ -1,0 +1,83 @@
+import importlib.util
+import os
+import sys
+import types
+import unittest
+from pathlib import Path
+
+import click
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+from ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=0.1, suite="default")
+
+
+KT_KERNEL_PATH = Path(__file__).resolve().parents[2] / "python"
+kt_kernel = types.ModuleType("kt_kernel")
+kt_kernel.__path__ = [str(KT_KERNEL_PATH)]
+sys.modules.setdefault("kt_kernel", kt_kernel)
+
+RUN_PATH = KT_KERNEL_PATH / "cli" / "commands" / "run.py"
+SPEC = importlib.util.spec_from_file_location("run_command", RUN_PATH)
+assert SPEC is not None and SPEC.loader is not None
+run_command = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(run_command)
+
+
+class Settings:
+    def __init__(self, sglang_args):
+        self.sglang_args = sglang_args
+
+    def get(self, key, default=None):
+        if key == "advanced.sglang_args":
+            return self.sglang_args
+        return default
+
+
+def build_command(sglang_args):
+    return run_command._build_sglang_command(
+        model_path=Path("/tmp/model"),
+        weights_path=None,
+        host="0.0.0.0",
+        port=30000,
+        gpu_experts=1,
+        cpu_threads=1,
+        numa_nodes=1,
+        tensor_parallel_size=1,
+        kt_method="AMXINT4",
+        kt_gpu_prefill_threshold=4096,
+        attention_backend="flashinfer",
+        max_total_tokens=40000,
+        max_running_requests=32,
+        chunked_prefill_size=4096,
+        mem_fraction_static=0.98,
+        watchdog_timeout=3000,
+        served_model_name="",
+        disable_shared_experts_fusion=False,
+        kt_numa_nodes=None,
+        tool_call_parser=None,
+        reasoning_parser=None,
+        settings=Settings(sglang_args),
+    )
+
+
+class TestRunSglangArgs(unittest.TestCase):
+    def test_string_sglang_args_are_split_into_argv_tokens(self):
+        cmd = build_command("--log-level warning")
+
+        self.assertEqual(cmd[-2:], ["--log-level", "warning"])
+        self.assertNotEqual(cmd[-19:], list("--log-level warning"))
+
+    def test_list_sglang_args_are_appended_unchanged(self):
+        cmd = build_command(["--log-level", "warning"])
+
+        self.assertEqual(cmd[-2:], ["--log-level", "warning"])
+
+    def test_invalid_sglang_args_type_is_rejected(self):
+        with self.assertRaises(click.BadParameter):
+            build_command({"log-level": "warning"})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/kt-kernel/test/per_commit/test_run_sglang_args.py
+++ b/kt-kernel/test/per_commit/test_run_sglang_args.py
@@ -78,6 +78,12 @@ class TestRunSglangArgs(unittest.TestCase):
         with self.assertRaises(click.BadParameter):
             build_command({"log-level": "warning"})
 
+    def test_unmatched_quotes_in_string_are_rejected(self):
+        with self.assertRaises(click.BadParameter) as exc:
+            build_command("--log-level 'warning")
+
+        self.assertIn("No closing quotation", str(exc.exception))
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
﻿# What does this PR do?

Normalizes configured `advanced.sglang_args` before appending them to the SGLang launch argv.

## What Problem This Solves

`kt run` builds the SGLang launch command as an argv list, but configured `advanced.sglang_args` can currently reach that builder as a plain string.

For example:

```bash
kt config set advanced.sglang_args "--log-level warning"
```

stores `advanced.sglang_args` as a string. `_build_sglang_command()` then passes that value to:

```python
cmd.extend(extra_args)
```

Because Python strings are iterable, `extend()` expands the value into single-character argv entries such as `'-', '-', 'l', ...` instead of complete command-line tokens like `['--log-level', 'warning']`.

The result is a silently malformed launch command: configuration appears to save successfully, but `kt run` later constructs broken arguments for `sglang.launch_server`.

## Changes

This PR normalizes `advanced.sglang_args` at the SGLang command-construction boundary:

- string values are parsed with `shlex.split()` into real argv tokens
- malformed string values, such as unmatched quotes, are reported as `click.BadParameter`
- existing `list[str]` values are appended unchanged
- unsupported config types are rejected with a clear parameter error

This intentionally leaves `extra_cli_args` unchanged because that path already comes from Click passthrough arguments as a list, and it does not change the generic config parser because ordinary strings are valid for other config keys.

## Evidence

Before the fix, a focused reproduction showed that a string config value was expanded character by character:

```text
parsed_type= str
parsed_value= --log-level warning
expected_tail_present= False
actual_last_19_entries= ['-', '-', 'l', 'o', 'g', '-', 'l', 'e', 'v', 'e', 'l', ' ', 'w', 'a', 'r', 'n', 'i', 'n', 'g']
is_character_split= True
```

After the fix, the focused test verifies:

- string config values become complete argv tokens: `['--log-level', 'warning']`
- existing `list[str]` config values are appended unchanged
- invalid config types are rejected with `click.BadParameter`
- malformed string values with unmatched quotes are rejected with `click.BadParameter`

## Possible call chain / impact

```text
kt config set advanced.sglang_args "--log-level warning"
  -> kt_kernel.cli.commands.config._parse_value(...)
  -> settings stores advanced.sglang_args as str
  -> kt run
  -> kt_kernel.cli.commands.run._build_sglang_command(...)
  -> cmd.extend(extra_args)
  -> broken single-character argv entries without this fix
```

This affects configured SGLang extra arguments consumed through `advanced.sglang_args`. It does not change ordinary CLI passthrough args, existing `list[str]` config values, or unrelated configuration keys.

Fixes #2078

## Validation

- `D:\ZXY\Dev\Miniforge3\envs\prw-ktransformers-py311\python.exe -m pytest test/per_commit/test_run_sglang_args.py -q` from `kt-kernel` — `4 passed`
- `D:\ZXY\Dev\Miniforge3\envs\prw-ktransformers-py311\python.exe test/per_commit/test_run_sglang_args.py` from `kt-kernel` — `OK`
- `D:\ZXY\Dev\Miniforge3\envs\prw-ktransformers-py311\python.exe -m black --check python/cli/commands/run.py test/per_commit/test_run_sglang_args.py` from `kt-kernel` — passed
- `D:\ZXY\Dev\Miniforge3\envs\prw-ktransformers-py311\python.exe -m py_compile python/cli/commands/run.py test/per_commit/test_run_sglang_args.py` from `kt-kernel` — passed
- `git diff --check` from `kt-kernel` — passed

## Before submitting

- [x] Did you read the [contributor guideline](https://github.com/kvcache-ai/ktransformers/blob/main/.github/CONTRIBUTING.md)?
- [x] Did you write any new necessary tests?
