### PR TITLE
fix(kt-kernel): harden qwen3.5 build script for setuptools Path / rglob

### DIFF
--- a/kt-kernel/pyproject.toml
+++ b/kt-kernel/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 # Minimum versions: setuptools for setup.py declarative usage, wheel for bdist_wheel
-requires = ["setuptools>=61", "wheel", "cmake>=3.16", "pybind11"]
+requires = ["setuptools>=61.0", "wheel", "cmake>=3.16", "pybind11"]
 build-backend = "setuptools.build_meta"
 
 [project]

--- a/kt-kernel/setup.py
+++ b/kt-kernel/setup.py
@@ -451,6 +451,9 @@ class CMakeBuild(build_ext):
             build_temp: Temporary build directory for CMake
             cfg: Build type (Release/Debug/etc.)
         """
+        # Ensure Path early (pip/setuptools may pass str; #1874) so later `/` and rglob are safe
+        build_temp = Path(build_temp)
+        build_temp.mkdir(parents=True, exist_ok=True)
 
         # Auto-detect CUDA toolkit if user did not explicitly set CPUINFER_USE_CUDA
         def detect_cuda_toolkit() -> bool:
@@ -661,10 +664,6 @@ class CMakeBuild(build_ext):
         for a in cmake_args:
             print("   ", a)
 
-        # Ensure build_temp is a Path before cmake (pip/setuptools may pass str; #1874)
-        build_temp = Path(build_temp)
-        build_temp.mkdir(parents=True, exist_ok=True)
-
         # Configure
         subprocess.run(["cmake", ext.sourcedir, *cmake_args], cwd=build_temp, check=True)
 
@@ -677,8 +676,7 @@ class CMakeBuild(build_ext):
         subprocess.run(["cmake", *build_args], cwd=build_temp, check=True)
 
         # On some systems LTO + CMake + pybind may place the built .so inside build tree; move if needed
-        # Path(...) guards against str build_temp (#1874 AttributeError: 'str' has no attribute 'rglob')
-        built_candidates = list(Path(build_temp).rglob(f"{ext.name}*.so"))
+        built_candidates = list(build_temp.rglob(f"{ext.name}*.so"))
         for cand in built_candidates:
             if cand.parent != extdir:
                 target = extdir / cand.name

--- a/kt-kernel/setup.py
+++ b/kt-kernel/setup.py
@@ -661,6 +661,10 @@ class CMakeBuild(build_ext):
         for a in cmake_args:
             print("   ", a)
 
+        # Ensure build_temp is a Path before cmake (pip/setuptools may pass str; #1874)
+        build_temp = Path(build_temp)
+        build_temp.mkdir(parents=True, exist_ok=True)
+
         # Configure
         subprocess.run(["cmake", ext.sourcedir, *cmake_args], cwd=build_temp, check=True)
 
@@ -673,7 +677,8 @@ class CMakeBuild(build_ext):
         subprocess.run(["cmake", *build_args], cwd=build_temp, check=True)
 
         # On some systems LTO + CMake + pybind may place the built .so inside build tree; move if needed
-        built_candidates = list(build_temp.rglob(f"{ext.name}*.so"))
+        # Path(...) guards against str build_temp (#1874 AttributeError: 'str' has no attribute 'rglob')
+        built_candidates = list(Path(build_temp).rglob(f"{ext.name}*.so"))
         for cand in built_candidates:
             if cand.parent != extdir:
                 target = extdir / cand.name


### PR DESCRIPTION
### What does this PR do?

Fixes #1874 on branch `qwen3.5`.

`pip install .` for `kt-kernel` still breaks on Python 3.12 / modern setuptools as reported in #1874, and the issue has been open for several months without a mergeable fix on `qwen3.5`. This PR applies the three build-script corrections so the branch installs cleanly again:

1. `setuptools>=61` is rejected on some envs → use `setuptools>=61.0`
2. cmake via `pip install .` fails while manual cmake works → normalize `build_temp` to `Path` and `mkdir` before `subprocess.run`
3. `AttributeError: 'str' object has no attribute 'rglob'` when collecting built `.so` → wrap with `Path(build_temp).rglob(...)`

### What changed

| File | Change |
|------|--------|
| `kt-kernel/pyproject.toml` | `setuptools>=61` → `setuptools>=61.0` |
| `kt-kernel/setup.py` | ensure `build_temp = Path(build_temp)` + `mkdir` before cmake; `Path(build_temp).rglob(...)` for `.so` collection |

### Test plan

Verified locally (build-script only; not full CUDA / SGLang stack):

- Host: cluster GPU node (`highmem_8gpu_node`), Linux
- Python 3.12 / setuptools 83 / cmake 4.4
- Config: `CPUINFER_USE_CUDA=0`, single AVX2 variant

| Check | Result |
|-------|--------|
| `pip install .` after patch | success (`BUILD_EXIT=0`) |
| Wheel produced | `kt-kernel` 0.5.1, CPython 3.12, linux x86_64 |
| Package install | `Successfully installed kt-kernel-0.5.1` |
| Issue symptom `AttributeError: 'str' object has no attribute 'rglob'` | not observed (0 hits in build log) |
| Native extension `.so` | built and loadable (`CPUInfer`, `moe`, `mlp`, …) |
| Full `import kt_kernel` (pulls torch) | skipped on purpose (`--no-deps`); out of scope |
