### PR TITLE
docs: document Qwen3-Next balance serve build

### DIFF
--- a/doc/en/Qwen3-Next.md
+++ b/doc/en/Qwen3-Next.md
@@ -30,7 +30,16 @@ huggingface-cli download --resume-download Qwen/Qwen3-Next-80B-A3B-Instruct
 
 ### 3. Install ktransformers
 
-To install KTransformers, follow the official [Installation Guide](https://kvcache-ai.github.io/ktransformers/en/install.html).
+Qwen3-Next uses the `balance_serve` backend in the launch command below, so build KTransformers with the balance-serve extension enabled:
+
+```bash
+git clone https://github.com/kvcache-ai/ktransformers.git
+cd ktransformers
+git submodule update --init --recursive
+USE_BALANCE_SERVE=1 bash ./install.sh
+```
+
+If startup fails with `ModuleNotFoundError: No module named 'sched_ext'`, the `balance_serve` scheduler extension was not built in the active environment. Re-run the install command above in a clean environment, then start the server again.
 
 ### 4. Run Qwen3-Next Inference Server
 

--- a/doc/en/Qwen3-Next.md
+++ b/doc/en/Qwen3-Next.md
@@ -30,6 +30,8 @@ huggingface-cli download --resume-download Qwen/Qwen3-Next-80B-A3B-Instruct
 
 ### 3. Install ktransformers
 
+Before proceeding, ensure you meet the prerequisites listed in the [Installation Guide](https://kvcache-ai.github.io/ktransformers/en/install.html).
+
 Qwen3-Next uses the `balance_serve` backend in the launch command below, so build KTransformers with the balance-serve extension enabled:
 
 ```bash
@@ -37,6 +39,7 @@ git clone https://github.com/kvcache-ai/ktransformers.git
 cd ktransformers
 git submodule update --init --recursive
 USE_BALANCE_SERVE=1 bash ./install.sh
+cd ..
 ```
 
 If startup fails with `ModuleNotFoundError: No module named 'sched_ext'`, the `balance_serve` scheduler extension was not built in the active environment. Re-run the install command above in a clean environment, then start the server again.


### PR DESCRIPTION
## Summary
- Add the required `USE_BALANCE_SERVE=1 bash ./install.sh` build step to the Qwen3-Next tutorial.
- Explain that `ModuleNotFoundError: No module named 'sched_ext'` means the `balance_serve` scheduler extension was not built in the active environment.

Refs #1514

## Test Plan
- `python` documentation guard check for the new Qwen3-Next `balance_serve` build guidance
- `git diff --check HEAD~1..HEAD`
