### PR TITLE
fix(kt-kernel): cap compressed-tensors below the torch>=2.10 releases (#2110)

### DIFF
--- a/kt-kernel/pyproject.toml
+++ b/kt-kernel/pyproject.toml
@@ -39,7 +39,11 @@ sglang = [
   "sglang-kt",
 ]
 convert = [
-  "compressed-tensors>=0.7.0",
+  # compressed-tensors 0.16.0 moved its offload stack onto torch.accelerator
+  # and requires torch>=2.10.0, but this package pins torch==2.9.1. Installing
+  # the newer release against that torch makes convert_gpu_weights.py fail with
+  # "module 'torch.accelerator' has no attribute 'get_memory_info'".
+  "compressed-tensors>=0.7.0,<0.16.0",
 ]
 test = [
   "pytest>=7.0.0",


### PR DESCRIPTION
Fixes #2110.

## Problem

`kt-kernel/pyproject.toml` pins `torch==2.9.1` in `[project.dependencies]`, but the `convert` extra only lower-bounds compressed-tensors:

```toml
convert = [
  "compressed-tensors>=0.7.0",
]
```

compressed-tensors 0.16.0 migrated its offload stack onto `torch.accelerator` and raised its own floor to `torch>=2.10.0`. When an environment ends up with 0.16.0+ next to the pinned torch 2.9.1, `scripts/convert_gpu_weights.py` runs for hours and then dies inside `dispatch_model()`:

```
File ".../compressed_tensors/offload/dispatch.py", line 261, in <dictcomp>
    torch.device(accel_type, idx): torch.accelerator.get_memory_info(idx)[1]
AttributeError: module 'torch.accelerator' has no attribute 'get_memory_info'
```

That is exactly the environment reported in #2110 (torch 2.9.1 + compressed_tensors 0.17.1).

## Evidence for the boundary

`torch.accelerator.get_memory_info` is first used by compressed-tensors in [`f764f6d`](https://github.com/vllm-project/compressed-tensors/commit/f764f6d2) ("[offload] Migrate offload stack to torch.accelerator"), which shipped in 0.16.0. The declared torch requirement flips at the same release:

| compressed-tensors | `requires_dist` torch (PyPI) | `torch.accelerator.get_memory_info` in `offload/dispatch.py` |
|---|---|---|
| 0.15.0 | `torch<2.11,>=1.7.0` | absent |
| 0.16.0 | `torch>=2.10.0` | present |
| 0.17.1 | `torch>=2.10.0` | present |

So `<0.16.0` is the exact set of releases compatible with the pinned `torch==2.9.1`.

## Change

One line in the `convert` extra, plus a comment recording why the cap exists so it can be lifted together with the torch pin:

```toml
convert = [
  "compressed-tensors>=0.7.0,<0.16.0",
]
```

Nothing else changes; the cap only affects the optional `convert` extra used by the weight-conversion scripts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
