### PR TITLE
docs: add submodule install troubleshooting

### DIFF
--- a/kt-kernel/README.md
+++ b/kt-kernel/README.md
@@ -723,6 +723,24 @@ pip install .
 
 ## Error Troubleshooting
 
+### Missing submodule CMakeLists.txt
+
+If CMake reports that `third_party/pybind11` or `third_party/llama.cpp` does not contain a
+`CMakeLists.txt`, the checkout is missing git submodules. Reinitialize them from the repository
+root, then rebuild:
+
+```bash
+git submodule update --init --recursive
+cd kt-kernel
+./install.sh build
+```
+
+When cloning a fresh copy, prefer:
+
+```bash
+git clone --recursive https://github.com/kvcache-ai/ktransformers.git
+```
+
 ### CUDA Not Found
 
 ```


### PR DESCRIPTION
## Summary
- Add a kt-kernel troubleshooting entry for missing `third_party/pybind11` or `third_party/llama.cpp` `CMakeLists.txt` errors.
- Document the correct recursive submodule recovery command and recommend `git clone --recursive` for fresh checkouts.

Refs #1795

## Test Plan
- `python` documentation guard check for the new submodule troubleshooting entry
- `git diff --check HEAD~1..HEAD`
