### PR TITLE
[perf](kt-kernel): blocked accumulators and opt-in packed INT4 weights for the AVX-VNNI-256 RAWINT4 backend

### DIFF
--- a/kt-kernel/operators/avx2/rawint4_avxvnni-moe.hpp
+++ b/kt-kernel/operators/avx2/rawint4_avxvnni-moe.hpp
@@ -13,6 +13,14 @@
  * weights are unpacked into signed int8 [N, K] once at load time. dpbusd then
  * does the group-wise inner product, followed by compensation (128 * weight_sum)
  * and rescale by (a_scale * w_scale).
+ *
+ * KT_RAWINT4_PACKED_WEIGHTS=1 keeps the weights resident as packed nibbles
+ * [N, K/2] instead and unpacks 32 values per 16 loaded bytes in-register
+ * inside the GEMM. That halves resident weight memory and produces the same
+ * int32 dots, hence bitwise-identical outputs. It is opt-in because halving
+ * the weight bytes wins bandwidth-bound decode (up to ~1.4x at large dims)
+ * but the unpack costs ~10% at qlen 16, where weight streaming amortizes;
+ * batch-heavy deployments keep the default.
  **/
 #ifndef CPUINFER_OPERATOR_AVX2_RAW_INT4_AVXVNNI_MOE_H
 #define CPUINFER_OPERATOR_AVX2_RAW_INT4_AVXVNNI_MOE_H
@@ -23,6 +31,7 @@
 #include <array>
 #include <cmath>
 #include <cstdint>
+#include <cstdlib>
 #include <cstring>
 #include <limits>
 #include <memory>
