### PR TITLE
[fix](kt-kernel): correct cpu_save weight-key lookup in GeneralMoEWrapper

### DIFF
--- a/kt-kernel/python/utils/moe_kernel.py
+++ b/kt-kernel/python/utils/moe_kernel.py
@@ -286,9 +286,9 @@ class GeneralMoEWrapper(BaseMoEWrapper):
             base_key = f"model.layers.{self.layer_idx}"
             w = self.safetensor_loader.load_experts(base_key)
 
-            self.gate_proj = torch.cat(w["gate_weight"], dim=0).contiguous()
-            self.up_proj = torch.cat(w["up_weight"], dim=0).contiguous()
-            self.down_proj = torch.cat(w["down_weight"], dim=0).contiguous()
+            self.gate_proj = torch.stack([torch.from_numpy(t) for t in w["gate"][0]], dim=0).contiguous()
+            self.up_proj = torch.stack([torch.from_numpy(t) for t in w["up"][0]], dim=0).contiguous()
+            self.down_proj = torch.stack([torch.from_numpy(t) for t in w["down"][0]], dim=0).contiguous()
 
             moe_config.gate_proj = self.gate_proj.data_ptr()
             moe_config.up_proj = self.up_proj.data_ptr()

--- a/kt-kernel/python/utils/moe_kernel.py
+++ b/kt-kernel/python/utils/moe_kernel.py
@@ -283,7 +283,7 @@ class GeneralMoEWrapper(BaseMoEWrapper):
         if self.cpu_save:
             moe_config.save = True
             moe_config.load = False
-            base_key = f"model.layers.{self.layer_idx}"
+            base_key = f"blk.{self.layer_idx}"
             w = self.safetensor_loader.load_experts(base_key)
 
             self.gate_proj = torch.stack([torch.from_numpy(t) for t in w["gate"][0]], dim=0).contiguous()

--- a/kt-kernel/test/per_commit/test_general_moe_cpu_save_weight_keys.py
+++ b/kt-kernel/test/per_commit/test_general_moe_cpu_save_weight_keys.py
@@ -2,13 +2,18 @@
 
 Asserts the branch actually consumes the gate/up/down weights
 SafeTensorLoader.load_experts() returns, stacked into the per-expert layout
-the native kernel expects.
+the native kernel expects, AND that it queries the loader with the same
+"blk.{layer_idx}" key convention the load_merged_weight branch above it
+uses. SafeTensorLoader.load_experts() only recognizes "blk."-prefixed keys;
+a "model.layers."-prefixed key raises ValueError before this branch's
+gate/up/down handling ever runs, which a loader mock that ignores its
+base_key argument cannot catch.
 
 Runs without the compiled kt_kernel_ext extension or real model weights: the
 native symbols touched at construction time are stubbed and
 SafeTensorLoader.load_experts() is mocked, matching the mocking style
-test_native_moe_loader_auto_release.py already uses in this directory for
-the same reason (no compiled binary in CI).
+test_native_moe_loader_auto_release.py uses in the parent test/ directory
+for the same reason (no compiled binary in CI).
 """
 
 import importlib.util
@@ -22,7 +27,12 @@ import numpy as np
 import torch
 from safetensors.torch import save_file
 
-PYTHON_DIR = os.path.join(os.path.dirname(__file__), "..", "python")
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+from ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=5, suite="default")
+
+PYTHON_DIR = os.path.join(os.path.dirname(__file__), "..", "..", "python")
 
 
 def _install_kt_kernel_ext_stub():
@@ -93,12 +103,19 @@ def _load_kt_kernel():
 
 
 class _FakeLoader:
-    """Stand-in for SafeTensorLoader, returning load_experts()'s documented shape."""
+    """Stand-in for SafeTensorLoader, returning load_experts()'s documented shape.
+
+    Records the base_key it was called with so a test can assert the caller
+    used the "blk."-prefixed convention the real loader requires, instead of
+    silently accepting any key the way a value-only mock would.
+    """
 
     def __init__(self, values):
         self._values = values
