### PR TITLE
[feat](kt-kernel): add co-activation-aware and online-EMA GPU expert placement

### DIFF
--- a/kt-kernel/python/__init__.py
+++ b/kt-kernel/python/__init__.py
@@ -52,6 +52,13 @@ kt_kernel_ext = _kt_kernel_ext
 # Import main API
 from .experts import KTMoEWrapper
 from .experts_base import generate_gpu_experts_masks
+from .expert_placement import (
+    EmaHotnessTracker,
+    build_coactivation_matrix,
+    gpu_hit_rate,
+    plan_gpu_expert_placement,
+    token_resident_rate,
+)
 
 def __getattr__(name):
     if name == "AMXSFTMoEWrapper":
@@ -93,4 +100,16 @@ except ImportError:
     except ImportError:
         __version__ = "0.6.1"
 
-__all__ = ["KTMoEWrapper", "AMXSFTMoEWrapper", "generate_gpu_experts_masks", "kt_kernel_ext", "__cpu_variant__", "__version__"]
+__all__ = [
+    "KTMoEWrapper",
+    "AMXSFTMoEWrapper",
+    "generate_gpu_experts_masks",
+    "plan_gpu_expert_placement",
+    "EmaHotnessTracker",
+    "build_coactivation_matrix",
+    "gpu_hit_rate",
+    "token_resident_rate",
+    "kt_kernel_ext",
+    "__cpu_variant__",
+    "__version__",
+]

