### PR TITLE
docs: clarify Qwen3 model metadata path

### DIFF
--- a/doc/en/AMX.md
+++ b/doc/en/AMX.md
@@ -29,6 +29,12 @@ python ktransformers/server/main.py --architectures Qwen3MoeForCausalLM --model_
 
 **Note: At present, Qwen3MoE running with AMX can only read BF16 GGUF; support for loading from safetensor will be added later.**
 
+`<model_dir>` must point to a local copy of the original Qwen3 model repository metadata,
+including files such as `config.json`, `tokenizer.json`, `tokenizer_config.json`, and the
+chat template. The large `.safetensors` weight files are not required there when serving from
+GGUF weights, but the tokenizer/config files are still needed so chat requests can resolve
+`tokenizer.chat_template` correctly.
+
 To make it easier for everyone to understand the AMX optimizations we’ve open-sourced, we’ve prepared a brief document. We also extend our gratitude to Intel for their assistance.
 
 # Introduction to AMX Instruction Set

--- a/doc/en/AMX.md
+++ b/doc/en/AMX.md
@@ -30,10 +30,10 @@ python ktransformers/server/main.py --architectures Qwen3MoeForCausalLM --model_
 **Note: At present, Qwen3MoE running with AMX can only read BF16 GGUF; support for loading from safetensor will be added later.**
 
 `<model_dir>` must point to a local copy of the original Qwen3 model repository metadata,
-including files such as `config.json`, `tokenizer.json`, `tokenizer_config.json`, and the
-chat template. The large `.safetensors` weight files are not required there when serving from
-GGUF weights, but the tokenizer/config files are still needed so chat requests can resolve
-`tokenizer.chat_template` correctly.
+including files such as `config.json`, `tokenizer.json`, and `tokenizer_config.json` (which
+embeds the chat template). The large `.safetensors` weight files are not required there when
+serving from GGUF weights, but the tokenizer/config files are still needed so chat requests
+can resolve `tokenizer.chat_template` correctly.
 
 To make it easier for everyone to understand the AMX optimizations we’ve open-sourced, we’ve prepared a brief document. We also extend our gratitude to Intel for their assistance.
 


### PR DESCRIPTION
## Summary
- Clarify the Qwen3 AMX tutorial's `<model_dir>` requirement.
- Explain that the directory still needs tokenizer/config metadata, including `tokenizer_config.json` and the chat template, even when large safetensor weights are not required for GGUF serving.

Refs #1226

## Test Plan
- `python` documentation guard check for the new Qwen3 model metadata guidance
- `git diff --check HEAD~1..HEAD`