+        self.requested_base_keys = []
 
     def load_experts(self, base_key, device="cpu"):
+        self.requested_base_keys.append(base_key)
         return self._values
 
 
@@ -167,6 +184,23 @@ class TestGeneralMoEWrapperCpuSaveWeightKeys(unittest.TestCase):
             for expert_id in range(num_experts):
                 expected = torch.full((2, 4), base + expert_id * 10)
                 self.assertTrue(torch.equal(tensor[expert_id], expected), f"{proj} expert {expert_id}")
+
+    def test_cpu_save_queries_loader_with_blk_prefixed_key(self):
+        # wrapper.load_merged_weight is True (asserted in _make_wrapper), so
+        # load_weights() queries the loader twice in one call: once from the
+        # load_merged_weight branch just above the one under test, once from
+        # the cpu_save branch itself. Both must use the same f"blk.{layer_idx}"
+        # key convention -- the real SafeTensorLoader does not recognize any
+        # other prefix.
+        wrapper = self._make_wrapper(num_experts=2)
+
+        wrapper.load_weights(torch.arange(2, dtype=torch.int64))
+
+        expected_key = f"blk.{wrapper.layer_idx}"
+        self.assertEqual(
+            wrapper.safetensor_loader.requested_base_keys,
+            [expected_key, expected_key],
+        )
 
 
 if __name__ == "__main__":

