### PR TITLE
docs: add CUDA host compiler troubleshooting

### DIFF
--- a/kt-kernel/README.md
+++ b/kt-kernel/README.md
@@ -735,13 +735,16 @@ Make sure you have the CUDA toolkit installed and `nvcc` is in your system PATH.
 
 Try `export CMAKE_ARGS="-D CMAKE_CUDA_COMPILER=$(which nvcc)"` and reinstall again.
 
-### CUDA host compiler mismatch
+### CUDA Host Compiler Mismatch
 
 On newer distributions, CUDA may fail during `nvcc` compilation with messages such as
 `unsupported GNU version` or other host-compiler compatibility errors. Install a GCC/G++
 version supported by your CUDA toolkit and point `nvcc` at that host compiler:
 
 ```bash
+# Install the supported GCC/G++ version (Debian/Ubuntu example)
+sudo apt install gcc-13 g++-13
+
 export CC=/usr/bin/gcc-13
 export CXX=/usr/bin/g++-13
 export CUDAHOSTCXX=/usr/bin/g++-13

--- a/kt-kernel/README.md
+++ b/kt-kernel/README.md
@@ -735,6 +735,22 @@ Make sure you have the CUDA toolkit installed and `nvcc` is in your system PATH.
 
 Try `export CMAKE_ARGS="-D CMAKE_CUDA_COMPILER=$(which nvcc)"` and reinstall again.
 
+### CUDA host compiler mismatch
+
+On newer distributions, CUDA may fail during `nvcc` compilation with messages such as
+`unsupported GNU version` or other host-compiler compatibility errors. Install a GCC/G++
+version supported by your CUDA toolkit and point `nvcc` at that host compiler:
+
+```bash
+export CC=/usr/bin/gcc-13
+export CXX=/usr/bin/g++-13
+export CUDAHOSTCXX=/usr/bin/g++-13
+./install.sh build
+```
+
+`CUDAHOSTCXX` is forwarded to CMake as `CMAKE_CUDA_HOST_COMPILER` during the kt-kernel build.
+Adjust the GCC/G++ version to match your CUDA release.
+
 ### hwloc Not Found
 
 Run `sudo apt install libhwloc-dev` if on a Debian-based system or build from source: https://www.open-mpi.org/projects/hwloc/.


### PR DESCRIPTION
## Summary
- Add kt-kernel troubleshooting for CUDA host compiler mismatch errors on newer distributions.
- Document `CC`, `CXX`, and `CUDAHOSTCXX` overrides, including the `g++-13` case reported for Debian 13-style environments.
- Note that `CUDAHOSTCXX` is forwarded to CMake as `CMAKE_CUDA_HOST_COMPILER`.

Refs #1479

## Test Plan
- `python` documentation guard check for the new troubleshooting entry and setup.py `CUDAHOSTCXX` forwarding
- `git diff --check HEAD~1..HEAD`