--- a/kt-kernel/python/expert_placement.py
+++ b/kt-kernel/python/expert_placement.py
@@ -1,0 +1,590 @@
+# Co-activation-aware GPU expert placement planner
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Co-activation-aware GPU expert placement for MoE inference.
+
+The default placement helper (:func:`kt_kernel.generate_gpu_experts_masks`)
+selects the globally most-frequently-activated experts. That objective scores
+every expert *independently*: it answers "which experts are hot on their own?"
+but is blind to which experts fire *together* on the same token.
+
+For CPU/GPU hybrid MoE serving this matters. Every token routes to ``top_k``
+experts, and the throughput-relevant quantity is how many of a token's routed
+experts are GPU-resident. If two experts almost always co-fire but only one is
+placed on the GPU, that token still pays the slow CPU path for the other. A
+placement that keeps *co-firing clusters* together therefore raises the
+per-token GPU hit rate at the same GPU-expert budget.
+
+This module builds pairwise co-occurrence statistics from per-token expert
+selection traces and plans placement to maximise expected co-resident hits per
+token, rather than the sum of marginal frequencies. When only marginal
+activation counts are available (no per-token traces), it degrades to exactly
+the frequency top-k behaviour, so it never regresses against the existing
+strategy.
+
+The planner is pure Python/torch, performs no routing and no weight movement,
+and produces the same ``(num_layers, num_experts)`` boolean mask that the rest
+of the pipeline already consumes.
+
+Example:
+    >>> import torch
+    >>> from kt_kernel.expert_placement import plan_gpu_expert_placement
+    >>> # Two layers, four experts, per-token routed-expert traces per layer.
+    >>> traces = {
+    ...     0: torch.tensor([[0, 1], [0, 1], [2, 3]]),
+    ...     1: torch.tensor([[1, 2], [1, 2], [0, 3]]),
+    ... }
+    >>> mask = plan_gpu_expert_placement(
+    ...     num_layers=2, num_experts=4, num_gpu_experts=4, token_traces=traces
+    ... )
+    >>> mask.shape
+    torch.Size([2, 4])
+"""
+
+from __future__ import annotations
+
+import torch
+from typing import Dict, Optional
+
+
+def build_coactivation_matrix(
+    token_traces: torch.Tensor,
+    num_experts: int,
+) -> torch.Tensor:
+    """
+    Build a symmetric pairwise co-occurrence matrix from per-token traces.
+
+    ``C[i][j]`` counts the number of tokens in which experts ``i`` and ``j``
+    were both routed. The diagonal ``C[i][i]`` holds the marginal activation
+    count of expert ``i`` (the number of tokens that routed to it).
+
+    Args:
+        token_traces: Long/int tensor of shape ``(num_tokens, top_k)`` holding
+                      the routed expert ids for each token in one layer. Values
+                      outside ``[0, num_experts)`` (e.g. ``-1`` padding) are
+                      ignored.
+        num_experts: Total number of experts in the layer.
+
+    Returns:
+        Float tensor of shape ``(num_experts, num_experts)`` on CPU.
+    """
+    coactivation = torch.zeros(num_experts, num_experts, dtype=torch.float32, device="cpu")
+
+    if token_traces.numel() == 0:
+        return coactivation
+
+    traces = token_traces.to(device="cpu", dtype=torch.long)
+    if traces.dim() == 1:
+        traces = traces.unsqueeze(0)
+
+    num_tokens, top_k = traces.shape
+    for token_idx in range(num_tokens):
+        ids = traces[token_idx]
+        valid = ids[(ids >= 0) & (ids < num_experts)]
+        unique_ids = torch.unique(valid)
+        if unique_ids.numel() == 0:
+            continue
+        # Outer product over the present experts increments every ordered pair,
+        # including the (i, i) diagonal, giving marginal counts for free.
+        rows = unique_ids.unsqueeze(1).expand(-1, unique_ids.numel()).reshape(-1)
+        cols = unique_ids.unsqueeze(0).expand(unique_ids.numel(), -1).reshape(-1)
+        coactivation[rows, cols] += 1.0
+
+    return coactivation
+
+
+def _greedy_cluster_select(
+    coactivation: torch.Tensor,
+    budget: int,
+) -> torch.Tensor:
+    """
+    Greedily select ``budget`` experts that form a tight co-firing cluster.
+
+    The objective is to keep experts that fire *together* on the GPU, so that
+    whole tokens become GPU-resident and skip the CPU path. The selection is
+    seeded with the single strongest co-firing pair (largest off-diagonal
+    entry), then grown by adding, at each step, the expert with the highest
+    total co-activation with the experts already chosen.
+
+    Seeding from the strongest pair rather than the single hottest expert is
+    what distinguishes this from frequency top-k: an individually-hot expert
+    that never co-fires with a resident partner does not help whole-token
+    residency, whereas a co-firing pair does.
+
+    Args:
+        coactivation: ``(num_experts, num_experts)`` co-occurrence matrix whose
+                      diagonal holds marginal counts and whose off-diagonal
+                      holds pairwise co-firing counts.
+        budget: Number of experts to select for this layer.
+
+    Returns:
+        Long tensor of selected expert indices (length ``min(budget, num_experts)``).
+    """
+    num_experts = coactivation.shape[0]
+    budget = max(0, min(int(budget), num_experts))
+    if budget == 0:
+        return torch.empty(0, dtype=torch.long)
+
+    marginal = torch.diagonal(coactivation)
+    if budget == 1:
+        # No pair to keep together; fall back to the hottest single expert.
+        return torch.tensor([int(torch.argmax(marginal).item())], dtype=torch.long)
+
+    # Off-diagonal only: zero the diagonal so seeding picks a genuine pair.
+    off_diagonal = coactivation - torch.diag(marginal)
+    selected = torch.zeros(num_experts, dtype=torch.bool)
+
+    # Seed with the strongest co-firing pair. argmax over the flattened matrix
+    # yields the (i, j) with the largest co-activation; ties break toward the
+    # lowest flattened index for determinism.
+    pair_flat = int(torch.argmax(off_diagonal).item())
+    seed_i, seed_j = divmod(pair_flat, num_experts)
+    if off_diagonal[seed_i, seed_j] <= 0:
+        # No expert ever co-fires with another (degenerate trace): fall back to
+        # marginal top-k so behaviour matches the frequency strategy.
+        return torch.topk(marginal, k=budget, largest=True, sorted=False).indices
+    selected[seed_i] = True
+    selected[seed_j] = True
+
+    # Affinity of every expert to the current selected set.
+    affinity = off_diagonal[seed_i].clone() + off_diagonal[seed_j].clone()
+
+    while int(selected.sum().item()) < budget:
+        candidate_score = affinity.clone()
+        candidate_score[selected] = float("-inf")
+        # Tie-break toward the hotter marginal expert, then lowest index.
+        best_score = torch.max(candidate_score)
+        if best_score == float("-inf"):
+            break
+        tied = (candidate_score == best_score).nonzero(as_tuple=False).flatten()
+        best = int(tied[torch.argmax(marginal[tied])].item())
+        selected[best] = True
+        affinity += off_diagonal[best]
+
+    chosen = int(selected.sum().item())
+    if chosen < budget:
+        # Cluster smaller than budget (isolated experts remain): fill the rest
+        # by marginal frequency so the GPU budget is fully used.
+        remaining = budget - chosen
+        fill_scores = marginal.clone()
+        fill_scores[selected] = float("-inf")
+        extra = torch.topk(fill_scores, k=remaining, largest=True, sorted=False).indices
+        selected[extra] = True
+
+    return torch.nonzero(selected, as_tuple=False).flatten()
+
+
+def _coverage_select(
+    token_traces: torch.Tensor,
+    num_experts: int,
+    budget: int,
+    core_threshold: float = 0.9,
+) -> torch.Tensor:
+    """
+    Select experts to maximise the number of *fully-resident tokens* (coverage).
+
+    A token skips the CPU path only when *every* one of its routed experts is on
+    the GPU. The objective is therefore not to place the tightest cluster nor
+    the individually-hottest experts, but to cover as many whole tokens as the
+    budget allows. This is a weighted maximum-coverage / set-cover problem.
+
+    Two-phase greedy:
+
+    1. **Core.** Experts that fire in at least ``core_threshold`` of tokens are
+       placed first. A stable core (e.g. the 6 experts present in nearly every
+       token of a Qwen-style top-8 route) is always worth resident space.
+    2. **Residual set-cover.** Each token is reduced to its non-core experts.
+       The planner repeatedly adds the group of residual experts that covers the
+       most currently-uncovered tokens per extra slot spent
+       (``tokens_gained / new_experts_needed``), until the budget is exhausted.
+
+    Crucially, co-occurrence is scored *among residual (non-core) experts*, not
+    against the always-on core. Scoring against the core is misleading: every
+    expert co-occurs with an always-on core, so an expert whose true partner can
+    never be afforded would look attractive yet complete zero tokens. Reducing
+    to residuals removes that decoy signal.
+
+    Args:
+        token_traces: ``(num_tokens, top_k)`` routed expert ids for one layer.
+        num_experts: Total experts in the layer.
+        budget: GPU-expert budget for this layer.
+        core_threshold: Fraction of tokens an expert must appear in to be treated
+                        as always-on core. Defaults to 0.9.
+
+    Returns:
+        Long tensor of selected expert indices (length ``<= budget``).
+    """
+    budget = max(0, min(int(budget), num_experts))
+    if budget == 0:
+        return torch.empty(0, dtype=torch.long)
+
+    traces = token_traces.to(device="cpu", dtype=torch.long)
+    if traces.dim() == 1:
+        traces = traces.unsqueeze(0)
+
+    # Reduce each token to the set of valid, unique routed experts.
+    token_sets = []
+    for token_ids in traces:
+        valid = token_ids[(token_ids >= 0) & (token_ids < num_experts)]
+        if valid.numel() > 0:
+            token_sets.append(set(int(e) for e in valid.tolist()))
+    num_tokens = len(token_sets)
+    if num_tokens == 0:
+        return torch.empty(0, dtype=torch.long)
+
+    # Marginal presence per expert.
+    presence = torch.zeros(num_experts, dtype=torch.float32)
+    for s in token_sets:
+        for e in s:
+            presence[e] += 1.0
+
+    selected = torch.zeros(num_experts, dtype=torch.bool)
+
+    # Phase 1: place the always-on core (subject to budget).
+    core = (presence >= core_threshold * num_tokens) & (presence > 0)
+    core_ids = torch.nonzero(core, as_tuple=False).flatten()
+    # If the core alone exceeds budget, keep the most frequent core experts.
+    if core_ids.numel() > budget:
+        keep = torch.topk(presence[core_ids], k=budget, largest=True, sorted=False).indices
+        core_ids = core_ids[keep]
+    selected[core_ids] = True
+
+    # Phase 2: weighted set-cover on residuals (non-core experts per token).
+    selected_set = set(int(e) for e in torch.nonzero(selected, as_tuple=False).flatten().tolist())
+    while int(selected.sum().item()) < budget:
+        remaining_budget = budget - int(selected.sum().item())
+
+        # For each not-yet-selected expert, tally the residual it would help
+        # complete: tokens whose only missing experts include it. We score whole
+        # residual groups by counting, per uncovered token, the extra experts it
+        # needs, and crediting candidate groups by tokens-gained per slot.
+        # Aggregate candidate residual groups across uncovered tokens.
+        group_gain: Dict[frozenset, int] = {}
+        for s in token_sets:
+            missing = s - selected_set
+            if not missing:
+                continue  # already fully covered
+            if len(missing) > remaining_budget:
+                continue  # cannot be completed within remaining budget
+            key = frozenset(missing)
+            group_gain[key] = group_gain.get(key, 0) + 1
+
+        if not group_gain:
+            break  # no token can be completed with the remaining budget
+
+        # Pick the residual group with the best tokens-gained-per-extra-slot,
+        # breaking ties toward more tokens covered, then fewer experts.
+        best_key = None
+        best_ratio = -1.0
+        best_tokens = -1
+        for key, tokens_gained in group_gain.items():
+            cost = len(key)
+            ratio = tokens_gained / cost
+            if ratio > best_ratio or (ratio == best_ratio and tokens_gained > best_tokens):
+                best_ratio = ratio
+                best_tokens = tokens_gained
+                best_key = key
+
+        if best_key is None:
+            break
+        for e in best_key:
+            selected[e] = True
+            selected_set.add(e)
+
+    # If budget remains and every token is covered, fill by marginal frequency.
+    if int(selected.sum().item()) < budget:
+        remaining = budget - int(selected.sum().item())
+        fill_scores = presence.clone()
+        fill_scores[selected] = float("-inf")
+        extra = torch.topk(fill_scores, k=remaining, largest=True, sorted=False).indices
+        selected[extra] = True
+
+    return torch.nonzero(selected, as_tuple=False).flatten()
+
+
+def plan_gpu_expert_placement(
+    num_layers: int,
+    num_experts: int,
+    num_gpu_experts: int,
+    token_traces: Optional[Dict[int, torch.Tensor]] = None,
+    activation_freq: Optional[torch.Tensor] = None,
+    strategy: str = "coverage",
+    core_threshold: float = 0.9,
+) -> torch.Tensor:
+    """
+    Plan GPU expert placement to maximise whole-token GPU residency.
+
+    The GPU-expert budget is distributed evenly across layers (matching the
+    ``num_gpu_experts`` semantics used elsewhere: it is the per-layer count).
+
+    Strategies (used only when per-layer ``token_traces`` are available):
+        - ``"coverage"`` (default): weighted maximum-coverage. Places a stable
+          core, then greedily adds the residual expert groups that complete the
+          most tokens per slot. Maximises the number of fully-resident tokens,
+          which is the quantity that governs CPU-path avoidance. See
+          :func:`_coverage_select`.
+        - ``"cluster"``: single greedy co-firing cluster grown from the strongest
+          pair. See :func:`_greedy_cluster_select`.
+
+    Fallback order when a layer has no traces (independent of ``strategy``):
+        1. ``activation_freq`` present -> marginal frequency top-k (identical to
+           :func:`generate_gpu_experts_masks` restricted per layer).
+        2. Neither -> uniform (first ``num_gpu_experts`` experts per layer).
+
+    Args:
+        num_layers: Number of MoE layers.
+        num_experts: Experts per layer.
+        num_gpu_experts: Experts to place on GPU *per layer*.
+        token_traces: Optional mapping ``layer_idx -> (num_tokens, top_k)`` tensor
+                      of routed expert ids. Layers absent from the map fall back
+                      to ``activation_freq``/uniform for that layer.
+        activation_freq: Optional ``(num_layers, num_experts)`` marginal counts,
+                         used as a fallback when a layer has no traces.
+        strategy: ``"coverage"`` or ``"cluster"``. Defaults to ``"coverage"``.
+        core_threshold: Core-membership fraction for the coverage strategy.
+
+    Returns:
+        Boolean mask of shape ``(num_layers, num_experts)`` on CPU. ``True``
+        means the expert should be placed on GPU.
+    """
+    if strategy not in ("coverage", "cluster"):
+        raise ValueError(f"unknown strategy {strategy!r}; expected 'coverage' or 'cluster'")
+
+    per_layer_budget = max(0, min(int(num_gpu_experts), num_experts))
+    mask = torch.zeros(num_layers, num_experts, dtype=torch.bool, device="cpu")
+
+    if per_layer_budget == 0:
+        return mask
+
+    for layer_idx in range(num_layers):
+        layer_trace = None if token_traces is None else token_traces.get(layer_idx)
+
+        if layer_trace is not None and layer_trace.numel() > 0:
+            if strategy == "coverage":
+                selected = _coverage_select(layer_trace, num_experts, per_layer_budget, core_threshold)
+            else:
+                coactivation = build_coactivation_matrix(layer_trace, num_experts)
+                selected = _greedy_cluster_select(coactivation, per_layer_budget)
+        elif activation_freq is not None:
+            freq = activation_freq[layer_idx].to(device="cpu")
+            selected = torch.topk(freq, k=per_layer_budget, largest=True, sorted=False).indices
+        else:
+            selected = torch.arange(per_layer_budget, dtype=torch.long)
+
+        mask[layer_idx, selected] = True
+
+    return mask
+
+
+class EmaHotnessTracker:
+    """Online per-layer EMA expert-hotness tracker for adaptive GPU placement.
+
+    The planners above choose a *static* placement from a fixed trace. In serving
+    the workload shifts -- a coding request routes to different experts than a
+    math one -- so a mask frozen at load time drifts out of date and the per-token
+    GPU hit rate falls. This tracker instead maintains a per-layer exponential
+    moving average of expert activation and can emit an up-to-date residency mask
+    at any point, adapting to the live workload with only ``O(top_k)`` work per
+    layer per observed token.
+
+    It is workload- and model-agnostic: no offline profile and no per-domain
+    tables are required, so the same tracker applies unchanged across models,
+    quantizations, and deployments. Cold start optionally warms from marginal
+    activation frequencies (e.g. the same ``activation_freq`` that
+    :func:`generate_gpu_experts_masks` consumes); with no prior it begins uniform
+    and converges as tokens arrive. Because the warm-started mask before any
+    observation is exactly frequency top-k, the tracker never regresses against
+    the existing static strategy at cold start.
+
+    The update rule matches a standard EMA of the per-token activation indicator:
+    each observed token decays every score by ``decay`` and adds ``1 - decay`` to
+    the experts it routed to. Higher ``decay`` means longer memory (closer to
+    global frequency); lower ``decay`` adapts faster to the current request.
+
+    This class performs no routing and moves no weights. It only tracks statistics
+    and produces the same ``(num_layers, num_experts)`` boolean mask the rest of
+    the pipeline already consumes, so integrating it is a drop-in replacement for a
+    static mask.
+
+    Example:
+        >>> tracker = EmaHotnessTracker(num_layers=2, num_experts=4,
+        ...                             num_gpu_experts=2, decay=0.9)
+        >>> tracker.observe(0, torch.tensor([0, 1]))  # a token routed to 0,1
+        >>> tracker.observe(0, torch.tensor([0, 2]))  # then to 0,2
+        >>> mask = tracker.mask()
+        >>> mask.shape
+        torch.Size([2, 4])
+    """
+
+    def __init__(
+        self,
+        num_layers: int,
+        num_experts: int,
+        num_gpu_experts: int,
+        decay: float = 0.9,
+        activation_freq: Optional[torch.Tensor] = None,
+    ) -> None:
+        if num_layers <= 0 or num_experts <= 0:
+            raise ValueError("num_layers and num_experts must be positive")
+        if not 0.0 <= decay < 1.0:
+            raise ValueError(f"decay must be in [0.0, 1.0); got {decay}")
+
+        self.num_layers = int(num_layers)
+        self.num_experts = int(num_experts)
+        self.num_gpu_experts = max(0, min(int(num_gpu_experts), int(num_experts)))
+        self.decay = float(decay)
+        self._hotness = torch.zeros(self.num_layers, self.num_experts, dtype=torch.float32, device="cpu")
+
+        if activation_freq is not None:
+            freq = activation_freq.to(device="cpu", dtype=torch.float32)
+            if freq.shape != (self.num_layers, self.num_experts):
+                raise ValueError(
+                    f"activation_freq shape {tuple(freq.shape)} != " f"{(self.num_layers, self.num_experts)}"
+                )
+            # Normalise each layer to a proper starting hotness so the warm-start
+            # mask equals frequency top-k. Rows that are all-zero stay uniform.
+            row_max = freq.amax(dim=1, keepdim=True)
+            self._hotness = torch.where(row_max > 0, freq / row_max, freq)
+
+    def observe(self, layer_idx: int, routed_expert_ids: torch.Tensor) -> None:
+        """Update one layer's EMA with the experts a single token routed to.
+
+        Args:
+            layer_idx: Layer index in ``[0, num_layers)``. Out-of-range is ignored.
+            routed_expert_ids: 1-D tensor of the token's routed expert ids. Values
+                               outside ``[0, num_experts)`` (e.g. ``-1`` padding)
+                               are ignored.
+        """
+        if layer_idx < 0 or layer_idx >= self.num_layers:
+            return
+        ids = routed_expert_ids.to(device="cpu", dtype=torch.long).flatten()
+        ids = ids[(ids >= 0) & (ids < self.num_experts)]
+        row = self._hotness[layer_idx]
+        row.mul_(self.decay)
+        if ids.numel() > 0:
+            row.index_add_(0, ids, torch.full((ids.numel(),), 1.0 - self.decay, dtype=torch.float32))
+
+    def observe_batch(self, token_traces: Dict[int, torch.Tensor]) -> None:
+        """Feed a batch of per-layer traces token-by-token, preserving order.
+
+        Args:
+            token_traces: Mapping ``layer_idx -> (num_tokens, top_k)`` routed ids.
+                          Tokens are consumed in row order so recency is respected.
+        """
+        for layer_idx, traces in token_traces.items():
+            ids = traces.to(device="cpu", dtype=torch.long)
+            if ids.dim() == 1:
+                ids = ids.unsqueeze(0)
+            for token_ids in ids:
+                self.observe(layer_idx, token_ids)
+
+    def scores(self) -> torch.Tensor:
+        """Return a copy of the current ``(num_layers, num_experts)`` EMA scores."""
+        return self._hotness.clone()
+
+    def mask(self) -> torch.Tensor:
+        """Emit the current GPU-residency mask: per-layer top-``num_gpu_experts``.
+
+        Returns:
+            Boolean ``(num_layers, num_experts)`` tensor on CPU. ``True`` means the
+            expert should be GPU-resident given activation observed so far.
+        """
+        mask = torch.zeros(self.num_layers, self.num_experts, dtype=torch.bool, device="cpu")
+        if self.num_gpu_experts == 0:
+            return mask
+        for layer_idx in range(self.num_layers):
+            selected = torch.topk(self._hotness[layer_idx], k=self.num_gpu_experts, largest=True, sorted=False).indices
+            mask[layer_idx, selected] = True
+        return mask
+
+
+def gpu_hit_rate(
+    mask: torch.Tensor,
+    token_traces: Dict[int, torch.Tensor],
+) -> float:
+    """
+    Compute the mean fraction of a token's routed experts that are GPU-resident.
+
+    This per-selection hit rate counts individual experts. Note that it is
+    maximised exactly by marginal frequency top-k, since it equals the summed
+    marginal counts of the resident experts; it does not reward keeping
+    co-firing experts together. Use :func:`token_resident_rate` for the metric
+    that actually reflects CPU-path avoidance.
+
+    Args:
+        mask: ``(num_layers, num_experts)`` boolean GPU-residency mask.
+        token_traces: Mapping ``layer_idx -> (num_tokens, top_k)`` routed ids.
+
+    Returns:
+        Mean per-selection GPU hit rate in ``[0.0, 1.0]``. Returns ``0.0`` when
+        there are no valid routed selections.
+    """
+    total_hits = 0
+    total_selections = 0
+    num_layers, num_experts = mask.shape
+
+    for layer_idx, traces in token_traces.items():
+        if layer_idx < 0 or layer_idx >= num_layers:
+            continue
+        ids = traces.to(device="cpu", dtype=torch.long)
+        if ids.dim() == 1:
+            ids = ids.unsqueeze(0)
+        valid = (ids >= 0) & (ids < num_experts)
+        layer_mask = mask[layer_idx]
+        # Gather residency only for valid ids; clamp to keep indexing in range.
+        resident = layer_mask[ids.clamp(min=0, max=num_experts - 1)]
+        total_hits += int((resident & valid).sum().item())
+        total_selections += int(valid.sum().item())
+
+    if total_selections == 0:
+        return 0.0
+    return total_hits / total_selections
+
+
+def token_resident_rate(
+    mask: torch.Tensor,
+    token_traces: Dict[int, torch.Tensor],
+) -> float:
+    """
+    Compute the fraction of tokens whose routed experts are *all* GPU-resident.
+
+    This is the placement-quality metric that reflects hybrid throughput: a
+    token only skips the slow CPU expert path when *every* one of its routed
+    experts is resident on the GPU. A single non-resident expert forces the CPU
+    path for that whole token, so keeping co-firing experts together (rather
+    than scattering individually-hot ones) is what raises this rate.
+
+    Unlike :func:`gpu_hit_rate`, this metric rewards co-activation-aware
+    placement and is not maximised by marginal frequency top-k.
+
+    Args:
+        mask: ``(num_layers, num_experts)`` boolean GPU-residency mask.
+        token_traces: Mapping ``layer_idx -> (num_tokens, top_k)`` routed ids.
+
+    Returns:
+        Mean fraction of fully-resident tokens in ``[0.0, 1.0]``. Returns ``0.0``
+        when there are no valid tokens.
+    """
+    total_tokens = 0
+    fully_resident = 0
+    num_layers, num_experts = mask.shape
+
+    for layer_idx, traces in token_traces.items():
+        if layer_idx < 0 or layer_idx >= num_layers:
+            continue
+        ids = traces.to(device="cpu", dtype=torch.long)
+        if ids.dim() == 1:
+            ids = ids.unsqueeze(0)
+        layer_mask = mask[layer_idx]
+        for token_ids in ids:
+            valid = token_ids[(token_ids >= 0) & (token_ids < num_experts)]
+            if valid.numel() == 0:
+                continue
+            total_tokens += 1
+            if bool(layer_mask[valid].all()):
+                fully_resident += 1
+
+    if total_tokens == 0:
+        return 0.0
+    return fully_resident / total_tokens

--- a/kt-kernel/python/expert_placement.py
+++ b/kt-kernel/python/expert_placement.py
@@ -78,18 +78,18 @@ def build_coactivation_matrix(
     if traces.dim() == 1:
         traces = traces.unsqueeze(0)
 
+    # Build a per-token binary indicator over experts, then C = I^T @ I. Row
+    # i, col j of the product counts tokens where both i and j were present;
+    # the diagonal holds marginal counts. Out-of-range ids (e.g. -1 padding)
+    # are steered into a scratch column that is dropped before the matmul. The
+    # binary indicator dedups repeated ids within a token, matching the earlier
+    # per-token unique() semantics. Fully vectorized (no Python token loop).
     num_tokens, top_k = traces.shape
-    for token_idx in range(num_tokens):
-        ids = traces[token_idx]
-        valid = ids[(ids >= 0) & (ids < num_experts)]
-        unique_ids = torch.unique(valid)
-        if unique_ids.numel() == 0:
-            continue
-        # Outer product over the present experts increments every ordered pair,
-        # including the (i, i) diagonal, giving marginal counts for free.
-        rows = unique_ids.unsqueeze(1).expand(-1, unique_ids.numel()).reshape(-1)
-        cols = unique_ids.unsqueeze(0).expand(unique_ids.numel(), -1).reshape(-1)
-        coactivation[rows, cols] += 1.0
+    clamped = torch.where((traces >= 0) & (traces < num_experts), traces, num_experts)
+    indicator = torch.zeros(num_tokens, num_experts + 1, dtype=torch.float32, device="cpu")
+    indicator.scatter_(1, clamped, 1.0)
+    indicator = indicator[:, :num_experts]
+    coactivation = indicator.t().mm(indicator)
 
     return coactivation
 
@@ -292,6 +292,11 @@ def _coverage_select(
             selected[e] = True
             selected_set.add(e)
 
+        # Drop tokens that are now fully covered so later iterations scan fewer
+        # of them. Coverage is monotone (selected_set only grows), so a covered
+        # token stays covered and can be removed permanently.
+        token_sets = [s for s in token_sets if not s.issubset(selected_set)]
+
     # If budget remains and every token is covered, fill by marginal frequency.
     if int(selected.sum().item()) < budget:
         remaining = budget - int(selected.sum().item())
@@ -473,11 +478,27 @@ class EmaHotnessTracker:
                           Tokens are consumed in row order so recency is respected.
         """
         for layer_idx, traces in token_traces.items():
