### PR TITLE
docs: quote pip extras install examples

### DIFF
--- a/doc/en/xpu.md
+++ b/doc/en/xpu.md
@@ -47,7 +47,7 @@ strings ~/anaconda3/envs/ktransformers/lib/libstdc++.so.6 | grep GLIBCXX
 Install PyTorch with XPU backend support and [IPEX-LLM](https://github.com/intel/ipex-llm):
 
 ```bash
-pip install ipex-llm[xpu_2.6]==2.3.0b20250518 --extra-index-url https://download.pytorch.org/whl/xpu
+pip install 'ipex-llm[xpu_2.6]==2.3.0b20250518' --extra-index-url https://download.pytorch.org/whl/xpu
 pip uninstall torch torchvision torchaudio
 pip install torch==2.7+xpu torchvision torchaudio --index-url https://download.pytorch.org/whl/test/xpu # install torch2.7
 pip uninstall intel-opencl-rt dpcpp-cpp-rt


### PR DESCRIPTION
## Summary
- Quote `pip install` examples that include extras.

## Why
- Shells such as zsh can expand unquoted bracket expressions before `pip` receives them.

## Scope
- Files changed:
- `doc/en/xpu.md`
- This does not change dependencies or runtime behavior.

## Testing
- `git diff --check`

## Maintainer Fit
- Small install-command correctness fix.
- Duplicate PR search terms checked: `quote pip extras`, `quote optional dependency`, `zsh pip install extras`, `pip extras install examples`