### PR TITLE
docs: fix broken injection tutorial link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ KTransformers is a research project focused on efficient inference and fine-tuni
 * **Feb 15, 2025**: Longer Context (from 4K to 8K for 24GB VRAM) & Slightly Faster Speed （+15%, up to 16 Tokens/s), update [docs](./doc/en/DeepseekR1_V3_tutorial.md) and [online books](https://kvcache-ai.github.io/ktransformers/).
 * **Feb 10, 2025**: Support Deepseek-R1 and V3 on single (24GB VRAM)/multi gpu and 382G DRAM, up to 3~28x speedup. For detailed show case and reproduction tutorial, see [here](./doc/en/DeepseekR1_V3_tutorial.md).
 * **Aug 28, 2024**: Decrease DeepseekV2's required VRAM from 21G to 11G.
-* **Aug 15, 2024**: Update detailed [tutorial](doc/en/injection_tutorial.md) for injection and multi-GPU.
+* **Aug 15, 2024**: Update detailed [tutorial](doc/en/SFT/injection_tutorial.md) for injection and multi-GPU.
 * **Aug 14, 2024**: Support llamfile as linear backend.
 * **Aug 12, 2024**: Support multiple GPU; Support new model: mixtral 8\*7B  and 8\*22B; Support q2k, q3k, q5k dequant on gpu.
 * **Aug 9, 2024**: Support windows native.


### PR DESCRIPTION
The changelog entry for **Aug 15, 2024** links the word *tutorial* to `doc/en/injection_tutorial.md`:

```
* **Aug 15, 2024**: Update detailed [tutorial](doc/en/injection_tutorial.md) for injection and multi-GPU.
```

That path returns a **404** — the file was moved to `doc/en/SFT/injection_tutorial.md` during the docs restructure (#1623), but this changelog link was not updated. The target doc (*"Tutorial: Inject Operator Step by Step"*, which includes the `Muti-GPU` section) matches the link text exactly.

This one-line fix points the link at the current location so it resolves.

No functional changes — docs only.