### PR TITLE
fix(kt-kernel): pick default CUDA archs by nvcc version (fixes #2098)

### DIFF
--- a/kt-kernel/setup.py
+++ b/kt-kernel/setup.py
@@ -664,6 +664,7 @@ class CMakeBuild(build_ext):
             print("-- Enabling CUDA backend (-DKTRANSFORMERS_USE_CUDA=ON)")
             # Inject nvcc compiler path automatically unless user already specified one.
             user_specified_compiler = any("CMAKE_CUDA_COMPILER" in a for a in cmake_args)
+            nvcc_path = None
             if not user_specified_compiler:
                 extra_env = os.environ.get("CMAKE_ARGS", "")
                 if "CMAKE_CUDA_COMPILER" in extra_env:
@@ -685,9 +686,13 @@ class CMakeBuild(build_ext):
             # sm_89, CUDA < 12.0 has no sm_90), which makes the build fail outright
             # on older toolkits. So when the user has not pinned CPUINFER_CUDA_ARCHS,
             # derive a default that the detected nvcc actually supports.
-            def _default_cuda_archs() -> str:
+            def _default_cuda_archs(nvcc: str | None) -> str:
                 full = "80;86;89;90"
-                nvcc = find_nvcc_path()
+                # Reuse the nvcc already resolved for -DCMAKE_CUDA_COMPILER above; only
+                # fall back to a fresh lookup when the compiler was user-specified and
+                # we never resolved a path ourselves. This avoids a second set of
+                # filesystem probes and guarantees both uses pick the same binary.
+                nvcc = nvcc or find_nvcc_path()
                 if not nvcc:
                     return full
                 try:
@@ -723,7 +728,7 @@ class CMakeBuild(build_ext):
             if "CPUINFER_CUDA_ARCHS" in os.environ:
                 archs_env = os.environ["CPUINFER_CUDA_ARCHS"].strip()
             else:
-                archs_env = _default_cuda_archs()
+                archs_env = _default_cuda_archs(nvcc_path)
             if archs_env and not any("CMAKE_CUDA_ARCHITECTURES" in a for a in cmake_args):
                 cmake_args.append(f"-DCMAKE_CUDA_ARCHITECTURES={archs_env}")
                 print(f"-- Set CUDA architectures: {archs_env}")

--- a/kt-kernel/setup.py
+++ b/kt-kernel/setup.py
@@ -680,8 +680,44 @@ class CMakeBuild(build_ext):
                 hostcxx = os.environ["CUDAHOSTCXX"]
                 cmake_args.append(f"-DCMAKE_CUDA_HOST_COMPILER={hostcxx}")
                 print(f"-- Using CUDA host compiler from CUDAHOSTCXX: {hostcxx}")
-            # Set CUDA architectures (default: Ampere/Ada/Hopper)
-            archs_env = os.environ.get("CPUINFER_CUDA_ARCHS", "80;86;89;90").strip()
+            # Set CUDA architectures. The default targets Ampere/Ada/Hopper, but
+            # nvcc rejects architectures it does not know about (CUDA < 11.8 has no
+            # sm_89, CUDA < 12.0 has no sm_90), which makes the build fail outright
+            # on older toolkits. So when the user has not pinned CPUINFER_CUDA_ARCHS,
+            # derive a default that the detected nvcc actually supports.
+            def _default_cuda_archs() -> str:
+                full = "80;86;89;90"
+                nvcc = find_nvcc_path()
+                if not nvcc:
+                    return full
+                try:
+                    ver_out = subprocess.check_output(
+                        [nvcc, "--version"], text=True, stderr=subprocess.STDOUT
+                    )
+                except Exception:
+                    return full
+                m = re.search(r"release\s+(\d+)\.(\d+)", ver_out)
+                if not m:
+                    return full
+                ver = (int(m.group(1)), int(m.group(2)))
+                archs = []
+                if ver >= (11, 0):
+                    archs.append("80")
+                if ver >= (11, 1):
+                    archs.append("86")
+                if ver >= (11, 8):
+                    archs.append("89")
+                if ver >= (12, 0):
+                    archs.append("90")
+                selected = ";".join(archs) if archs else full
+                if selected != full:
+                    print(
+                        f"-- Detected CUDA {ver[0]}.{ver[1]}; defaulting CUDA "
+                        f"architectures to {selected} (set CPUINFER_CUDA_ARCHS to override)"
+                    )
+                return selected
+
+            archs_env = os.environ.get("CPUINFER_CUDA_ARCHS", "").strip() or _default_cuda_archs()
             if archs_env and not any("CMAKE_CUDA_ARCHITECTURES" in a for a in cmake_args):
                 cmake_args.append(f"-DCMAKE_CUDA_ARCHITECTURES={archs_env}")
                 print(f"-- Set CUDA architectures: {archs_env}")

--- a/kt-kernel/setup.py
+++ b/kt-kernel/setup.py
@@ -717,7 +717,13 @@ class CMakeBuild(build_ext):
                     )
                 return selected
 
-            archs_env = os.environ.get("CPUINFER_CUDA_ARCHS", "").strip() or _default_cuda_archs()
+            # Only derive a default when the variable is absent: an explicitly
+            # empty CPUINFER_CUDA_ARCHS is the documented way to suppress
+            # -DCMAKE_CUDA_ARCHITECTURES entirely, so keep honoring it.
+            if "CPUINFER_CUDA_ARCHS" in os.environ:
+                archs_env = os.environ["CPUINFER_CUDA_ARCHS"].strip()
+            else:
+                archs_env = _default_cuda_archs()
             if archs_env and not any("CMAKE_CUDA_ARCHITECTURES" in a for a in cmake_args):
                 cmake_args.append(f"-DCMAKE_CUDA_ARCHITECTURES={archs_env}")
                 print(f"-- Set CUDA architectures: {archs_env}")


### PR DESCRIPTION
## Problem

`kt-kernel/setup.py` sets `-DCMAKE_CUDA_ARCHITECTURES=80;86;89;90` whenever `CPUINFER_CUDA_ARCHS` is unset:

```python
archs_env = os.environ.get("CPUINFER_CUDA_ARCHS", "80;86;89;90").strip()
```

An architecture only becomes valid to `nvcc` in a specific CUDA toolkit release — `sm_89` (Ada) needs CUDA **11.8+** and `sm_90` (Hopper) needs CUDA **12.0+**. On an older toolkit `nvcc` rejects the unknown `-gencode` targets, so the wheel build fails during compilation with no clear cause. This is exactly what #2098 hits on CUDA 11.5 (a 4×A100 box):

```
error: subprocess-exited-with-error
× Building wheel for kt-kernel (pyproject.toml) did not run successfully.
```

## Fix

When `CPUINFER_CUDA_ARCHS` is **not** set, derive the default from the detected `nvcc` release (reusing the existing `find_nvcc_path()` helper) and keep only the architectures that toolkit supports:

| nvcc CUDA | default archs |
|-----------|---------------|
| ≥ 12.0    | `80;86;89;90` (unchanged) |
| 11.8–11.x | `80;86;89` |
| 11.1–11.7 | `80;86` |
| 11.0      | `80` |

Behavior is preserved everywhere it matters:

- An explicitly set `CPUINFER_CUDA_ARCHS` still wins — untouched.
- On a modern toolkit (≥ 12.0) the default is byte-for-byte the old `80;86;89;90`.
- If `nvcc` can't be probed, we fall back to the previous full list, so nothing regresses when detection is unavailable.

A one-line note is printed when the default is narrowed, pointing users at `CPUINFER_CUDA_ARCHS` if they want to override.

Fixes #2098.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