+            if layer_idx < 0 or layer_idx >= self.num_layers:
+                continue
             ids = traces.to(device="cpu", dtype=torch.long)
             if ids.dim() == 1:
                 ids = ids.unsqueeze(0)
-            for token_ids in ids:
-                self.observe(layer_idx, token_ids)
+            num_tokens, top_k = ids.shape
+            if num_tokens == 0:
+                continue
+            # Vectorized equivalent of applying observe() to each row in order:
+            # the prior row decays by decay**num_tokens, and token t (0-indexed)
+            # contributes (1 - decay) * decay**(num_tokens - 1 - t), so later
+            # tokens weigh more. A single index_add_ replaces the per-token loop.
+            row = self._hotness[layer_idx]
+            row.mul_(self.decay**num_tokens)
+            exponent = torch.arange(num_tokens, dtype=torch.float32, device="cpu")
+            weights = (1.0 - self.decay) * torch.pow(self.decay, num_tokens - 1 - exponent)
+            flat_weights = weights.unsqueeze(1).expand(-1, top_k).flatten()
+            flat_ids = ids.flatten()
+            valid_mask = (flat_ids >= 0) & (flat_ids < self.num_experts)
+            if valid_mask.any():
+                row.index_add_(0, flat_ids[valid_mask], flat_weights[valid_mask])
 
     def scores(self) -> torch.Tensor:
         """Return a copy of the current ``(num_layers, num_experts)`` EMA scores."""