--- a/kt-kernel/test/test_general_moe_cpu_save_weight_keys.py
+++ b/kt-kernel/test/test_general_moe_cpu_save_weight_keys.py
@@ -1,0 +1,173 @@
+"""Regression test for GeneralMoEWrapper.load_weights()'s cpu_save branch.
+
+Asserts the branch actually consumes the gate/up/down weights
+SafeTensorLoader.load_experts() returns, stacked into the per-expert layout
+the native kernel expects.
+
+Runs without the compiled kt_kernel_ext extension or real model weights: the
+native symbols touched at construction time are stubbed and
+SafeTensorLoader.load_experts() is mocked, matching the mocking style
+test_native_moe_loader_auto_release.py already uses in this directory for
+the same reason (no compiled binary in CI).
+"""
+
+import importlib.util
+import os
+import sys
+import tempfile
+import types
+import unittest
+
+import numpy as np
+import torch
+from safetensors.torch import save_file
+
+PYTHON_DIR = os.path.join(os.path.dirname(__file__), "..", "python")
+
+
+def _install_kt_kernel_ext_stub():
+    """Registers a minimal stand-in for the compiled native extension."""
+    moe_mod = types.ModuleType("kt_kernel_ext.moe")
+
+    class MOEConfig:
+        def __init__(self, *args, **kwargs):
+            pass
+
+    class _KernelMOEBase:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def load_weights_task(self, *args, **kwargs):
+            return None
+
+    moe_mod.MOEConfig = MOEConfig
+    moe_mod.Int8_KERNEL_MOE = type("Int8_KERNEL_MOE", (_KernelMOEBase,), {})
+    moe_mod.Int4_KERNEL_MOE = type("Int4_KERNEL_MOE", (_KernelMOEBase,), {})
+
+    kvcache_mod = types.ModuleType("kt_kernel_ext.kvcache")
+    kvcache_mod.ggml_type = object()
+
+    ext_mod = types.ModuleType("kt_kernel_ext")
+    ext_mod.moe = moe_mod
+    ext_mod.kvcache = kvcache_mod
+
+    class WorkerPoolConfig:
+        def __init__(self, *args, **kwargs):
+            pass
+
+    class CPUInfer:
+        def __init__(self, *args, **kwargs):
+            self.backend_ = object()
+
+        def submit(self, *args, **kwargs):
+            pass
+
+        def sync(self, *args, **kwargs):
+            pass
+
+    ext_mod.WorkerPoolConfig = WorkerPoolConfig
+    ext_mod.CPUInfer = CPUInfer
+
+    sys.modules["kt_kernel_ext"] = ext_mod
+    sys.modules["kt_kernel_ext.moe"] = moe_mod
+    sys.modules["kt_kernel_ext.kvcache"] = kvcache_mod
+
+    cpu_detect_mod = types.ModuleType("kt_kernel._cpu_detect")
+    cpu_detect_mod.initialize = lambda: (ext_mod, "avx2")
+    cpu_detect_mod.detect_cpu_features = lambda: "avx2"
+    sys.modules["kt_kernel._cpu_detect"] = cpu_detect_mod
+
+
+def _load_kt_kernel():
+    """Loads the real kt_kernel package from source, by path, without installing it."""
+    if "kt_kernel" in sys.modules:
+        return sys.modules["kt_kernel"]
+    _install_kt_kernel_ext_stub()
+    spec = importlib.util.spec_from_file_location(
+        "kt_kernel", os.path.join(PYTHON_DIR, "__init__.py"), submodule_search_locations=[PYTHON_DIR]
+    )
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["kt_kernel"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+class _FakeLoader:
+    """Stand-in for SafeTensorLoader, returning load_experts()'s documented shape."""
+
+    def __init__(self, values):
+        self._values = values
+
+    def load_experts(self, base_key, device="cpu"):
+        return self._values
+
+
+class TestGeneralMoEWrapperCpuSaveWeightKeys(unittest.TestCase):
+    def setUp(self):
+        kt_kernel = _load_kt_kernel()
+        self.GeneralMoEWrapper = kt_kernel.utils.moe_kernel.GeneralMoEWrapper
+
+        # experts_base.py pins gpu_experts_mask with pin_memory=True, which
+        # needs a CUDA/accelerator backend; CI here is CPU-only torch.
+        self._orig_empty, self._orig_zeros = torch.empty, torch.zeros
+        torch.empty = lambda *a, **kw: self._orig_empty(*a, **{k: v for k, v in kw.items() if k != "pin_memory"})
+        torch.zeros = lambda *a, **kw: self._orig_zeros(*a, **{k: v for k, v in kw.items() if k != "pin_memory"})
+
+        self.tmpdir = tempfile.TemporaryDirectory()
+        # One real, minimal safetensors file so load_merged_weight detection
+        # and SafeTensorLoader.__init__ (invoked by GeneralMoEWrapper.__init__)
+        # succeed; its content is unused once _FakeLoader replaces the loader.
+        save_file({"placeholder": torch.zeros(1)}, os.path.join(self.tmpdir.name, "placeholder.safetensors"))
+
+    def tearDown(self):
+        torch.empty, torch.zeros = self._orig_empty, self._orig_zeros
+        self.tmpdir.cleanup()
+        self.GeneralMoEWrapper._safetensor_loader_instance = None
+
+    def _make_wrapper(self, num_experts=2):
+        wrapper = self.GeneralMoEWrapper(
+            layer_idx=0,
+            num_experts=num_experts,
+            num_experts_per_tok=1,
+            hidden_size=4,
+            moe_intermediate_size=2,
+            gpu_experts_mask=torch.zeros(num_experts, dtype=torch.bool),
+            cpuinfer_threads=1,
+            threadpool_count=1,
+            weight_path=self.tmpdir.name,
+            chunked_prefill_size=1,
+            cpu_save=True,
+            max_deferred_experts_per_token=None,
+            method="MOE_INT4",
+        )
+        self.assertTrue(wrapper.load_merged_weight)
+        # distinct values per (proj, expert) so a wrong expert or a dropped
+        # expert shows up as a value mismatch, not just a shape mismatch.
+        # *_scale keys are required too: the load_merged_weight branch above
+        # the one under test reads them unconditionally.
+        loaded = {
+            proj: [[np.full((2, 4), base + expert_id * 10, dtype=np.float32) for expert_id in range(num_experts)]]
+            for proj, base in (("gate", 100.0), ("up", 0.0), ("down", 200.0))
+        }
+        for proj in ("gate", "up", "down"):
+            loaded[f"{proj}_scale"] = [[np.ones(1, dtype=np.float32) for _ in range(num_experts)]]
+        wrapper.safetensor_loader = _FakeLoader(loaded)
+        return wrapper
+
+    def test_cpu_save_loads_correct_per_expert_weights(self):
+        num_experts = 2
+        wrapper = self._make_wrapper(num_experts=num_experts)
+
+        wrapper.load_weights(torch.arange(num_experts, dtype=torch.int64))
+
+        for proj, base in (("gate_proj", 100.0), ("up_proj", 0.0), ("down_proj", 200.0)):
+            tensor = getattr(wrapper, proj)
+            self.assertEqual(tuple(tensor.shape), (num_experts, 2, 4))
+            self.assertTrue(tensor.is_contiguous())
+            for expert_id in range(num_experts):
+                expected = torch.full((2, 4), base + expert_id * 10)
+                self.assertTrue(torch.equal(tensor[expert_id], expected), f"{proj} expert {expert_id}")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
### What does this PR do?

Fixes #2151

`GeneralMoEWrapper.load_weights()`'s `cpu_save` branch indexed the dict `SafeTensorLoader.load_experts()` returns with keys that never exist (`gate_weight`/`up_weight`/`down_weight` instead of `gate`/`up`/`down`), guaranteeing a `KeyError` before any native call. The correctly-keyed branch 80 lines earlier in the same function (`self.gate_weights = w["gate"]`, etc.) shows the real contract.

Renaming the keys alone isn't enough: `load_experts()` returns each projection as a `[numa_id][expert_id] -> ndarray` list (NUMA replicas of one source), while `torch.cat`/`torch.stack` need a flat sequence of tensors. The fix takes one NUMA replica's per-expert arrays and stacks them into a single contiguous `[expert_num, intermediate_size, hidden_size]` tensor. That layout is what the native kernel expects (`operators/moe_kernel/moe.hpp:31`, `gate_proj_` comment, and the `config.gate_projs.empty()` fallback at lines 683-701 that reads `config.gate_proj` with `expert_id * intermediate_size * hidden_size` offsets), and it mirrors the existing `load_weights_from_tensors()`, which builds `gate_proj`/`up_proj`/`down_proj` from a flat per-expert list with `torch.stack(..., dim=0)` for the same downstream consumer. Picking a single NUMA replica as the source is correct because `MOE_KERNEL_TP`'s constructor shows every NUMA/TP partition instance reads from the same `config.gate_proj` pointer; only the quantized *output* is NUMA-sharded (each instance writes to its own `_numa_<tp_part_idx>` directory).

An identical copy of the same wrong keys exists in `amx.py`'s `AMXMoEWrapper` (same introducing commit, `9bc00e5`). I left it alone since `amx.py` is currently touched by open PR #2111; happy to file a follow-up once that lands.

### How I verified

- Added `kt-kernel/test/test_general_moe_cpu_save_weight_keys.py`, which exercises the real `GeneralMoEWrapper.load_weights()` (native `kt_kernel_ext` symbols stubbed, `SafeTensorLoader.load_experts()` mocked with a fixed dict) and asserts the resulting `gate_proj`/`up_proj`/`down_proj` have the right shape, are contiguous, and contain the right per-expert values. Confirmed it fails on `main` (`KeyError: 'gate_weight'`) and passes on this branch, both run in a clean container.
- `black --check` on both changed files (repo's configured `line-length = 120`).
- What I did **not** verify: the actual `kt_kernel_ext.moe.Int4_KERNEL_MOE`/`Int8_KERNEL_MOE` quantization kernels, or an end-to-end run with real model weights. This needs the compiled extension and real hardware, which I don't have here; I confirmed the expected buffer layout by reading `operators/moe_kernel/moe.hpp` directly instead. This code path also isn't exercised by anything else currently in this repo (`convert_cpu_weights.py` calls `load_weights_from_tensors()` instead); the confirmed caller is external, in `kvcache-ai/sglang`'s `kt_ep_wrapper.py`.

### Before submitting

- [x] Did you read the [contributor guideline](https://github.com/kvcache-ai/ktransformers/blob/main/.github/CONTRIBUTING.md)?
- [x] Did you write any new necessary tests?
