### PR TITLE
docs: pin transformers for MiniMax M2.5

### DIFF
--- a/doc/en/MiniMax-M2.5.md
+++ b/doc/en/MiniMax-M2.5.md
@@ -43,7 +43,16 @@ pip install kt-kernel sglang-kt
 > Note: You may need to reinstall cudnn: `pip install nvidia-cudnn-cu12==9.16.0.29`
 
 3. **CUDA toolkit** - Compatible with your GPU (CUDA 12.8+ recommended)
-4. **Hugging Face CLI** - For downloading models:
+4. **transformers==4.57.1** - Avoid the `DeepSeekV4Config` dataclass import error:
+
+   ```bash
+   pip install "transformers==4.57.1"
+   ```
+
+   `transformers` 5.x can raise `TypeError: non-default argument 'quantization_config'
+   follows default argument` while importing SGLang config classes. Pin `transformers`
+   to 4.57.1, or use a newer `sglang-kt` release once it declares a compatible version.
+5. **Hugging Face CLI** - For downloading models:
 
    ```bash
    pip install huggingface-hub

--- a/doc/en/MiniMax-M2.5.md
+++ b/doc/en/MiniMax-M2.5.md
@@ -43,15 +43,15 @@ pip install kt-kernel sglang-kt
 > Note: You may need to reinstall cudnn: `pip install nvidia-cudnn-cu12==9.16.0.29`
 
 3. **CUDA toolkit** - Compatible with your GPU (CUDA 12.8+ recommended)
-4. **transformers==4.57.1** - Avoid the `DeepSeekV4Config` dataclass import error:
+4. **transformers<5** - Avoid the `DeepSeekV4Config` dataclass import error:
 
    ```bash
-   pip install "transformers==4.57.1"
+   pip install "transformers<5"
    ```
 
    `transformers` 5.x can raise `TypeError: non-default argument 'quantization_config'
    follows default argument` while importing SGLang config classes. Pin `transformers`
-   to 4.57.1, or use a newer `sglang-kt` release once it declares a compatible version.
+   below 5.x, or use a newer `sglang-kt` release once it declares a compatible version.
 5. **Hugging Face CLI** - For downloading models:
 
    ```bash


### PR DESCRIPTION
## Summary
- Add the `transformers==4.57.1` prerequisite to the MiniMax-M2.5 tutorial.
- Explain the `TypeError: non-default argument 'quantization_config' follows default argument` import failure and the compatible dependency path.

Refs #1992

## Test Plan
- `python` documentation guard check for the new MiniMax transformers pin guidance
- `git diff --check HEAD~1..HEAD`