@@ -577,13 +598,17 @@ def token_resident_rate(
         if ids.dim() == 1:
             ids = ids.unsqueeze(0)
         layer_mask = mask[layer_idx]
-        for token_ids in ids:
-            valid = token_ids[(token_ids >= 0) & (token_ids < num_experts)]
-            if valid.numel() == 0:
-                continue
-            total_tokens += 1
-            if bool(layer_mask[valid].all()):
-                fully_resident += 1
+        # A token counts only if it has >=1 valid routed id, and is fully
+        # resident when every valid id maps to a True mask entry. Vectorized:
+        # padding positions are forced True so they don't fail the all() test,
+        # and tokens with no valid id are excluded from both counts.
+        valid = (ids >= 0) & (ids < num_experts)
+        has_valid = valid.any(dim=1)
+        total_tokens += int(has_valid.sum().item())
+        clamped_ids = ids.clamp(min=0, max=num_experts - 1)
+        resident = layer_mask[clamped_ids]
+        token_ok = (resident | ~valid).all(dim=1)
+        fully_resident += int((token_ok & has_valid).sum().item())
 
     if total_tokens == 0:
         return 0.0

--- a/kt-kernel/test/per_commit/test_expert_placement.py
+++ b/kt-kernel/test/per_commit/test_expert_placement.py
@@ -77,6 +77,13 @@ class TestCoactivationMatrix(unittest.TestCase):
         self.assertEqual(coact.shape, (4, 4))
         self.assertEqual(coact.sum().item(), 0.0)
 
+    def test_repeated_id_within_token_counts_once(self):
+        """A duplicated id in one token contributes a single presence, not two."""
+        traces = torch.tensor([[0, 0], [0, 1]])  # token 0 lists expert 0 twice
+        coact = build_coactivation_matrix(traces, num_experts=2)
+        self.assertEqual(coact[0, 0].item(), 2.0)  # present in 2 tokens, not 3
+        self.assertEqual(coact[0, 1].item(), 1.0)
+
 
 class TestCoactivationBeatsFrequency(unittest.TestCase):
     def test_coactivation_beats_frequency(self):
@@ -411,6 +418,22 @@ class TestEmaHotnessTracker(unittest.TestCase):
         t = EmaHotnessTracker(1, 4, 0)
         t.observe(0, torch.tensor([0, 1]))
         self.assertEqual(int(t.mask().sum()), 0)
+
+    def test_observe_batch_matches_scalar_multitoken(self):
+        """Vectorized observe_batch equals repeated scalar observe on a longer,
+        varied trace including padding -- guards the batched EMA math."""
+        traces = {0: torch.tensor([[0, 1], [2, -1], [1, 3], [0, 0], [3, 2]])}
+        batch = EmaHotnessTracker(1, 4, 2, decay=0.85)
+        batch.observe_batch(traces)
+        seq = EmaHotnessTracker(1, 4, 2, decay=0.85)
+        for row in traces[0]:
+            seq.observe(0, row)
+        self.assertTrue(bool(torch.allclose(batch.scores(), seq.scores(), atol=1e-6)))
+
+    def test_observe_batch_empty_layer(self):
+        t = EmaHotnessTracker(1, 4, 2, decay=0.9)
+        t.observe_batch({0: torch.empty(0, 2, dtype=torch.long)})
+        self.assertEqual(float(t.scores().sum()), 0.0)
 
 
 if __name__ == "__main__":

--- a/kt-kernel/test/per_commit/test_expert_placement.py
+++ b/kt-kernel/test/per_commit/test_expert_placement.py
@@ -1,0 +1,417 @@
+"""Tests for co-activation-aware GPU expert placement.
+
+These tests are pure Python/torch and do not touch the compiled ``kt_kernel_ext``
+extension, so they run in CPU CI. The placement module is imported directly from
+the ``python`` directory (added to ``sys.path``) to avoid importing the package
+``__init__``, which pulls in the native extension.
+
+The central claim under test: when experts fire in correlated clusters, keeping a
+cluster together on the GPU yields a higher per-token GPU hit rate than selecting
+the globally most-frequent experts independently. ``test_coactivation_beats_frequency``
+constructs a trace with a planted cluster and asserts exactly that.
+"""
+
+import os
+import sys
+import unittest
+
+import torch
+
+# Register this test for CPU CI.
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+from ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=5, suite="default")
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "python"))
+import expert_placement
+
+build_coactivation_matrix = expert_placement.build_coactivation_matrix
+plan_gpu_expert_placement = expert_placement.plan_gpu_expert_placement
+gpu_hit_rate = expert_placement.gpu_hit_rate
+token_resident_rate = expert_placement.token_resident_rate
+EmaHotnessTracker = expert_placement.EmaHotnessTracker
+
+
+def _frequency_mask(activation_freq: torch.Tensor, num_gpu_experts: int) -> torch.Tensor:
+    """Per-layer frequency top-k, the baseline the new planner must beat."""
+    num_layers, num_experts = activation_freq.shape
+    budget = max(0, min(int(num_gpu_experts), num_experts))
+    mask = torch.zeros(num_layers, num_experts, dtype=torch.bool)
+    if budget == 0:
+        return mask
+    for layer_idx in range(num_layers):
+        top = torch.topk(activation_freq[layer_idx], k=budget, largest=True, sorted=False).indices
+        mask[layer_idx, top] = True
+    return mask
+
+
+class TestCoactivationMatrix(unittest.TestCase):
+    def test_diagonal_holds_marginal_counts(self):
+        """The diagonal must equal each expert's per-token activation count."""
+        # Expert 0 fires in 3 tokens, expert 1 in 2, expert 2 in 1.
+        traces = torch.tensor([[0, 1], [0, 1], [0, 2]])
+        coact = build_coactivation_matrix(traces, num_experts=3)
+        self.assertEqual(coact[0, 0].item(), 3.0)
+        self.assertEqual(coact[1, 1].item(), 2.0)
+        self.assertEqual(coact[2, 2].item(), 1.0)
+
+    def test_offdiagonal_is_symmetric_cooccurrence(self):
+        """Off-diagonal entries count co-firing and are symmetric."""
+        traces = torch.tensor([[0, 1], [0, 1], [0, 2]])
+        coact = build_coactivation_matrix(traces, num_experts=3)
+        self.assertEqual(coact[0, 1].item(), 2.0)  # 0 and 1 co-fire twice
+        self.assertEqual(coact[1, 0].item(), 2.0)  # symmetric
+        self.assertEqual(coact[0, 2].item(), 1.0)  # 0 and 2 co-fire once
+        self.assertEqual(coact[1, 2].item(), 0.0)  # 1 and 2 never co-fire
+
+    def test_padding_ids_are_ignored(self):
+        """Out-of-range ids (e.g. -1 padding) must not be counted."""
+        traces = torch.tensor([[0, -1], [0, 1]])
+        coact = build_coactivation_matrix(traces, num_experts=2)
+        self.assertEqual(coact[0, 0].item(), 2.0)
+        self.assertEqual(coact[1, 1].item(), 1.0)
+
+    def test_empty_traces_return_zero_matrix(self):
+        coact = build_coactivation_matrix(torch.empty(0, dtype=torch.long), num_experts=4)
+        self.assertEqual(coact.shape, (4, 4))
+        self.assertEqual(coact.sum().item(), 0.0)
+
+
+class TestCoactivationBeatsFrequency(unittest.TestCase):
+    def test_coactivation_beats_frequency(self):
+        """The core claim: cluster placement wins on whole-token residency.
+
+        Six experts, top-2 routing, budget of 2 GPU experts for one layer.
+
+        - Cluster {0, 1} co-fires on 10 tokens (their pairwise count is 10).
+        - Experts 2 and 3 are individually hotter (12 tokens each) but each
+          spreads across four *rotating* cold partners (4..7), so no single
+          pair involving 2 or 3 co-fires more than 3 times, and 2 and 3 never
+          co-fire with each other.
+
+        Frequency top-2 picks {2, 3} (highest marginals: 12, 12 vs 10 each for
+        the pair). But 2 and 3 never appear in the same token, so *no* token is
+        ever fully resident: every one of their tokens still hits the CPU path.
+        Co-activation seeds from the strongest co-firing pair {0, 1} and keeps
+        them together, so all 10 of its tokens are fully GPU-resident. On the
+        whole-token metric that governs CPU-path avoidance, cluster placement
+        wins decisively.
+        """
+        tokens = []
+        tokens += [[0, 1]] * 10  # tight co-firing cluster, pairwise count 10
+        # Expert 2 is hot (marginal 12) but spread over rotating cold partners.
+        for partner in (4, 5, 6, 7):
+            tokens += [[2, partner]] * 3
+        # Expert 3 is hot (marginal 12) but spread over the same cold partners,
+        # and never co-fires with expert 2.
+        for partner in (4, 5, 6, 7):
+            tokens += [[3, partner]] * 3
+        traces = {0: torch.tensor(tokens)}
+
+        num_experts = 8
+        # Marginal counts for the frequency baseline: 2 and 3 are hottest.
+        activation_freq = torch.zeros(1, num_experts)
+        flat = torch.tensor(tokens).flatten()
+        for e in range(num_experts):
+            activation_freq[0, e] = (flat == e).sum()
+
+        freq_mask = _frequency_mask(activation_freq, num_gpu_experts=2)
+        coact_mask = plan_gpu_expert_placement(
+            num_layers=1,
+            num_experts=num_experts,
+            num_gpu_experts=2,
+            token_traces=traces,
+            strategy="cluster",
+        )
+
+        # Sanity: frequency really did pick the individually-hot, non-co-firing pair.
+        self.assertTrue(bool(freq_mask[0, 2]) and bool(freq_mask[0, 3]))
+        # Co-activation keeps the co-firing cluster together.
+        self.assertTrue(bool(coact_mask[0, 0]) and bool(coact_mask[0, 1]))
+
+        # Whole-token residency: the metric that reflects CPU-path avoidance.
+        freq_tok = token_resident_rate(freq_mask, traces)
+        coact_tok = token_resident_rate(coact_mask, traces)
+        self.assertEqual(freq_tok, 0.0)  # 2 and 3 never co-fire -> no full token
+        self.assertGreater(coact_tok, freq_tok)
+
+        # And the per-selection metric confirms frequency's known advantage there,
+        # documenting exactly why whole-token residency is the right objective.
+        self.assertGreaterEqual(gpu_hit_rate(freq_mask, traces), gpu_hit_rate(coact_mask, traces))
+
+
+class TestCoverageStrategy(unittest.TestCase):
+    def test_coverage_beats_frequency_and_cluster_with_stable_core(self):
+        """Your scenario: 6 stable core + 2 rotating slots, plus a decoy.
+
+        Realistic Qwen-style routing: top-8 of many experts, where 6 experts
+        form a nearly-always-on core and 2 slots rotate. A token is a hit only
+        when *all 8* of its experts are resident. Budget is 10 GPU experts, so
+        we can afford the 6-core plus 4 rotating experts (two rotating pairs).
+
+        Layout:
+        - Core = {0,1,2,3,4,5}, present in every token.
+        - Rotating pair A = {6,7} on 30 tokens.
+        - Rotating pair B = {8,9} on 25 tokens.
+        - Decoy expert 10 is the *single hottest* rotating expert (30 tokens),
+          but its 8th slot is a *unique* cold expert each time (11,12,...), so
+          completing any decoy token is impossible within budget.
+
+        Frequency top-10 spends its slots on the highest marginals: the 6 core,
+        then 6, 7, 10 (all 30) and only *one* of {8,9} (25). That wastes a slot
+        on the un-completable decoy 10 and breaks pair B (only 8 resident, 9
+        evicted), so pair B's tokens all miss. Coverage reduces to residuals,
+        sees {6,7} and {8,9} complete many tokens per slot while {10, cold}
+        completes only ~0.5, and packs both real pairs.
+        """
+        core = [0, 1, 2, 3, 4, 5]
+        tokens = []
+        tokens += [core + [6, 7]] * 30  # rotating pair A
+        tokens += [core + [8, 9]] * 25  # rotating pair B
+        # Decoy: expert 10 is the hottest rotating expert but its partner is a
+        # unique cold expert every time, so its tokens can never be completed.
+        for i in range(30):
+            tokens += [core + [10, 11 + i]]  # 11..40 each appear once
+        traces = {0: torch.tensor(tokens)}
+
+        num_experts = 48
+        budget = 10
+
+        activation_freq = torch.zeros(1, num_experts)
+        flat = torch.tensor(tokens).flatten()
+        for e in range(num_experts):
+            activation_freq[0, e] = (flat == e).sum()
+
+        freq_mask = _frequency_mask(activation_freq, num_gpu_experts=budget)
+        cluster_mask = plan_gpu_expert_placement(
+            num_layers=1, num_experts=num_experts, num_gpu_experts=budget, token_traces=traces, strategy="cluster"
+        )
+        coverage_mask = plan_gpu_expert_placement(
+            num_layers=1, num_experts=num_experts, num_gpu_experts=budget, token_traces=traces, strategy="coverage"
+        )
+
+        freq_cov = token_resident_rate(freq_mask, traces)
+        cluster_cov = token_resident_rate(cluster_mask, traces)
+        coverage_cov = token_resident_rate(coverage_mask, traces)
+
+        # Coverage must win the whole-token metric outright.
+        self.assertGreater(coverage_cov, freq_cov)
+        self.assertGreater(coverage_cov, cluster_cov)
+        # It should keep the core plus both real rotating pairs.
+        for e in core + [6, 7, 8, 9]:
+            self.assertTrue(bool(coverage_mask[0, e]), f"expert {e} should be resident")
+        # And it should not waste a slot on the un-completable decoy.
+        self.assertFalse(bool(coverage_mask[0, 10]), "decoy expert 10 should not be placed")
+        # All 55 rotating-pair tokens are covered; the 30 decoy tokens cannot be.
+        self.assertAlmostEqual(coverage_cov, 55 / 85, places=6)
+
+    def test_coverage_takes_all_rotating_when_budget_allows(self):
+        """When budget covers core + every rotating variant, coverage hits 100%."""
+        core = [0, 1, 2, 3]
+        tokens = []
+        tokens += [core + [4, 5]] * 10
+        tokens += [core + [6, 7]] * 10
+        traces = {0: torch.tensor(tokens)}
+        # Budget 8 = 4 core + 4 rotating -> everything fits.
+        mask = plan_gpu_expert_placement(
+            num_layers=1, num_experts=16, num_gpu_experts=8, token_traces=traces, strategy="coverage"
+        )
+        self.assertEqual(token_resident_rate(mask, traces), 1.0)
+
+
+class TestPlanFallbacks(unittest.TestCase):
+    def test_falls_back_to_frequency_without_traces(self):
+        """With no traces, planning matches per-layer frequency top-k exactly."""
+        activation_freq = torch.tensor([[0.1, 0.9, 0.3, 0.7], [0.5, 0.2, 0.8, 0.4]])
+        mask = plan_gpu_expert_placement(
+            num_layers=2,
+            num_experts=4,
+            num_gpu_experts=2,
+            token_traces=None,
+            activation_freq=activation_freq,
+        )
+        expected = _frequency_mask(activation_freq, num_gpu_experts=2)
+        self.assertTrue(torch.equal(mask, expected))
+
+    def test_per_layer_trace_absence_falls_back(self):
+        """A layer missing from the trace map uses activation_freq for that layer."""
+        traces = {0: torch.tensor([[0, 1], [0, 1]])}
+        activation_freq = torch.tensor([[9.0, 9.0, 0.0, 0.0], [0.0, 0.0, 5.0, 6.0]])
+        mask = plan_gpu_expert_placement(
+            num_layers=2,
+            num_experts=4,
+            num_gpu_experts=2,
+            token_traces=traces,
+            activation_freq=activation_freq,
+        )
+        # Layer 1 has no trace: falls back to frequency top-2 -> experts 2, 3.
+        self.assertTrue(bool(mask[1, 2]) and bool(mask[1, 3]))
+
+    def test_zero_budget_returns_empty_mask(self):
+        mask = plan_gpu_expert_placement(num_layers=3, num_experts=8, num_gpu_experts=0)
+        self.assertEqual(mask.shape, (3, 8))
+        self.assertFalse(bool(mask.any()))
+
+    def test_budget_clamped_to_num_experts(self):
+        mask = plan_gpu_expert_placement(num_layers=1, num_experts=4, num_gpu_experts=99)
+        self.assertEqual(int(mask.sum().item()), 4)
+
+    def test_uniform_fallback_without_any_stats(self):
+        """No traces and no freq -> first num_gpu_experts per layer."""
+        mask = plan_gpu_expert_placement(num_layers=2, num_experts=5, num_gpu_experts=2)
+        self.assertTrue(bool(mask[0, 0]) and bool(mask[0, 1]))
+        self.assertFalse(bool(mask[0, 2]))
+
+
+class TestGpuHitRate(unittest.TestCase):
+    def test_all_resident_is_one(self):
+        mask = torch.tensor([[True, True, False, False]])
+        traces = {0: torch.tensor([[0, 1], [0, 1]])}
+        self.assertEqual(gpu_hit_rate(mask, traces), 1.0)
+
+    def test_none_resident_is_zero(self):
+        mask = torch.tensor([[False, False, True, True]])
+        traces = {0: torch.tensor([[0, 1], [0, 1]])}
+        self.assertEqual(gpu_hit_rate(mask, traces), 0.0)
+
+    def test_half_resident(self):
+        mask = torch.tensor([[True, False, False, False]])
+        traces = {0: torch.tensor([[0, 1]])}  # one hit (0), one miss (1)
+        self.assertEqual(gpu_hit_rate(mask, traces), 0.5)
+
+    def test_no_selections_returns_zero(self):
+        mask = torch.tensor([[True, False]])
+        self.assertEqual(gpu_hit_rate(mask, {}), 0.0)
+
+
+class TestTokenResidentRate(unittest.TestCase):
+    def test_all_tokens_fully_resident(self):
+        mask = torch.tensor([[True, True, False, False]])
+        traces = {0: torch.tensor([[0, 1], [0, 1]])}
+        self.assertEqual(token_resident_rate(mask, traces), 1.0)
+
+    def test_partial_token_is_not_resident(self):
+        """A token with one resident and one non-resident expert counts as a miss."""
+        mask = torch.tensor([[True, False, False, False]])
+        traces = {0: torch.tensor([[0, 1]])}  # expert 1 on CPU -> whole token misses
+        self.assertEqual(token_resident_rate(mask, traces), 0.0)
+
+    def test_mixed_tokens(self):
+        mask = torch.tensor([[True, True, False, False]])
+        traces = {0: torch.tensor([[0, 1], [0, 2]])}  # first fully resident, second not
+        self.assertEqual(token_resident_rate(mask, traces), 0.5)
+
+    def test_no_tokens_returns_zero(self):
+        mask = torch.tensor([[True, True]])
+        self.assertEqual(token_resident_rate(mask, {}), 0.0)
+
+
+class TestEmaHotnessTracker(unittest.TestCase):
+    """Online EMA tracker: adapts placement to the live workload.
+
+    The central claim: when the workload shifts, an online tracker that follows
+    recent activation keeps a higher whole-token GPU residency than a mask frozen
+    from the earlier (now stale) traffic. ``test_adapts_to_workload_shift`` plants
+    a shift and asserts exactly that.
+    """
+
+    def test_mask_shape_and_budget(self):
+        t = EmaHotnessTracker(num_layers=3, num_experts=8, num_gpu_experts=4)
+        t.observe(0, torch.tensor([0, 1, 2, 3]))
+        mask = t.mask()
+        self.assertEqual(mask.shape, (3, 8))
+        self.assertEqual(int(mask[0].sum()), 4)
+
+    def test_hot_experts_selected(self):
+        """Experts that fire every token outrank experts that never fire."""
+        t = EmaHotnessTracker(num_layers=1, num_experts=6, num_gpu_experts=2)
+        for _ in range(10):
+            t.observe(0, torch.tensor([2, 5]))
+        mask = t.mask()
+        self.assertTrue(bool(mask[0, 2]) and bool(mask[0, 5]))
+        self.assertEqual(int(mask[0].sum()), 2)
+
+    def test_padding_ids_ignored(self):
+        t = EmaHotnessTracker(num_layers=1, num_experts=4, num_gpu_experts=2)
+        t.observe(0, torch.tensor([0, -1, 99, 1]))  # -1 and 99 are out of range
+        scores = t.scores()
+        self.assertGreater(float(scores[0, 0]), 0.0)
+        self.assertGreater(float(scores[0, 1]), 0.0)
+        self.assertEqual(float(scores[0, 2]), 0.0)
+        self.assertEqual(float(scores[0, 3]), 0.0)
+
+    def test_out_of_range_layer_ignored(self):
+        t = EmaHotnessTracker(num_layers=2, num_experts=4, num_gpu_experts=2)
+        t.observe(5, torch.tensor([0, 1]))  # no such layer; must not raise
+        self.assertEqual(float(t.scores().sum()), 0.0)
+
+    def test_recency_beats_staleness(self):
+        """Lower decay weights recent tokens more, so a switch flips the ranking."""
+        t = EmaHotnessTracker(num_layers=1, num_experts=4, num_gpu_experts=1, decay=0.5)
+        for _ in range(5):
+            t.observe(0, torch.tensor([0]))  # expert 0 hot for a while
+        for _ in range(5):
+            t.observe(0, torch.tensor([1]))  # workload switches to expert 1
+        mask = t.mask()
+        self.assertTrue(bool(mask[0, 1]))
+        self.assertFalse(bool(mask[0, 0]))
+
+    def test_warm_start_matches_frequency_top_k(self):
+        """Before any observation, a freq-warm-started mask equals frequency top-k."""
+        freq = torch.tensor([[10.0, 1.0, 5.0, 0.0]])  # hottest: expert 0, then 2
+        t = EmaHotnessTracker(num_layers=1, num_experts=4, num_gpu_experts=2, activation_freq=freq)
+        mask = t.mask()
+        expected = torch.zeros(1, 4, dtype=torch.bool)
+        expected[0, torch.topk(freq[0], k=2).indices] = True
+        self.assertTrue(bool((mask == expected).all()))
+
+    def test_observe_batch_order_preserved(self):
+        """observe_batch consumes rows in order; equivalent to sequential observe."""
+        traces = {0: torch.tensor([[0, 1], [0, 2], [0, 3]])}
+        batch = EmaHotnessTracker(1, 4, 2, decay=0.8)
+        batch.observe_batch(traces)
+        seq = EmaHotnessTracker(1, 4, 2, decay=0.8)
+        for row in traces[0]:
+            seq.observe(0, row)
+        self.assertTrue(bool(torch.allclose(batch.scores(), seq.scores())))
+
+    def test_adapts_to_workload_shift(self):
+        """Online tracker beats a mask frozen on stale traffic after a shift.
+
+        Phase 1 routes to experts {0,1}; phase 2 switches to {2,3}. A static mask
+        planned on phase-1 traffic misses every phase-2 token. The online tracker,
+        having observed the shift, places {2,3} and stays fully resident.
+        """
+        num_experts, budget = 4, 2
+        phase1 = torch.tensor([[0, 1]] * 8)
+        phase2 = torch.tensor([[2, 3]] * 8)
+
+        # Static placement fit on phase-1 traffic only.
+        static_mask = plan_gpu_expert_placement(1, num_experts, budget, token_traces={0: phase1}, strategy="cluster")
+        static_rate = token_resident_rate(static_mask, {0: phase2})
+
+        # Online tracker observes phase 1 then phase 2, then emits its mask.
+        tracker = EmaHotnessTracker(1, num_experts, budget, decay=0.7)
+        tracker.observe_batch({0: phase1})
+        tracker.observe_batch({0: phase2})
+        online_rate = token_resident_rate(tracker.mask(), {0: phase2})
+
+        self.assertEqual(static_rate, 0.0)  # stale mask misses the new workload
+        self.assertEqual(online_rate, 1.0)  # adaptive mask fully covers it
+        self.assertGreater(online_rate, static_rate)
+
+    def test_invalid_decay_rejected(self):
+        with self.assertRaises(ValueError):
+            EmaHotnessTracker(1, 4, 2, decay=1.0)
+        with self.assertRaises(ValueError):
+            EmaHotnessTracker(1, 4, 2, decay=-0.1)
+
+    def test_zero_budget_empty_mask(self):
+        t = EmaHotnessTracker(1, 4, 0)
+        t.observe(0, torch.tensor([0, 1]))
+        self.assertEqual(int(t.mask().sum()), 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
# What does this PR do?

The default expert placement (`generate_gpu_experts_masks`) keeps the globally
most-frequent experts, scoring each independently. That is blind to which experts
co-fire on the same token: if two experts almost always route together but only one
is GPU-resident, every such token still pays the slow CPU path for the other.

This adds `kt-kernel/python/expert_placement.py` with two drop-in capabilities that
raise the per-token GPU hit rate at the same GPU-expert budget:

- **`plan_gpu_expert_placement`** — static co-activation-aware planner with `coverage`
  (whole-token set-cover) and `cluster` (greedy co-firing cluster) strategies.
  Degrades to frequency top-k when only marginal counts are available, so it never
  regresses the existing behaviour.
- **`EmaHotnessTracker`** — online per-layer EMA of expert activation that emits an
  up-to-date residency mask as the live workload shifts, in O(top_k) work per layer
  per token. Model- and workload-agnostic (no offline profile). Optionally warm-starts
  from `activation_freq` so the cold-start mask equals frequency top-k and never regresses.

Both produce the same `(num_layers, num_experts)` boolean mask the pipeline already
consumes, so integration is drop-in. Pure Python/torch — no routing, no weight movement.
Also adds `gpu_hit_rate` and `token_resident_rate` metrics.

Fixes # (N/A — enhancement)

## Before submitting

- [x] Did you read the contributor guideline?
- [x] Did you write any new necessary tests? (30 CPU-only tests in
      `test/per_commit/test_expert_placement.py`, all passing; black clean)