### PR TITLE
docs: clarify balance_serve FlashInfer package

### DIFF
--- a/doc/en/DeepseekR1_V3_tutorial.md
+++ b/doc/en/DeepseekR1_V3_tutorial.md
@@ -197,6 +197,14 @@ To use this feature, [install flashinfer](https://github.com/flashinfer-ai/flash
 
 Note: The latest MLA kernel in FlashInfer still has a few minor issues. They are continuously fixing them on the main branch. If you are using FlashInfer, please install it from the main source code.
 
+> [!WARNING]
+> The FlashInfer instruction above applies to the legacy `ktransformers` backend in this
+> longer-context section. If you are running the v0.2.4+ `balance_serve` backend, use the
+> `custom_flashinfer` installed by the balance-serve build instead. Do not reinstall upstream
+> FlashInfer packages (`flashinfer` / `flashinfer-python`) after building `balance_serve`, because
+> replacing the patched package can break the scheduler/attention wrapper ABI. See
+> [Balance Serve backend](./balance-serve.md#installation-guide) for the matching setup.
+
 If you want to use long context(longer than 20K) for prefill, enable the matrix absorption MLA during the prefill phase, which will significantly reduce the size of the kv cache. Modify yaml file like this:
 
 ```

--- a/doc/en/balance-serve.md
+++ b/doc/en/balance-serve.md
@@ -55,9 +55,10 @@ docker exec -it ktrans bash
 
 ⚠️ Please note that installing this project will replace flashinfer in your environment. It is strongly recommended to create a new conda environment!!!
 
-⚠️ Please note that installing this project will replace flashinfer in your environment. It is strongly recommended to create a new conda environment!!!
-
-⚠️ Please note that installing this project will replace flashinfer in your environment. It is strongly recommended to create a new conda environment!!!
+`balance_serve` depends on KTransformers' patched `custom_flashinfer`, which is installed by
+the balance-serve build. Do not reinstall upstream `flashinfer` / `flashinfer-python` in the
+same environment after installation; doing so can replace the patched package and cause runtime
+ABI mismatches such as unexpected keyword argument errors in FlashInfer attention wrappers.
 
 ### 2. Set Up Conda Environment
 


### PR DESCRIPTION
## Summary
- Clarify that the old DeepSeek R1/V3 longer-context FlashInfer instruction applies to the legacy `ktransformers` backend.
- Point `balance_serve` users to the patched `custom_flashinfer` installed by the balance-serve build.
- Replace duplicated balance-serve install warnings with a specific note about avoiding upstream `flashinfer` / `flashinfer-python` reinstalls in the same environment.

Refs #1278

## Test Plan
- `python` documentation guard check for the new `balance_serve` / `custom_flashinfer` warning text
- `git diff --check HEAD~1..HEAD`
