### PR TITLE
fix(security): bind balance_serve scheduler ZMQ socket to loopback (#2087)

### DIFF
--- a/archive/kt-sft/ktransformers/server/balance_serve/sched_rpc.py
+++ b/archive/kt-sft/ktransformers/server/balance_serve/sched_rpc.py
@@ -28,7 +28,7 @@ class SchedulerServer:
         self.context = zmq.Context()
         self.frontend = self.context.socket(zmq.ROUTER)
         print(f"sched zmq rpc server on port {main_args.sched_port}")
-        self.frontend.bind(f"tcp://*:{main_args.sched_port}") 
+        self.frontend.bind(f"tcp://127.0.0.1:{main_args.sched_port}") 
 
         self.backend = self.context.socket(zmq.DEALER)
         self.backend.bind("inproc://backend")

--- a/archive/ktransformers/server/balance_serve/sched_rpc.py
+++ b/archive/ktransformers/server/balance_serve/sched_rpc.py
@@ -40,7 +40,7 @@ class SchedulerServer:
         self.context = zmq.Context()
         self.frontend = self.context.socket(zmq.ROUTER)
         print(f"sched zmq rpc server on port {main_args.sched_port}")
-        self.frontend.bind(f"tcp://*:{main_args.sched_port}") 
+        self.frontend.bind(f"tcp://127.0.0.1:{main_args.sched_port}") 
 
         # 创建内部的 DEALER 套接字，用于与工作线程通信
         self.backend = self.context.socket(zmq.DEALER)


### PR DESCRIPTION
## Summary

Fixes #2087 (GHSA-83vp-v6wg-x93x): unauthenticated pickle-deserialization RCE on the `balance_serve` scheduler.

The scheduler binds its ZeroMQ ROUTER socket with `tcp://*` (i.e. `0.0.0.0`, **all** interfaces) and calls `pickle.loads()` on every received message with no authentication. Any host that can reach the auto-assigned `sched_port` can send a crafted pickle whose `__reduce__` runs a shell command, achieving remote code execution as the server process.

## Fix

Bind the scheduler socket to loopback (`tcp://127.0.0.1`) instead of `tcp://*`.

This is safe because the scheduler RPC is **purely inter-process on the same host**:

- `SchedulerClient.__init__` already connects to `tcp://localhost:{sched_port}` (`sched_rpc.py`), and
- the scheduler is launched as a local subprocess by the `balance_serve` backend (`subprocess.Popen([... sched_rpc.py ...])`).

So loopback binding is functionally identical for the legitimate local client, while removing the socket from every non-loopback interface and closing the network attack surface. This implements the primary remediation from the issue ("Bind the scheduler socket to loopback").

## Scope

- Applied to both copies of the file that carry the identical bind:
  - `archive/ktransformers/server/balance_serve/sched_rpc.py`
  - `archive/kt-sft/ktransformers/server/balance_serve/sched_rpc.py`
- Each change is a single line (`tcp://*` → `tcp://127.0.0.1`).

**Left out of scope (larger change):** the `pickle.loads()` on the inter-process channel remains. With the socket now loopback-only the network RCE vector is closed, but replacing pickle with a schema-validated format (JSON/msgpack) or adding ZeroMQ CURVE auth is a broader design change best handled separately — happy to follow up if maintainers want it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
