### PR TITLE
docs: add README build mode guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ pip install kt-kernel sglang-kt
 # CPU-only / portable CPU build from source (AVX2 baseline, no CUDA kernels)
 git clone --recursive https://github.com/kvcache-ai/ktransformers.git
 cd ktransformers/kt-kernel
-CPUINFER_USE_CUDA=0 CPUINFER_CPU_INSTRUCT=AVX2 CPUINFER_ENABLE_AMX=OFF ./install.sh build --manual
+CPUINFER_USE_CUDA=0 CPUINFER_CPU_INSTRUCT=AVX2 CPUINFER_ENABLE_AMX=OFF ./install.sh all --manual
 
 # CUDA source build for CPU-GPU heterogeneous serving
 cd /path/to/ktransformers

--- a/README.md
+++ b/README.md
@@ -76,6 +76,26 @@ cd kt-kernel
 pip install .
 ```
 
+**Installation / build modes:**
+
+```bash
+# Recommended: prebuilt package with CPU variants and CUDA support
+pip install kt-kernel sglang-kt
+
+# CPU-only / portable CPU build from source (AVX2 baseline, no CUDA kernels)
+git clone --recursive https://github.com/kvcache-ai/ktransformers.git
+cd ktransformers/kt-kernel
+CPUINFER_USE_CUDA=0 CPUINFER_CPU_INSTRUCT=AVX2 CPUINFER_ENABLE_AMX=OFF ./install.sh build --manual
+
+# CUDA source build for CPU-GPU heterogeneous serving
+cd /path/to/ktransformers
+CPUINFER_USE_CUDA=1 ./install.sh all
+```
+
+For pure CPU experiments, use the KT-Kernel CPU backends directly. The production
+`balance_serve` path is CPU-GPU heterogeneous serving; it still relies on GPU-side
+attention/RMS/linear operators and is not a standalone CPU-only server path yet.
+
 **Use Cases:**
 
 - CPU-GPU hybrid inference for large MoE models


### PR DESCRIPTION
## Summary
- Add README build-mode guidance for the inference quick start.
- Show the recommended prebuilt install, a CPU-only / portable AVX2 source build, and a CUDA source build path.
- Clarify that pure CPU experiments should use KT-Kernel CPU backends directly, while `balance_serve` remains a CPU-GPU heterogeneous serving path.

Refs #1187

## Test Plan
- `python` README guard check for the new build-mode text
- `./install.sh --help` output contains `--manual`
- `kt-kernel/install.sh --help` output contains `CPUINFER_CPU_INSTRUCT` and `CPUINFER_ENABLE_AMX`
- `git diff --check HEAD~1..HEAD`
