### PR TITLE
release: bump version to 0.6.4

### DIFF
--- a/version.py
+++ b/version.py
@@ -3,4 +3,4 @@ KTransformers version information.
 Shared across the top-level package and kt-kernel.
 """
 
-__version__ = "0.6.3.post1"
+__version__ = "0.6.4"


### PR DESCRIPTION
## Summary

- bump the shared package version from `0.6.3.post1` to `0.6.4`
- trigger the `Release to PyPI` workflow after merge to `main`

## Validation

- `version.py` resolves to `0.6.4`
- top-level package metadata resolves to `0.6.4`
- built and inspected `ktransformers-0.6.4.tar.gz`; `version.py` is included
- confirmed `0.6.4` is not yet present on PyPI for `ktransformers`, `kt-kernel`, or `sglang-kt`

GitHub release: https://github.com/kvcache-ai/ktransformers/releases/tag/v0.6.4