### PR TITLE
docs: add flash-attn import troubleshooting

### DIFF
--- a/doc/en/install.md
+++ b/doc/en/install.md
@@ -63,6 +63,18 @@ Some preparation:
   ```
 - At the same time, you should download and install the corresponding version of flash-attention from https://github.com/Dao-AILab/flash-attention/releases.
 
+  If runtime fails with `NameError: name 'flash_attn_func' is not defined`, verify that
+  `flash-attn` is installed for the active Python / PyTorch / CUDA environment:
+
+  ```bash
+  python -c "from flash_attn import flash_attn_func; print('flash-attn OK')"
+  ```
+
+  Install PyTorch first, then choose a `flash-attn` wheel that matches your Python version,
+  CUDA version, PyTorch version, and C++ ABI. For the newer `balance_serve` backend, follow
+  [the balance-serve FlashInfer note](./balance-serve.md#installation-guide) instead of
+  replacing its patched FlashInfer package.
+
 ## Installation
 
 ### Attention

--- a/doc/en/install.md
+++ b/doc/en/install.md
@@ -70,8 +70,8 @@ Some preparation:
   python -c "from flash_attn import flash_attn_func; print('flash-attn OK')"
   ```
 
-  Install PyTorch first, then choose a `flash-attn` wheel that matches your Python version,
-  CUDA version, PyTorch version, and C++ ABI. For the newer `balance_serve` backend, follow
+  Choose a `flash-attn` wheel that matches your Python version, CUDA version, PyTorch
+  version, and C++ ABI. For the newer `balance_serve` backend, follow
   [the balance-serve FlashInfer note](./balance-serve.md#installation-guide) instead of
   replacing its patched FlashInfer package.
 


### PR DESCRIPTION
## Summary
- Add troubleshooting for `NameError: name 'flash_attn_func' is not defined` in the install guide.
- Show a direct import check for the active environment and clarify that the `flash-attn` wheel must match Python / PyTorch / CUDA / C++ ABI.
- Point `balance_serve` users to the patched FlashInfer note instead of replacing that package.

Refs #944

## Test Plan
- `python` documentation guard check for the new flash-attn troubleshooting text and link target
- `git diff --check HEAD~1..HEAD`