@@ -40,6 +49,14 @@
 namespace avxvnni_rawint4 {
 
 static constexpr int MAX_SUPPORTED_GROUP_SIZE = 256;
+
+// Opt-in packed weight storage (see the header comment). Sampled when a
+// backend instance allocates its weight buffers, so instances built under
+// different settings coexist; each BufferB carries its own layout flag.
+static inline bool packed_weights_enabled() {
+  const char* env = getenv("KT_RAWINT4_PACKED_WEIGHTS");
+  return env && env[0] != '0';
+}
 
 static inline int hsum_epi32_avx2(__m256i v) {
   __m128i lo = _mm256_castsi256_si128(v);
@@ -121,16 +138,19 @@ struct GemmKernelAVXVNNI256RawInt4 {
   };
 
   struct BufferB {
-    int8_t* qweight_s8 = nullptr;    // [N, K] unpacked signed int8 weights
+    int8_t* qweight_s8 = nullptr;    // [N, K] unpacked signed int8 weights (packed mode: unused)
+    uint8_t* qweight_i4 = nullptr;   // [N, K/2] packed nibbles, low nibble = even k (packed mode only)
     float* scales = nullptr;         // [N, num_groups] float32 (converted from bf16)
-    int16_t* weight_sums = nullptr;  // [N, num_groups] per-group sum of unpacked int8 weights
+    int16_t* weight_sums = nullptr;  // [N, num_groups] per-group sum of the signed int4 weights
     int n = 0;
     int k = 0;
     int group_size = 128;
     int num_groups = 0;
+    bool packed = false;
 
     BufferB() = default;
-    BufferB(size_t n_, size_t k_, int gs, void* ptr) : n((int)n_), k((int)k_), group_size(gs) {
+    BufferB(size_t n_, size_t k_, int gs, bool packed_, void* ptr)
+        : n((int)n_), k((int)k_), group_size(gs), packed(packed_) {
       if (group_size <= 0 || (group_size % 32) != 0) {
         throw std::runtime_error("AVX-VNNI RAWINT4 requires group_size to be a positive multiple of 32");
       }
@@ -141,37 +161,60 @@ struct GemmKernelAVXVNNI256RawInt4 {
         throw std::runtime_error("AVX-VNNI RAWINT4 requires k to be divisible by both 8 and group_size");
       }
       num_groups = k / group_size;
-      qweight_s8 = (int8_t*)ptr;
-      scales = (float*)((uint8_t*)ptr + (size_t)k * n * sizeof(int8_t));
+      if (packed) {
+        qweight_i4 = (uint8_t*)ptr;
+        scales = (float*)((uint8_t*)ptr + (size_t)k / 2 * n);
+      } else {
+        qweight_s8 = (int8_t*)ptr;
+        scales = (float*)((uint8_t*)ptr + (size_t)k * n * sizeof(int8_t));
+      }
       weight_sums = (int16_t*)((uint8_t*)scales + (size_t)num_groups * n * sizeof(float));
     }
 
-    static size_t required_size(size_t n, size_t k, int gs) {
+    static size_t required_size(size_t n, size_t k, int gs, bool packed) {
       const size_t num_groups = k / gs;
-      return k * n * sizeof(int8_t) + num_groups * n * sizeof(float) + num_groups * n * sizeof(int16_t);
+      const size_t weight_bytes = packed ? k / 2 * n : k * n * sizeof(int8_t);
+      return weight_bytes + num_groups * n * sizeof(float) + num_groups * n * sizeof(int16_t);
     }
 
     // Unpack packed RAWINT4 weights [n_len, k/2] (row-major, low nibble = even k) into
     // signed int8 [n_len, k], convert bf16 scales [n_len, num_groups] to float32,
-    // and compute int16 weight_sums [n_len, num_groups].
+    // and compute int16 weight_sums [n_len, num_groups]. In packed mode the nibble
+    // rows are copied as-is and the weight_sums come from the same nibble arithmetic,
+    // so both layouts hold identical scales and weight_sums for identical sources.
     void from_raw_mat(const uint8_t* src_packed, const ggml_bf16_t* src_scales, int ith, int nth) {
       auto [n_start, n_end] = avx2::split_range(n, ith, nth);
       const size_t row_bytes = (size_t)k / 2;
 
       for (int ni = n_start; ni < n_end; ++ni) {
         const uint8_t* src_row = src_packed + (size_t)ni * row_bytes;
-        int8_t* dst_col = qweight_s8 + (size_t)ni * k;
         const ggml_bf16_t* src_sc_row = src_scales + (size_t)ni * num_groups;
         float* dst_sc_row = scales + (size_t)ni * num_groups;
         int16_t* dst_ws_row = weight_sums + (size_t)ni * num_groups;
 
+        if (packed) {
+          std::memcpy(qweight_i4 + (size_t)ni * row_bytes, src_row, row_bytes);
+          for (int g = 0; g < num_groups; ++g) {
+            const int k_base = g * group_size;
+            int sum = 0;
+            for (int kk = 0; kk < group_size; kk += 2) {
+              const uint8_t packed_byte = src_row[(k_base + kk) / 2];
+              sum += (int8_t)((packed_byte & 0x0F) - 8) + (int8_t)(((packed_byte >> 4) & 0x0F) - 8);
+            }
+            dst_ws_row[g] = (int16_t)sum;
+            dst_sc_row[g] = GGML_BF16_TO_FP32(src_sc_row[g]);
+          }
+          continue;
+        }
+
+        int8_t* dst_col = qweight_s8 + (size_t)ni * k;
         for (int g = 0; g < num_groups; ++g) {
           const int k_base = g * group_size;
           int sum = 0;
           for (int kk = 0; kk < group_size; kk += 2) {
-            const uint8_t packed = src_row[(k_base + kk) / 2];
-            const int8_t v0 = (int8_t)((packed & 0x0F) - 8);         // even k
-            const int8_t v1 = (int8_t)(((packed >> 4) & 0x0F) - 8);  // odd k
+            const uint8_t packed_byte = src_row[(k_base + kk) / 2];
+            const int8_t v0 = (int8_t)((packed_byte & 0x0F) - 8);         // even k
+            const int8_t v1 = (int8_t)(((packed_byte >> 4) & 0x0F) - 8);  // odd k
             dst_col[k_base + kk] = v0;
             dst_col[k_base + kk + 1] = v1;
             sum += v0 + v1;
@@ -212,10 +255,117 @@ struct GemmKernelAVXVNNI256RawInt4 {
   };
 };
 
+// Unpack 16 packed bytes (32 int4 values, low nibble = even k) into 32 signed
+// int8 in k order. Matches from_raw_mat: value = nibble - 8.
+KT_AVXVNNI256_RAWINT4_TARGET
+static inline __m256i unpack32_rawint4(const uint8_t* p) {
+  const __m128i raw = _mm_loadu_si128((const __m128i*)p);
+  const __m128i m4 = _mm_set1_epi8(0x0F);
+  const __m128i lo = _mm_and_si128(raw, m4);                     // even k nibbles
+  const __m128i hi = _mm_and_si128(_mm_srli_epi16(raw, 4), m4);  // odd k nibbles
+  const __m128i il0 = _mm_unpacklo_epi8(lo, hi);                 // k 0..15
+  const __m128i il1 = _mm_unpackhi_epi8(lo, hi);                 // k 16..31
+  return _mm256_sub_epi8(_mm256_set_m128i(il1, il0), _mm256_set1_epi8(8));
+}
+
+// Packed-mode GEMM: same blocking and the same integer/float composition as
+// gemm_rawint4_avxvnni256 below, but streams the packed nibble rows and
+// unpacks in-register. Equal int32 dots imply bit-equal float output.
+KT_AVXVNNI256_RAWINT4_TARGET
+static inline void gemm_rawint4_avxvnni256_packed(int m, int n, int k, GemmKernelAVXVNNI256RawInt4::BufferA& a,
+                                                  GemmKernelAVXVNNI256RawInt4::BufferB& b,
+                                                  GemmKernelAVXVNNI256RawInt4::BufferC& c, int ith, int nth) {
+  (void)k;
+  auto [n_start, n_end] = avx2::split_range(n, ith, nth);
+  const int group_size = b.group_size;
+  const int num_groups = b.num_groups;
+  const size_t row_bytes = (size_t)b.k / 2;
+
+  alignas(32) std::array<uint8_t, MAX_SUPPORTED_GROUP_SIZE> a_u8{};
+  alignas(16) int32_t dots[4];
+
+  for (int mi = 0; mi < m; ++mi) {
+    const ggml_bf16_t* a_row = a.data + (size_t)mi * a.k;
+    float* c_row = c.data + (size_t)mi * n;
+    std::fill(c_row + n_start, c_row + n_end, 0.0f);
+
+    for (int g = 0; g < num_groups; ++g) {
+      const int k_base = g * group_size;
+      const int p_base = k_base >> 1;  // group_size is a multiple of 32, so exact
+      const float a_scale = quantize_activation_group_u8(a_row + k_base, group_size, a_u8.data());
+      if (a_scale == 0.0f) {
+        continue;
+      }
+
+      int ni = n_start;
+      for (; ni + 4 <= n_end; ni += 4) {
+        const uint8_t* w_col0 = b.qweight_i4 + (size_t)(ni + 0) * row_bytes + p_base;
+        const uint8_t* w_col1 = b.qweight_i4 + (size_t)(ni + 1) * row_bytes + p_base;
+        const uint8_t* w_col2 = b.qweight_i4 + (size_t)(ni + 2) * row_bytes + p_base;
+        const uint8_t* w_col3 = b.qweight_i4 + (size_t)(ni + 3) * row_bytes + p_base;
+
+        __m256i acc0a = _mm256_setzero_si256(), acc0b = _mm256_setzero_si256();
+        __m256i acc1a = _mm256_setzero_si256(), acc1b = _mm256_setzero_si256();
+        __m256i acc2a = _mm256_setzero_si256(), acc2b = _mm256_setzero_si256();
+        __m256i acc3a = _mm256_setzero_si256(), acc3b = _mm256_setzero_si256();
+
+        int kk = 0;
+        for (; kk + 64 <= group_size; kk += 64) {
+          const __m256i a_vec0 = _mm256_load_si256((const __m256i*)(a_u8.data() + kk));
+          const __m256i a_vec1 = _mm256_load_si256((const __m256i*)(a_u8.data() + kk + 32));
+          const int pb = kk >> 1;
+          acc0a = _mm256_dpbusd_avx_epi32(acc0a, a_vec0, unpack32_rawint4(w_col0 + pb));
+          acc0b = _mm256_dpbusd_avx_epi32(acc0b, a_vec1, unpack32_rawint4(w_col0 + pb + 16));
+          acc1a = _mm256_dpbusd_avx_epi32(acc1a, a_vec0, unpack32_rawint4(w_col1 + pb));
+          acc1b = _mm256_dpbusd_avx_epi32(acc1b, a_vec1, unpack32_rawint4(w_col1 + pb + 16));
+          acc2a = _mm256_dpbusd_avx_epi32(acc2a, a_vec0, unpack32_rawint4(w_col2 + pb));
+          acc2b = _mm256_dpbusd_avx_epi32(acc2b, a_vec1, unpack32_rawint4(w_col2 + pb + 16));
+          acc3a = _mm256_dpbusd_avx_epi32(acc3a, a_vec0, unpack32_rawint4(w_col3 + pb));
+          acc3b = _mm256_dpbusd_avx_epi32(acc3b, a_vec1, unpack32_rawint4(w_col3 + pb + 16));
+        }
+        if (kk < group_size) {  // group_size % 64 == 32 tail
+          const __m256i a_vec0 = _mm256_load_si256((const __m256i*)(a_u8.data() + kk));
+          const int pb = kk >> 1;
+          acc0a = _mm256_dpbusd_avx_epi32(acc0a, a_vec0, unpack32_rawint4(w_col0 + pb));
+          acc1a = _mm256_dpbusd_avx_epi32(acc1a, a_vec0, unpack32_rawint4(w_col1 + pb));
+          acc2a = _mm256_dpbusd_avx_epi32(acc2a, a_vec0, unpack32_rawint4(w_col2 + pb));
+          acc3a = _mm256_dpbusd_avx_epi32(acc3a, a_vec0, unpack32_rawint4(w_col3 + pb));
+        }
+
+        const __m128i sums = hsum4_epi32_avx2(_mm256_add_epi32(acc0a, acc0b), _mm256_add_epi32(acc1a, acc1b),
+                                              _mm256_add_epi32(acc2a, acc2b), _mm256_add_epi32(acc3a, acc3b));
+        _mm_store_si128((__m128i*)dots, sums);
+
+        for (int col = 0; col < 4; ++col) {
+          const int nc = ni + col;
+          const int dot = dots[col] - 128 * (int)b.weight_sums[(size_t)nc * num_groups + g];
+          c_row[nc] += (float)dot * a_scale * b.scales[(size_t)nc * num_groups + g];
+        }
+      }
+
+      for (; ni < n_end; ++ni) {
+        __m256i acc = _mm256_setzero_si256();
+        const uint8_t* w_col = b.qweight_i4 + (size_t)ni * row_bytes + p_base;
+        for (int kk = 0; kk < group_size; kk += 32) {
+          const __m256i a_vec = _mm256_load_si256((const __m256i*)(a_u8.data() + kk));
+          acc = _mm256_dpbusd_avx_epi32(acc, a_vec, unpack32_rawint4(w_col + (kk >> 1)));
+        }
+
+        const int dot = hsum_epi32_avx2(acc) - 128 * (int)b.weight_sums[(size_t)ni * num_groups + g];
+        c_row[ni] += (float)dot * a_scale * b.scales[(size_t)ni * num_groups + g];
+      }
+    }
+  }
+}
+
 KT_AVXVNNI256_RAWINT4_TARGET
 static inline void gemm_rawint4_avxvnni256(int m, int n, int k, GemmKernelAVXVNNI256RawInt4::BufferA& a,
                                            GemmKernelAVXVNNI256RawInt4::BufferB& b,
                                            GemmKernelAVXVNNI256RawInt4::BufferC& c, int ith, int nth) {
+  if (b.packed) {
+    gemm_rawint4_avxvnni256_packed(m, n, k, a, b, c, ith, nth);
+    return;
+  }
   (void)k;
   auto [n_start, n_end] = avx2::split_range(n, ith, nth);
   const int group_size = b.group_size;
@@ -338,15 +488,16 @@ class AVXVNNI256_RAW_INT4_MOE_TP : public AVX2_MOE_BASE<T, AVXVNNI256_RAW_INT4_M
     if (qc.zero_point) {
       throw std::runtime_error("AVX-VNNI-256 RAWINT4 only supports signed INT4 without zero point");
     }
-    printf("Created AVXVNNI256_RAW_INT4_MOE_TP %d at numa %d (group_size=%d)\n", tp_part_idx,
-           numa_node_of_cpu(sched_getcpu()), qc.group_size);
+    printf("Created AVXVNNI256_RAW_INT4_MOE_TP %d at numa %d (group_size=%d%s)\n", tp_part_idx,
+           numa_node_of_cpu(sched_getcpu()), qc.group_size,
+           avxvnni_rawint4::packed_weights_enabled() ? ", packed weights" : "");
   }
 
   ~AVXVNNI256_RAW_INT4_MOE_TP() = default;
 
   size_t buffer_a_required_size_impl(size_t m, size_t k) const { return T::BufferA::required_size(m, k); }
   size_t buffer_b_required_size_impl(size_t n, size_t k) const {
-    return T::BufferB::required_size(n, k, config_.quant_config.group_size);
+    return T::BufferB::required_size(n, k, config_.quant_config.group_size, avxvnni_rawint4::packed_weights_enabled());
   }
   size_t buffer_c_required_size_impl(size_t m, size_t n) const { return T::BufferC::required_size(m, n); }
 
@@ -354,7 +505,8 @@ class AVXVNNI256_RAW_INT4_MOE_TP : public AVX2_MOE_BASE<T, AVXVNNI256_RAW_INT4_M
     return std::make_shared<typename T::BufferA>(m, k, data);
   }
   std::shared_ptr<typename T::BufferB> make_buffer_b_impl(size_t n, size_t k, void* data) const {
-    return std::make_shared<typename T::BufferB>(n, k, config_.quant_config.group_size, data);
+    return std::make_shared<typename T::BufferB>(n, k, config_.quant_config.group_size,
+                                                 avxvnni_rawint4::packed_weights_enabled(), data);
   }
   std::shared_ptr<typename T::BufferC> make_buffer_c_impl(size_t m, size_t n, void* data) const {
     return std::make_shared<typename T::BufferC>(m, n, data);

--- a/kt-kernel/operators/avx2/rawint4_avxvnni-moe.hpp
+++ b/kt-kernel/operators/avx2/rawint4_avxvnni-moe.hpp
@@ -50,6 +50,14 @@ static inline int hsum_epi32_avx2(__m256i v) {
   return _mm_cvtsi128_si32(sum);
 }
 
+// Horizontal sums of four accumulators at once: lane i of the result holds the sum of vi.
+static inline __m128i hsum4_epi32_avx2(__m256i v0, __m256i v1, __m256i v2, __m256i v3) {
+  __m256i s01 = _mm256_hadd_epi32(v0, v1);
+  __m256i s23 = _mm256_hadd_epi32(v2, v3);
+  __m256i s = _mm256_hadd_epi32(s01, s23);
+  return _mm_add_epi32(_mm256_castsi256_si128(s), _mm256_extracti128_si256(s, 1));
+}
+
 // Quantize one activation group to biased uint8 for dpbusd.
 // Returns the activation scale. A return value of 0 means the group is all zero.
 static inline float quantize_activation_group_u8(const ggml_bf16_t* src, int group_size, uint8_t* dst) {
@@ -214,6 +222,7 @@ static inline void gemm_rawint4_avxvnni256(int m, int n, int k, GemmKernelAVXVNN
   const int num_groups = b.num_groups;
 
   alignas(32) std::array<uint8_t, MAX_SUPPORTED_GROUP_SIZE> a_u8{};
+  alignas(16) int32_t dots[4];
 
   for (int mi = 0; mi < m; ++mi) {
     const ggml_bf16_t* a_row = a.data + (size_t)mi * a.k;
@@ -227,7 +236,53 @@ static inline void gemm_rawint4_avxvnni256(int m, int n, int k, GemmKernelAVXVNN
         continue;
       }
 
-      for (int ni = n_start; ni < n_end; ++ni) {
+      // Four columns with two dpbusd chains each keep independent accumulators in
+      // flight; one combined reduction replaces four per-column horizontal sums.
+      int ni = n_start;
+      for (; ni + 4 <= n_end; ni += 4) {
+        const int8_t* w_col0 = b.qweight_s8 + (size_t)(ni + 0) * b.k + k_base;
+        const int8_t* w_col1 = b.qweight_s8 + (size_t)(ni + 1) * b.k + k_base;
+        const int8_t* w_col2 = b.qweight_s8 + (size_t)(ni + 2) * b.k + k_base;
+        const int8_t* w_col3 = b.qweight_s8 + (size_t)(ni + 3) * b.k + k_base;
+
+        __m256i acc0a = _mm256_setzero_si256(), acc0b = _mm256_setzero_si256();
+        __m256i acc1a = _mm256_setzero_si256(), acc1b = _mm256_setzero_si256();
+        __m256i acc2a = _mm256_setzero_si256(), acc2b = _mm256_setzero_si256();
+        __m256i acc3a = _mm256_setzero_si256(), acc3b = _mm256_setzero_si256();
+
+        int kk = 0;
+        for (; kk + 64 <= group_size; kk += 64) {
+          const __m256i a_vec0 = _mm256_load_si256((const __m256i*)(a_u8.data() + kk));
+          const __m256i a_vec1 = _mm256_load_si256((const __m256i*)(a_u8.data() + kk + 32));
+          acc0a = _mm256_dpbusd_avx_epi32(acc0a, a_vec0, _mm256_loadu_si256((const __m256i*)(w_col0 + kk)));
+          acc0b = _mm256_dpbusd_avx_epi32(acc0b, a_vec1, _mm256_loadu_si256((const __m256i*)(w_col0 + kk + 32)));
+          acc1a = _mm256_dpbusd_avx_epi32(acc1a, a_vec0, _mm256_loadu_si256((const __m256i*)(w_col1 + kk)));
+          acc1b = _mm256_dpbusd_avx_epi32(acc1b, a_vec1, _mm256_loadu_si256((const __m256i*)(w_col1 + kk + 32)));
+          acc2a = _mm256_dpbusd_avx_epi32(acc2a, a_vec0, _mm256_loadu_si256((const __m256i*)(w_col2 + kk)));
+          acc2b = _mm256_dpbusd_avx_epi32(acc2b, a_vec1, _mm256_loadu_si256((const __m256i*)(w_col2 + kk + 32)));
+          acc3a = _mm256_dpbusd_avx_epi32(acc3a, a_vec0, _mm256_loadu_si256((const __m256i*)(w_col3 + kk)));
+          acc3b = _mm256_dpbusd_avx_epi32(acc3b, a_vec1, _mm256_loadu_si256((const __m256i*)(w_col3 + kk + 32)));
+        }
+        if (kk < group_size) {  // group_size % 64 == 32 tail
+          const __m256i a_vec0 = _mm256_load_si256((const __m256i*)(a_u8.data() + kk));
+          acc0a = _mm256_dpbusd_avx_epi32(acc0a, a_vec0, _mm256_loadu_si256((const __m256i*)(w_col0 + kk)));
+          acc1a = _mm256_dpbusd_avx_epi32(acc1a, a_vec0, _mm256_loadu_si256((const __m256i*)(w_col1 + kk)));
+          acc2a = _mm256_dpbusd_avx_epi32(acc2a, a_vec0, _mm256_loadu_si256((const __m256i*)(w_col2 + kk)));
+          acc3a = _mm256_dpbusd_avx_epi32(acc3a, a_vec0, _mm256_loadu_si256((const __m256i*)(w_col3 + kk)));
+        }
+
+        const __m128i sums = hsum4_epi32_avx2(_mm256_add_epi32(acc0a, acc0b), _mm256_add_epi32(acc1a, acc1b),
+                                              _mm256_add_epi32(acc2a, acc2b), _mm256_add_epi32(acc3a, acc3b));
+        _mm_store_si128((__m128i*)dots, sums);
+
+        for (int col = 0; col < 4; ++col) {
+          const int nc = ni + col;
+          const int dot = dots[col] - 128 * (int)b.weight_sums[(size_t)nc * num_groups + g];
+          c_row[nc] += (float)dot * a_scale * b.scales[(size_t)nc * num_groups + g];
+        }
+      }
+
+      for (; ni < n_end; ++ni) {
         __m256i acc = _mm256_setzero_si256();
         const int8_t* w_col = b.qweight_s8 + (size_t)ni * b.k + k_base;
         for (int kk = 0; kk < group_size; kk += 32) {

--- a/kt-kernel/test/per_commit/test_moe_rawint4_load_equivalence.py
+++ b/kt-kernel/test/per_commit/test_moe_rawint4_load_equivalence.py
@@ -71,7 +71,7 @@ def identity_map():
     return torch.tensor(range(expert_num), dtype=torch.int64).contiguous()
 
 
-def make_rawint4_weights(seed):
+def make_rawint4_weights(seed, gs=group_size):
     """Random packed RAWINT4 weights and bf16 scales for all three projections."""
     gen = torch.Generator().manual_seed(seed)
 
@@ -79,7 +79,7 @@ def make_rawint4_weights(seed):
         return torch.randint(0, 256, (expert_num, n, k // 2), dtype=torch.uint8, generator=gen).contiguous()
 
     def scales(n, k):
-        s = torch.rand((expert_num, n, k // group_size), generator=gen) * 0.02 + 0.001
+        s = torch.rand((expert_num, n, k // gs), generator=gen) * 0.02 + 0.001
         return s.to(torch.bfloat16).contiguous()
 
     return {
@@ -92,18 +92,18 @@ def make_rawint4_weights(seed):
     }
 
 
-def base_config(pool_backend):
+def base_config(pool_backend, gs=group_size):
     config = kt_kernel_ext.moe.MOEConfig(expert_num, num_experts_per_tok, hidden_size, intermediate_size, 0)
     config.max_len = max_len
     config.quant_config.bits = 4
-    config.quant_config.group_size = group_size
+    config.quant_config.group_size = gs
     config.quant_config.zero_point = False
     config.pool = pool_backend
     return config
 
 
-def build_flat_moe(backend_cls, cpu_infer, w, p2l_map):
-    config = base_config(cpu_infer.backend_)
+def build_flat_moe(backend_cls, cpu_infer, w, p2l_map, gs=group_size):
+    config = base_config(cpu_infer.backend_, gs)
     config.gate_proj = w["gate_qw"].data_ptr()
     config.up_proj = w["up_qw"].data_ptr()
     config.down_proj = w["down_qw"].data_ptr()
@@ -116,7 +116,7 @@ def build_flat_moe(backend_cls, cpu_infer, w, p2l_map):
     return moe
 
 
-def build_per_expert_moe(backend_cls, cpu_infer, w, p2l_map):
+def build_per_expert_moe(backend_cls, cpu_infer, w, p2l_map, gs=group_size):
     """Load through per-expert pointers, each expert in its own storage.
 
     Returns the MoE instance and the per-expert tensors, which the caller must
@@ -124,7 +124,7 @@ def build_per_expert_moe(backend_cls, cpu_infer, w, p2l_map):
     directly from these buffers).
     """
     holders = []
-    config = base_config(cpu_infer.backend_)
+    config = base_config(cpu_infer.backend_, gs)
     for weight_key, scale_key, proj_attr, scale_attr in (
         ("gate_qw", "gate_sc", "gate_projs", "gate_scales"),
         ("up_qw", "up_sc", "up_projs", "up_scales"),
@@ -282,6 +282,43 @@ def test_int32_pack_quantized_layout_matches_uint8():
         assert torch.equal(out_i32, out_u8), f"int32-packed weights differ from uint8 (qlen={qlen})"
 
 
+def test_avxvnni_packed_weights_match_unpacked():
+    """KT_RAWINT4_PACKED_WEIGHTS=1 keeps nibbles resident and unpacks in-register.
+
+    Same weight bytes, same scales and weight_sums, same integer dots: outputs
+    must be bitwise equal to the default unpacked-int8 layout, through both the
+    flat and the per-expert load path.
+    """
+    backend_cls = avxvnni_backend()
+    if backend_cls is None:
+        print("Skipping: AVXVNNI256RawInt4_MOE not available")
+        return
+
+    prev = os.environ.get("KT_RAWINT4_PACKED_WEIGHTS")
+    try:
+        for gs in (32, 128):
+            w = make_rawint4_weights(seed=555 + gs, gs=gs)
+            p2l_map = identity_map()
+            cpu_infer = make_cpu_infer(1)
+            os.environ["KT_RAWINT4_PACKED_WEIGHTS"] = "0"
+            moe_unpacked = build_flat_moe(backend_cls, cpu_infer, w, p2l_map, gs=gs)
+            os.environ["KT_RAWINT4_PACKED_WEIGHTS"] = "1"
+            moe_packed = build_flat_moe(backend_cls, cpu_infer, w, p2l_map, gs=gs)
+            moe_packed_pe, holders = build_per_expert_moe(backend_cls, cpu_infer, w, p2l_map, gs=gs)
+
+            for qlen in (1, 16):
+                out_unpacked = run_forward(cpu_infer, moe_unpacked, qlen, seed=qlen)
+                out_packed = run_forward(cpu_infer, moe_packed, qlen, seed=qlen)
+                out_packed_pe = run_forward(cpu_infer, moe_packed_pe, qlen, seed=qlen)
+                assert torch.equal(out_packed, out_unpacked), f"packed flat load differs (gs={gs}, qlen={qlen})"
+                assert torch.equal(out_packed_pe, out_unpacked), f"packed per-expert load differs (gs={gs}, qlen={qlen})"
+    finally:
+        if prev is None:
+            os.environ.pop("KT_RAWINT4_PACKED_WEIGHTS", None)
+        else:
+            os.environ["KT_RAWINT4_PACKED_WEIGHTS"] = prev
+
+
 def test_flat_load_two_subpools_matches_single():
     backends = available_backends()
     if not backends:
@@ -316,5 +353,6 @@ if __name__ == "__main__":
     test_avx2_per_expert_load_matches_flat()
     test_per_expert_load_respects_physical_to_logical_map()
     test_int32_pack_quantized_layout_matches_uint8()
+    test_avxvnni_packed_weights_match_unpacked()
     test_flat_load_two_subpools_matches_single()
     print("PASSED")


### PR DESCRIPTION

# What does this PR do?

#2092 made native RAWINT4 checkpoints load on CPUs where the AVX-VNNI-256 backend is selected; this PR makes the backend cheaper to run there. The main change is an opt-in packed weight storage mode, `KT_RAWINT4_PACKED_WEIGHTS=1`, that keeps expert weights exactly as loaded, packed nibble rows `[N, K/2]`, instead of unpacking them to signed int8 `[N, K]` for the process lifetime: resident expert weight memory halves, and single-token decode, which at production thread counts runs at the memory bandwidth ceiling, gets up to 1.40x faster at hidden 7168 / intermediate 2048 with group_size 128, measured through the real operator path (tables in Testing). Underneath it, the GEMM inner loop is restructured around blocked dpbusd accumulators; that restructure produces bitwise-identical outputs to the shipped kernel and replaces it outright.

The two changes belong together because the first one's measurements motivate the second. Blocking the accumulators is an ILP fix: the old loop computed each output column with a single dpbusd chain, serializing on the instruction's latency, and collapsed it with a five-instruction horizontal sum once per column per k-group. The new loop runs four columns per pass with two chains each (eight independent accumulators when the group has at least 64 elements, four at group_size 32) and reduces all four columns with one combined hadd tree per group; leftover columns keep the single-column loop, and weight layout, load path, buffer formats and the kernel signature are unchanged. There is no old-vs-new dispatch: the blocked loop replaces the old one outright, since it was faster in every measured kernel-level cell and is bitwise identical. At the kernel level that is 1.1 to 1.8x in cycles. Through the real operator it is worth 1.01 to 1.11x on batched qlen-16 cells but stays about par on single-token decode, and the reason is the finding this PR is built around: decode in this operator runs at the memory bandwidth ceiling. One token at 7168/2048 streams 88 MB of expert weights, and both builds sit at the effective ceiling (about 18 GB/s at 1 thread, 35 to 43 GB/s at 4), so no amount of instruction-level parallelism buys decode back; the win that transfers is streaming half as many bytes, which is exactly what packed storage does.

In packed mode the GEMM unpacks 32 weights per 16 loaded bytes in-register (mask, shift, two byte interleaves, one subtract) and feeds the same blocked dpbusd scheme. `weight_sums` are computed from the nibbles at load with the same arithmetic as before, scales are converted the same way, and the float update per (column, group) is textually identical, so packed and unpacked instances produce bitwise-equal outputs (measured, see Testing). Both weight load paths (flat and per-expert pointers) feed both modes, each instance samples the variable at construction so mixed-mode instances coexist in one process, and the default is byte-for-byte today's behavior: layout, kernel and allocation sizes are unchanged unless the variable is set.

Resident weight buffers shrink by exactly 2x in the mode; with the per-group scales and weight_sums included, the whole per-expert allocation shrinks by 1.9x at group_size 128. Measured RSS delta of eight loaded experts (construction plus load, flat path, one subpool, one process per run):

| dims (hidden, intermediate) | group_size | unpacked | packed | allocation sizes say |
|---|---|---|---|---|
| 7168, 2048 | 128 | 357 MiB | 189 MiB | 352 / 184 MiB |
| 7168, 2048 | 32 | 420 MiB | 231 MiB | 399 / 231 MiB |
| 2048, 768 | 128 | 38.6 MiB | 20.5 MiB | 37.7 / 19.7 MiB |
| 2048, 768 | 32 | 45.4 MiB | 27.3 MiB | 42.8 / 24.8 MiB |

At model scale that is the difference between fitting and not fitting: for a 30B-class int4 MoE (48 layers x 128 experts at hidden 2048, intermediate 768, the Qwen3-30B-A3B geometry) the routed expert weight buffers alone go from about 29 GB resident to about 14.5 GB, with the scale/weight_sum arrays (about 1.4 GB at group_size 128) the same in both modes.

Why opt-in instead of the new default: the tradeoff splits by workload. Decode streams each expert's weights once per token, so halving the bytes is a direct win at the bandwidth ceiling; qlen-16 batches land only about 4 rows per expert GEMM (16 tokens at top-2 over 8 experts), too few to amortize the in-register unpack, and those cells lose 10 to 13% (0.87 to 0.90 in the operator table below). That cost is stated plainly because it is the whole reason the mode is opt-in: batch-heavy users keep today's layout and kernel byte for byte, while memory-tight decode deployments get half the weight memory and the decode win. Part of the qlen-16 loss is gcc 15 compiling the in-register unpack to slower code than clang 21 does (details in Testing), so the batched side has room to improve with no format change, and the default can be revisited with field data. The switch follows the existing selection idioms (`KT_RAWINT4_BACKEND` selects the backend class on the Python side; `SFT_MOE_NAN_CHECK` is the in-tree getenv toggle pattern).

## Changes

- `kt-kernel/operators/avx2/rawint4_avxvnni-moe.hpp`: the first commit blocks the accumulators in `gemm_rawint4_avxvnni256` and adds a four-way horizontal-sum helper next to the existing single-column one; the second adds the `packed` flag and dual layout in `BufferB` (constructor, `required_size`, `from_raw_mat`), an in-register nibble unpack helper, the packed-mode GEMM, and a one-branch dispatch.
- `kt-kernel/test/per_commit/test_moe_rawint4_load_equivalence.py`: packed-vs-unpacked equivalence case at group sizes 32 and 128 through both load paths; the group size becomes a parameter of the existing helpers, defaults unchanged.

## Not addressed here

The default stays unpacked; flipping it, or adding a per-shape dispatch that picks packed for decode and unpacked for batched GEMMs, waits on field data and on closing the gcc unpack-codegen gap. The GPU expert staging entry points (`write_weights_to_buffer`, `write_weight_scale_to_buffer`) keep their pre-existing not-implemented throws in both modes; no reader of the unpacked buffer is reachable in packed mode. The AVX2 sibling backends are untouched, and their known limitation from #2092 (per-expert mode requires `--kt-threadpool-count 1`) stays as it was.

## Testing

Host: Intel Core Ultra 5 225 (Arrow Lake, AVX2 + AVX-VNNI, no AVX512, no AMX), Linux, gcc 15, default build flags (`-O3 -ffast-math -march=native`).

Correctness comes in two bitwise layers, one per functional commit, plus the suites in both modes:

- Bitwise identity across builds (the restructure): the module built at the base commit and at the first commit, forwards on fixed seeds through both, compared with `torch.equal`: group_size 32 and 128, qlen 1 and 16, flat and per-expert load, one and two worker subpools, 16 comparisons, all bitwise equal. Two runs of the base build were compared first to establish run-to-run determinism, and the untouched AVX2 backend ran in the same harness as a control; both checks also come out bitwise equal, so the comparison method is sound. This is guaranteed by construction as well as measured: the restructure only reassociates integer additions, which reassociate exactly, and the float update `c += dot * a_scale * w_scale` is untouched and runs once per column per group in the same order.
- Bitwise equality across modes (packed storage): packed and unpacked instances in one process, same weight bytes, `torch.equal` on fixed seeds: group_size {32, 128} x load {flat, per-expert} x subpools {1, 2} x qlen {1, 16}, 16 comparisons, all bitwise equal, with the same style of determinism control run first (two unpacked instances of the same config at both group sizes).
- `test_moe_rawint4_load_equivalence.py`: PASSED with the variable unset and PASSED with `KT_RAWINT4_PACKED_WEIGHTS=1` exported for the whole file (which makes every AVX-VNNI instance in the older tests packed too, including the permuted-map and two-subpool cases).
- `test_moe_rawint4_accuracy.py`: PASSED in both modes with identical error statistics (about 0.003 for AVX2, about 0.014 for AVX-VNNI against the torch reference), as bitwise-equal outputs require.
- Rest of `test/per_commit` with the variable unset: outcome identical to the #2092 baseline; the eight `test_moe_amx_*` files stop at torch calls that need CUDA before reaching any kt-kernel code (CPU-only torch on this host).

Performance, operator level (primary). All timing goes through the real extension: `perf_counter` around `cpu_infer.submit(forward_task)` plus sync on the MoE operator, 8 experts, top-2 routing, fixed per-cell iteration counts identical across arms, expert routing rotated with fixed seeds so every arm executes identical work, 4 threads, one subpool, gcc 15 builds with the default flags.

First the restructure alone, both arms unpacked: the base build against the first-commit build, whole processes interleaved arm-for-arm within every round, medians of 7 rounds (mins track medians within 2%). Speedup is base time over new time:

| hidden, intermediate | group_size | qlen | old ms | new ms | speedup |
|---|---|---|---|---|---|
| 7168, 2048 | 32 | 1 | 2.590 | 2.478 | 1.05x |
| 7168, 2048 | 32 | 16 | 22.649 | 20.456 | 1.11x |
| 7168, 2048 | 128 | 1 | 2.046 | 2.035 | 1.00x |
| 7168, 2048 | 128 | 16 | 14.341 | 13.672 | 1.05x |
| 2048, 768 | 32 | 1 | 0.306 | 0.302 | 1.01x |
| 2048, 768 | 32 | 16 | 2.565 | 2.353 | 1.09x |
| 2048, 768 | 128 | 1 | 0.205 | 0.213 | 0.97x |
| 2048, 768 | 128 | 16 | 1.527 | 1.506 | 1.01x |

Decode moves little because in this operator it is memory bound: one token at 7168/2048 streams 88 MB of expert weights, and both builds run at the effective ceiling (about 18 GB/s at 1 thread, 35 to 43 GB/s at 4), so removing latency stalls cannot buy much there. The gains land where compute is exposed: qlen 16, and group_size 32 with its per-group reduction overhead. The one cell below par, 2048/768 gs128 qlen 1 at 0.97x, traces to weight residency, not to the loop change itself: an 11-round focused A/B on that cell shows the deficit only when the rotated expert weights stream from DRAM (about 3 percent at 4 threads, larger at 1 thread, an 8 microsecond delta on a 0.2 ms call), while the same cell with routing pinned to two experts, so the touched weights sit in L3, flips to a 1.03 to 1.08x win for the new loop in 11 of 11 rounds. The old single-row walk prefetches a little better on DRAM-cold weights at group_size 128; once the lines are cached the blocked loop wins everywhere, and no other cell regresses.

Then the storage mode: packed vs unpacked instances of this branch's build, both in one process (the variable is sampled per instance) alternating within every round, medians of 9 rounds. Speedup is unpacked time over packed time:

| hidden, intermediate | group_size | qlen | unpacked ms | packed ms | speedup |
|---|---|---|---|---|---|
| 7168, 2048 | 32 | 1 | 2.468 | 2.276 | 1.08x |
| 7168, 2048 | 32 | 16 | 21.278 | 24.112 | 0.88x |
| 7168, 2048 | 128 | 1 | 2.014 | 1.444 | 1.40x |
| 7168, 2048 | 128 | 16 | 14.261 | 16.016 | 0.89x |
| 2048, 768 | 32 | 1 | 0.309 | 0.280 | 1.10x |
| 2048, 768 | 32 | 16 | 2.558 | 2.948 | 0.87x |
| 2048, 768 | 128 | 1 | 0.213 | 0.169 | 1.26x |
| 2048, 768 | 128 | 16 | 1.584 | 1.758 | 0.90x |

Decode wins because it is bandwidth bound at these thread counts: the token that streamed 88 MB unpacked streams half that packed, and the win grows with threads (1.06x single threaded, 1.40x at 4 on the large gs128 cell), which is what bandwidth relief looks like. The qlen-16 cells lose 10 to 13% for two reasons that compound: about 4 rows per expert GEMM cannot amortize the per-load unpack, and gcc 15 compiles the unpack sequence to slower code than clang 21 does (the clang-built harness below has packed well ahead on the large m=16 shapes). Neither is a property of the layout, so the qlen-16 side has room to improve without a format change.

One more control: this branch's build with the variable unset, timed against the first-commit build, lands within 3% of parity on every cell, so the packed-mode plumbing (a per-buffer flag and one dispatch branch) costs the default path nothing measurable.

Performance, kernel level (supporting, not end-to-end). The original loop, the blocked loop and the packed loop, lifted with their buffer structs into a standalone harness, all arms compiled identically (clang 21, `-O3 -march=native`), single thread, rdtscp cycle counts serialized with lfence, arms interleaved within every round, min of 9 rounds, expert weight sets rotated across reps. Cycles are frequency independent, so the ratios hold under laptop clocking. Two passes run back to back.

Blocked loop vs the old loop (speedup, old cycles over new):

| shape | gs32, pass 1 / 2 | gs128, pass 1 / 2 |
|---|---|---|
| decode m=1, n=768, k=2048 | 1.46x / 1.35x | 1.76x / 1.56x |
| decode m=1, n=2048, k=7168 | 1.31x / 1.28x | 1.74x / 1.70x |
| prefill m=16, n=768, k=2048 | 1.18x / 1.19x | 1.19x / 1.22x |
| prefill m=16, n=2048, k=7168 | 1.21x / 1.20x | 1.41x / 1.35x |
| prefill m=64, n=768, k=2048 | 1.20x / 1.22x | 1.23x / 1.24x |
| prefill m=64, n=2048, k=7168 | 1.19x / 1.14x | 1.32x / 1.34x |

Packed GEMM vs the blocked kernel it dispatches from (ratio, packed cycles over blocked; below 1.00 means packed is faster):

| shape | gs32, pass 1 / 2 | gs128, pass 1 / 2 |
|---|---|---|
| decode m=1, n=768, k=2048 | 0.93 / 0.83 | 1.41 / 1.30 |
| decode m=1, n=2048, k=7168 | 0.89 / 0.87 | 1.69 / 1.65 |
| prefill m=16, n=768, k=2048 | 1.06 / 1.07 | 1.37 / 1.38 |
| prefill m=16, n=2048, k=7168 | 0.58 / 0.59 | 0.87 / 0.78 |
| prefill m=64, n=768, k=2048 | 1.04 / 1.03 | 1.35 / 1.37 |
| prefill m=64, n=2048, k=7168 | 0.55 / 0.55 | 0.73 / 0.72 |

These single-core numbers explain the operator tables rather than replace them. The blocked loop reads up to 1.8x on decode here because the harness baseline runs below the memory ceiling (about 10 to 12 GB/s implied at the 3.264 GHz TSC), which exposes the latency stalls; in the real extension both arms sit at the ceiling and decode barely moves. The decode rows at n=768, k=2048 also rotate a weight set small enough to stay L3-resident (12.6 MB against 20 MB of L3), so they describe the cache-warm regime, the same regime where the pinned-routing A/B above shows the blocked loop winning in situ. Within the kernel, decode gains the most because m=1 makes the whole GEMM latency and reduction bound, and group_size 128 gains more than 32 because the old loop chained four dpbusds deep there, while at 32 the shared per-group activation quantization takes a fixed slice of the time that blocking cannot touch. The packed table inverts through the operator for the mirror-image reason: single core below the ceiling, the packed kernel pays its extra unpack instructions and loses gs128 decode on raw instruction count, while at 4 threads through forward_task the unpacked arm is pinned at the bandwidth ceiling and streaming half the bytes wins decode outright; packed wins the large m=16 and m=64 shapes here because many rows amortize each unpack. The same harness built with gcc 15 and the project's flags reproduces the blocked bands (decode 1.4 to 1.6x) and shows gcc compiling the in-register unpack to slower code than clang 21, the codegen gap noted above. A third quiet-window pass plus 15-round focused reruns reproduce all these bands.

## Before submitting

- [x] Read the contributor guideline.
- [x] New test: packed-vs-unpacked case in the load-path equivalence file, group sizes 32 and 128 through both load paths; skips cleanly where the backend or avx_vnni is unavailable. The restructure itself adds none: its outputs are bitwise identical, and the equivalence tests from #2092 plus `test_moe_rawint4_accuracy.py` pin this kernel's behavior in both modes.
