### PR TITLE
[perf] Add native FP8 layerwise batch transport for GLM-5-Next

### DIFF
--- a/kt-kernel/ext_bindings.cpp
+++ b/kt-kernel/ext_bindings.cpp
@@ -75,6 +75,7 @@ static const bool _is_plain_ = false;
 #include <memory>
 #include <type_traits>
 
+#include "fp8_layerwise_transport.hpp"
 #include "operators/kvcache/kvcache.h"
 #include "operators/llamafile/linear.h"
 #include "operators/llamafile/mla.hpp"
@@ -513,6 +514,25 @@ void bind_moe_module(py::module_& moe_module, const char* name) {
     moe_cls.def("write_weight_scale_to_buffer_task", &WriteWeightScaleToBufferBindings::cpuinfer_interface,
                 py::arg("gpu_tp_count"), py::arg("expert_id"), py::arg("w13_weight_ptrs"), py::arg("w13_scale_ptrs"),
                 py::arg("w2_weight_ptrs"), py::arg("w2_scale_ptrs"));
+
+    moe_cls.def(
+        "run_layerwise_fp8_batch",
+        [](std::shared_ptr<MoeClass> moe, const std::shared_ptr<kt::layerwise::FP8LayerwiseTransport>& transport,
+           std::uint64_t epoch, std::int64_t layer_id, int expert_count) {
+          if (!transport) throw std::invalid_argument("FP8 layerwise transport is null");
+          const int tp_size = transport->tp_size();
+          transport->run_producer(
+              epoch, layer_id, expert_count,
+              [moe, tp_size](int expert_id, const std::vector<std::uintptr_t>& w13_weight_ptrs,
+                             const std::vector<std::uintptr_t>& w13_scale_ptrs,
+                             const std::vector<std::uintptr_t>& w2_weight_ptrs,
+                             const std::vector<std::uintptr_t>& w2_scale_ptrs) {
+                moe->write_weight_scale_to_buffer(tp_size, expert_id, w13_weight_ptrs, w13_scale_ptrs, w2_weight_ptrs,
+                                                  w2_scale_ptrs);
+              });
+        },
+        py::arg("transport"), py::arg("epoch"), py::arg("layer_id"), py::arg("expert_count"),
+        py::call_guard<py::gil_scoped_release>());
   }
 }
 
@@ -543,6 +563,51 @@ PYBIND11_MODULE(kt_kernel_ext, m) {
   m.attr("__fp8_kernel__") = "unsupported";
 #endif
   m.attr("__fp8_weight_layout__") = "block-e4m3-128x128";
+
+  m.def("initialize_fp8_layerwise_control", &kt::layerwise::initialize_fp8_layerwise_control,
+        py::arg("control_ptr"), py::arg("control_size"), py::arg("tp_size"));
+
+  py::class_<kt::layerwise::FP8LayerwiseTransport, std::shared_ptr<kt::layerwise::FP8LayerwiseTransport>>(
+      m, "FP8LayerwiseTransport")
+      .def(py::init<std::uintptr_t, std::size_t, int, int, int, const std::vector<std::uintptr_t>&,
+                    const std::vector<std::uintptr_t>&, const std::vector<std::uintptr_t>&,
+                    const std::vector<std::size_t>&, int, std::uint64_t>(),
+           py::arg("control_ptr"), py::arg("control_size"), py::arg("rank"), py::arg("tp_size"),
+           py::arg("cuda_device"), py::arg("local_host_ptrs"), py::arg("local_gpu_ptrs"),
+           py::arg("all_rank_host_ptrs"), py::arg("expert_nbytes"), py::arg("num_experts"),
+           py::arg("timeout_ms") = 60000)
+      .def("join", &kt::layerwise::FP8LayerwiseTransport::join, py::arg("epoch"), py::arg("layer_id"),
+           py::arg("expert_count"), py::call_guard<py::gil_scoped_release>())
+      .def(
+          "wait",
+          [](kt::layerwise::FP8LayerwiseTransport& transport, std::uint64_t epoch) {
+            kt::layerwise::FP8LayerwiseStats stats;
+            {
+              py::gil_scoped_release release;
+              stats = transport.wait(epoch);
+            }
+            py::dict result;
+            result["epoch"] = stats.epoch;
+            result["layer_id"] = stats.layer_id;
+            result["expert_count"] = stats.expert_count;
+            result["rank"] = stats.rank;
+            result["writer_ms"] = stats.writer_ms;
+            result["slot_wait_ms"] = stats.slot_wait_ms;
+            result["h2d_ms"] = stats.h2d_ms;
+            result["total_ms"] = stats.total_ms;
+            result["bytes"] = stats.bytes;
+            result["poisoned"] = stats.poisoned;
+            result["error_code"] = stats.error_code;
+            result["error_rank"] = stats.error_rank;
+            result["error_message"] = stats.error_message;
+            return result;
+          },
+          py::arg("epoch"))
+      .def("close", &kt::layerwise::FP8LayerwiseTransport::close, py::call_guard<py::gil_scoped_release>())
+      .def_property_readonly("rank", &kt::layerwise::FP8LayerwiseTransport::rank)
+      .def_property_readonly("tp_size", &kt::layerwise::FP8LayerwiseTransport::tp_size)
+      .def_property_readonly("num_experts", &kt::layerwise::FP8LayerwiseTransport::num_experts)
+      .def_property_readonly("closed", &kt::layerwise::FP8LayerwiseTransport::closed);
 
   py::class_<WorkerPool>(m, "WorkerPool").def(py::init<int>());
   py::class_<WorkerPoolConfig>(m, "WorkerPoolConfig")

--- a/kt-kernel/fp8_layerwise_transport.cpp
+++ b/kt-kernel/fp8_layerwise_transport.cpp
@@ -1,0 +1,744 @@
+#include "fp8_layerwise_transport.hpp"
+
+#include <algorithm>
+#include <atomic>
+#include <chrono>
+#include <condition_variable>
+#include <cstdio>
+#include <cstring>
+#include <limits>
+#include <mutex>
+#include <sstream>
+#include <stdexcept>
+#include <thread>
+#include <type_traits>
+#include <utility>
+
+#if defined(KTRANSFORMERS_USE_CUDA) || defined(USE_CUDA)
+#include <cuda_runtime_api.h>
+#define KT_FP8_LAYERWISE_HAS_CUDA 1
+#else
+#define KT_FP8_LAYERWISE_HAS_CUDA 0
+#endif
+
+namespace kt::layerwise {
+namespace {
+
+using Clock = std::chrono::steady_clock;
+
+constexpr std::uint64_t kControlMagic = 0x4b544650384c5731ULL;  // "KTFP8LW1"
+constexpr std::uint64_t kControlVersion = 1;
+constexpr int kMaxTPSize = 4;
+constexpr std::uint64_t kPoisonClaimed = std::numeric_limits<std::uint64_t>::max();
+
+enum ErrorCode : int {
+  kErrorNone = 0,
+  kErrorProtocol = 1,
+  kErrorTimeout = 2,
+  kErrorCudaInitialization = 3,
+  kErrorCudaCopy = 4,
+  kErrorWriter = 5,
+  kErrorClosedWhileActive = 6,
+};
+
+struct alignas(64) AtomicCell {
+  std::uint64_t value;
+  std::uint8_t padding[56];
+};
+static_assert(sizeof(AtomicCell) == 64);
+
+struct alignas(64) ControlHeader {
+  std::uint64_t magic;
+  std::uint64_t version;
+  std::uint64_t struct_bytes;
+  std::uint64_t tp_size;
+  std::uint8_t padding[32];
+};
+static_assert(sizeof(ControlHeader) == 64);
+
+struct alignas(64) ReadySlot {
+  AtomicCell sequence;
+  AtomicCell epoch;
+  AtomicCell expert_id;
+};
+
+// This type is intentionally POD. It lives in mmap'ed process-shared memory;
+// all synchronization goes through the __atomic helpers below.
+struct alignas(64) FP8LayerwiseControl {
+  ControlHeader header;
+  AtomicCell poison_state;  // 0 healthy, UINT64_MAX claimed/writing, 1 poisoned
+  AtomicCell error_code;
+  AtomicCell error_rank;
+  alignas(64) char error_message[256];
+
+  AtomicCell active_epoch;
+  AtomicCell layer_id;
+  AtomicCell expert_count;
+  AtomicCell next_sequence;
+  AtomicCell producer_done_epoch;
+
+  AtomicCell join_epoch[kMaxTPSize];
+  AtomicCell consumer_done_epoch[kMaxTPSize];
+  AtomicCell wait_returned_epoch[kMaxTPSize];
+
+  ReadySlot ready[kFP8LayerwiseHostSlots];
+  AtomicCell ack_sequence[kMaxTPSize][kFP8LayerwiseHostSlots];
+
+  AtomicCell layer_start_ns;
+  AtomicCell writer_ns;
+  AtomicCell slot_wait_ns;
+  AtomicCell producer_total_ns;
+  AtomicCell h2d_ns[kMaxTPSize];
+  AtomicCell bytes[kMaxTPSize];
+};
+
+static_assert(std::is_trivial_v<FP8LayerwiseControl>);
+static_assert(std::is_standard_layout_v<FP8LayerwiseControl>);
+static_assert(sizeof(FP8LayerwiseControl) <= kFP8LayerwiseControlBytes,
+              "FP8 layerwise control must fit in one 4 KiB shared page");
+
+std::uint64_t load_acquire(const AtomicCell& cell) {
+  return __atomic_load_n(&cell.value, __ATOMIC_ACQUIRE);
+}
+
+std::uint64_t load_relaxed(const AtomicCell& cell) {
+  return __atomic_load_n(&cell.value, __ATOMIC_RELAXED);
+}
+
+void store_release(AtomicCell& cell, std::uint64_t value) {
+  __atomic_store_n(&cell.value, value, __ATOMIC_RELEASE);
+}
+
+void store_relaxed(AtomicCell& cell, std::uint64_t value) {
+  __atomic_store_n(&cell.value, value, __ATOMIC_RELAXED);
+}
+
+std::uint64_t fetch_add_relaxed(AtomicCell& cell, std::uint64_t value) {
+  return __atomic_fetch_add(&cell.value, value, __ATOMIC_RELAXED);
+}
+
+bool compare_exchange(AtomicCell& cell, std::uint64_t& expected, std::uint64_t desired) {
+  return __atomic_compare_exchange_n(&cell.value, &expected, desired, false, __ATOMIC_ACQ_REL, __ATOMIC_ACQUIRE);
+}
+
+std::uint64_t now_ns() {
+  return static_cast<std::uint64_t>(
+      std::chrono::duration_cast<std::chrono::nanoseconds>(Clock::now().time_since_epoch()).count());
+}
+
+double ns_to_ms(std::uint64_t ns) { return static_cast<double>(ns) / 1.0e6; }
+
+std::uint64_t signed_to_bits(std::int64_t value) { return static_cast<std::uint64_t>(value); }
+
+std::int64_t bits_to_signed(std::uint64_t value) { return static_cast<std::int64_t>(value); }
+
+void validate_control_region(std::uintptr_t control_ptr, std::size_t control_size) {
+  if (control_ptr == 0) throw std::invalid_argument("FP8 layerwise control pointer is null");
+  if ((control_ptr & 63U) != 0) throw std::invalid_argument("FP8 layerwise control pointer must be 64-byte aligned");
+  if (control_size < kFP8LayerwiseControlBytes) {
+    throw std::invalid_argument("FP8 layerwise control region must be at least 4096 bytes");
+  }
+}
+
+FP8LayerwiseControl* checked_control(std::uintptr_t control_ptr, std::size_t control_size, int tp_size) {
+  validate_control_region(control_ptr, control_size);
+  auto* control = reinterpret_cast<FP8LayerwiseControl*>(control_ptr);
+  const auto magic = __atomic_load_n(&control->header.magic, __ATOMIC_ACQUIRE);
+  if (magic != kControlMagic || control->header.version != kControlVersion ||
+      control->header.struct_bytes != sizeof(FP8LayerwiseControl)) {
+    throw std::runtime_error("FP8 layerwise control is uninitialized or has an incompatible ABI");
+  }
+  if (control->header.tp_size != static_cast<std::uint64_t>(tp_size)) {
+    throw std::invalid_argument("FP8 layerwise control TP size does not match transport TP size");
+  }
+  return control;
+}
+
+std::string poison_message(FP8LayerwiseControl* control) {
+  // The process which wins the poison claim fills diagnostics before changing
+  // kPoisonClaimed to 1. Wait briefly so readers normally avoid a partial
+  // string, but never let a process dying mid-publication hang every rank.
+  const auto claim_deadline = Clock::now() + std::chrono::milliseconds(10);
+  while (load_acquire(control->poison_state) == kPoisonClaimed && Clock::now() < claim_deadline) {
+    std::this_thread::yield();
+  }
+  if (load_acquire(control->poison_state) == kPoisonClaimed) {
+    return "FP8 layerwise transport poisoned, but poison publication did not complete (claim owner may have died)";
+  }
+  std::ostringstream out;
+  out << "FP8 layerwise transport poisoned (code=" << load_relaxed(control->error_code)
+      << ", rank=" << bits_to_signed(load_relaxed(control->error_rank)) << ")";
+  if (control->error_message[0] != '\0') out << ": " << control->error_message;
+  return out.str();
+}
+
+void publish_poison(FP8LayerwiseControl* control, int code, int rank, const std::string& message) noexcept {
+  std::uint64_t expected = 0;
+  if (!compare_exchange(control->poison_state, expected, kPoisonClaimed)) return;
+  store_relaxed(control->error_code, static_cast<std::uint64_t>(code));
+  store_relaxed(control->error_rank, signed_to_bits(rank));
+  std::snprintf(control->error_message, sizeof(control->error_message), "%s", message.c_str());
+  __atomic_thread_fence(__ATOMIC_RELEASE);
+  store_release(control->poison_state, 1);
+}
+
+void throw_if_poisoned(FP8LayerwiseControl* control) {
+  if (load_acquire(control->poison_state) != 0) throw std::runtime_error(poison_message(control));
+}
+
+std::uint64_t fold_progress(std::uint64_t seed, std::uint64_t value) {
+  // A cheap mixer used only to notice progress and refresh a timeout deadline.
+  return seed ^ (value + 0x9e3779b97f4a7c15ULL + (seed << 6U) + (seed >> 2U));
+}
+
+}  // namespace
+
+void initialize_fp8_layerwise_control(std::uintptr_t control_ptr, std::size_t control_size, int tp_size) {
+  validate_control_region(control_ptr, control_size);
+  if (tp_size <= 0 || tp_size > kMaxTPSize) {
+    throw std::invalid_argument("FP8 layerwise transport supports TP sizes 1 through 4");
+  }
+  auto* control = reinterpret_cast<FP8LayerwiseControl*>(control_ptr);
+  std::memset(control, 0, kFP8LayerwiseControlBytes);
+  control->header.version = kControlVersion;
+  control->header.struct_bytes = sizeof(FP8LayerwiseControl);
+  control->header.tp_size = static_cast<std::uint64_t>(tp_size);
+  store_relaxed(control->error_rank, signed_to_bits(-1));
+  __atomic_store_n(&control->header.magic, kControlMagic, __ATOMIC_RELEASE);
+}
+
+class FP8LayerwiseTransport::Impl {
+ public:
+  Impl(std::uintptr_t control_ptr, std::size_t control_size, int rank, int tp_size, int cuda_device,
+       const std::vector<std::uintptr_t>& local_host_ptrs, const std::vector<std::uintptr_t>& local_gpu_ptrs,
+       const std::vector<std::uintptr_t>& all_rank_host_ptrs, const std::vector<std::size_t>& expert_nbytes,
+       int num_experts, std::uint64_t timeout_ms)
+      : control_(checked_control(control_ptr, control_size, tp_size)),
+        rank_(rank),
+        tp_size_(tp_size),
+        cuda_device_(cuda_device),
+        num_experts_(num_experts),
+        timeout_(timeout_ms) {
+    if (rank < 0 || rank >= tp_size) throw std::invalid_argument("FP8 layerwise rank is outside TP range");
+    if (num_experts <= 0) throw std::invalid_argument("FP8 layerwise num_experts must be positive");
+    if (timeout_ms == 0) throw std::invalid_argument("FP8 layerwise timeout_ms must be positive");
+    if (local_host_ptrs.size() != kFP8LayerwiseHostSlots * kFP8LayerwiseBufferKinds) {
+      throw std::invalid_argument("FP8 layerwise local_host_ptrs must contain 8 pointers in [slot][kind] order");
+    }
+    if (local_gpu_ptrs.size() != kFP8LayerwiseBufferKinds) {
+      throw std::invalid_argument("FP8 layerwise local_gpu_ptrs must contain 4 pointers");
+    }
+    if (expert_nbytes.size() != kFP8LayerwiseBufferKinds) {
+      throw std::invalid_argument("FP8 layerwise expert_nbytes must contain 4 sizes");
+    }
+    const std::size_t expected_all_rank = kFP8LayerwiseHostSlots * tp_size * kFP8LayerwiseBufferKinds;
+    if ((rank == 0 && all_rank_host_ptrs.size() != expected_all_rank) || (rank != 0 && !all_rank_host_ptrs.empty())) {
+      throw std::invalid_argument(
+          "FP8 layerwise all_rank_host_ptrs must be [slot][rank][kind] on rank zero and empty on other ranks");
+    }
+    if (std::any_of(local_host_ptrs.begin(), local_host_ptrs.end(), [](auto ptr) { return ptr == 0; }) ||
+        std::any_of(local_gpu_ptrs.begin(), local_gpu_ptrs.end(), [](auto ptr) { return ptr == 0; }) ||
+        std::any_of(expert_nbytes.begin(), expert_nbytes.end(), [](auto size) { return size == 0; }) ||
+        (rank == 0 &&
+         std::any_of(all_rank_host_ptrs.begin(), all_rank_host_ptrs.end(), [](auto ptr) { return ptr == 0; }))) {
+      throw std::invalid_argument("FP8 layerwise buffer pointers and expert byte sizes must be non-zero");
+    }
+
+    std::copy(local_host_ptrs.begin(), local_host_ptrs.end(), local_host_ptrs_.begin());
+    std::copy(local_gpu_ptrs.begin(), local_gpu_ptrs.end(), local_gpu_ptrs_.begin());
+    std::copy(expert_nbytes.begin(), expert_nbytes.end(), expert_nbytes_.begin());
+    all_rank_host_ptrs_ = all_rank_host_ptrs;
+    for (int slot = 0; slot < kFP8LayerwiseHostSlots; ++slot) {
+      last_ready_sequence_[slot] = load_acquire(control_->ready[slot].sequence);
+    }
+
+#if KT_FP8_LAYERWISE_HAS_CUDA
+    worker_ = std::thread(&Impl::consumer_main, this);
+    std::unique_lock lock(init_mutex_);
+    init_cv_.wait(lock, [this] { return init_complete_; });
+    if (!init_error_.empty()) {
+      lock.unlock();
+      stopping_.store(true, std::memory_order_release);
+      if (worker_.joinable()) worker_.join();
+      throw std::runtime_error(init_error_);
+    }
+#else
+    throw std::runtime_error("FP8 layerwise transport requires a CUDA-enabled kt-kernel build");
+#endif
+  }
+
+  ~Impl() { close(); }
+
+  void join(std::uint64_t epoch, std::int64_t layer_id, int expert_count) {
+    ensure_open();
+    throw_if_poisoned(control_);
+    validate_call(epoch, layer_id, expert_count);
+
+    if (rank_ == 0) {
+      const std::uint64_t previous_epoch = load_acquire(control_->active_epoch);
+      if (epoch <= previous_epoch) {
+        poison_and_throw(kErrorProtocol, "rank zero attempted to reuse or decrease a layerwise epoch");
+      }
+      if (previous_epoch != 0) {
+        wait_until(
+            "all ranks returning from the previous layer",
+            [&] {
+              for (int rank = 0; rank < tp_size_; ++rank) {
+                if (load_acquire(control_->wait_returned_epoch[rank]) < previous_epoch) return false;
+              }
+              return true;
+            },
+            [&] {
+              std::uint64_t progress = 0;
+              for (int rank = 0; rank < tp_size_; ++rank) {
+                progress = fold_progress(progress, load_relaxed(control_->wait_returned_epoch[rank]));
+              }
+              return progress;
+            });
+      }
+
+      store_relaxed(control_->layer_id, signed_to_bits(layer_id));
+      store_relaxed(control_->expert_count, static_cast<std::uint64_t>(expert_count));
+      store_relaxed(control_->layer_start_ns, now_ns());
+      store_relaxed(control_->writer_ns, 0);
+      store_relaxed(control_->slot_wait_ns, 0);
+      store_relaxed(control_->producer_total_ns, 0);
+      for (int rank = 0; rank < tp_size_; ++rank) {
+        store_relaxed(control_->h2d_ns[rank], 0);
+        store_relaxed(control_->bytes[rank], 0);
+      }
+      __atomic_thread_fence(__ATOMIC_RELEASE);
+      store_release(control_->active_epoch, epoch);
+    } else {
+      wait_until(
+          "rank zero publishing the requested epoch",
+          [&] {
+            const auto active = load_acquire(control_->active_epoch);
+            if (active > epoch) poison_and_throw(kErrorProtocol, "rank joined an epoch older than the active epoch");
+            return active == epoch;
+          },
+          [&] { return load_relaxed(control_->active_epoch); });
+      if (bits_to_signed(load_relaxed(control_->layer_id)) != layer_id ||
+          load_relaxed(control_->expert_count) != static_cast<std::uint64_t>(expert_count)) {
+        poison_and_throw(kErrorProtocol, "ranks supplied inconsistent layer_id or expert_count");
+      }
+    }
+
+    store_release(control_->join_epoch[rank_], epoch);
+  }
+
+  FP8LayerwiseStats wait(std::uint64_t epoch) {
+    ensure_open();
+    throw_if_poisoned(control_);
+    if (epoch == 0 || load_acquire(control_->join_epoch[rank_]) != epoch) {
+      poison_and_throw(kErrorProtocol, "wait called before this rank joined the epoch");
+    }
+
+    wait_until(
+        "local H2D consumer and producer completion",
+        [&] {
+          return load_acquire(control_->consumer_done_epoch[rank_]) >= epoch &&
+                 load_acquire(control_->producer_done_epoch) >= epoch;
+        },
+        [&] {
+          return fold_progress(load_relaxed(control_->consumer_done_epoch[rank_]),
+                               load_relaxed(control_->producer_done_epoch));
+        });
+
+    FP8LayerwiseStats stats;
+    stats.epoch = epoch;
+    stats.layer_id = bits_to_signed(load_relaxed(control_->layer_id));
+    stats.expert_count = static_cast<int>(load_relaxed(control_->expert_count));
+    stats.rank = rank_;
+    stats.writer_ms = ns_to_ms(load_relaxed(control_->writer_ns));
+    stats.slot_wait_ms = ns_to_ms(load_relaxed(control_->slot_wait_ns));
+    stats.h2d_ms = ns_to_ms(load_relaxed(control_->h2d_ns[rank_]));
+    stats.total_ms = ns_to_ms(load_relaxed(control_->producer_total_ns));
+    stats.bytes = load_relaxed(control_->bytes[rank_]);
+    stats.poisoned = load_acquire(control_->poison_state) != 0;
+    stats.error_code = static_cast<int>(load_relaxed(control_->error_code));
+    stats.error_rank = static_cast<int>(bits_to_signed(load_relaxed(control_->error_rank)));
+    stats.error_message = control_->error_message;
+    store_release(control_->wait_returned_epoch[rank_], epoch);
+    return stats;
+  }
+
+  void run_producer(std::uint64_t epoch, std::int64_t layer_id, int expert_count, const Writer& writer) {
+    ensure_open();
+    throw_if_poisoned(control_);
+    if (rank_ != 0) throw std::invalid_argument("run_layerwise_fp8_batch is rank-zero only");
+    if (!writer) throw std::invalid_argument("FP8 layerwise writer callback is empty");
+    validate_call(epoch, layer_id, expert_count);
+    if (load_acquire(control_->active_epoch) != epoch || bits_to_signed(load_relaxed(control_->layer_id)) != layer_id ||
+        load_relaxed(control_->expert_count) != static_cast<std::uint64_t>(expert_count) ||
+        load_acquire(control_->join_epoch[0]) != epoch) {
+      poison_and_throw(kErrorProtocol, "producer arguments do not match the joined layer");
+    }
+
+    const auto producer_begin = Clock::now();
+    try {
+      wait_until(
+          "all ranks joining the layer",
+          [&] {
+            for (int rank = 0; rank < tp_size_; ++rank) {
+              if (load_acquire(control_->join_epoch[rank]) != epoch) return false;
+            }
+            return true;
+          },
+          [&] {
+            std::uint64_t progress = 0;
+            for (int rank = 0; rank < tp_size_; ++rank) {
+              progress = fold_progress(progress, load_relaxed(control_->join_epoch[rank]));
+            }
+            return progress;
+          });
+
+      std::array<std::uint64_t, kFP8LayerwiseHostSlots> published_sequence{};
+      std::array<std::vector<std::uintptr_t>, kFP8LayerwiseBufferKinds> ptrs;
+      for (auto& values : ptrs) values.resize(tp_size_);
+      std::uint64_t writer_ns = 0;
+      std::uint64_t slot_wait_ns = 0;
+      for (int expert = 0; expert < expert_count; ++expert) {
+        const int slot = expert % kFP8LayerwiseHostSlots;
+        if (published_sequence[slot] != 0) {
+          const auto wait_begin = Clock::now();
+          wait_for_slot_ack(slot, published_sequence[slot]);
+          slot_wait_ns += static_cast<std::uint64_t>(
+              std::chrono::duration_cast<std::chrono::nanoseconds>(Clock::now() - wait_begin).count());
+        }
+
+        for (int rank = 0; rank < tp_size_; ++rank) {
+          for (int kind = 0; kind < kFP8LayerwiseBufferKinds; ++kind) {
+            ptrs[kind][rank] =
+                all_rank_host_ptrs_[((slot * tp_size_ + rank) * kFP8LayerwiseBufferKinds) + kind];
+          }
+        }
+
+        const auto writer_begin = Clock::now();
+        writer(expert, ptrs[0], ptrs[1], ptrs[2], ptrs[3]);
+        writer_ns += static_cast<std::uint64_t>(
+            std::chrono::duration_cast<std::chrono::nanoseconds>(Clock::now() - writer_begin).count());
+
+        const std::uint64_t sequence = fetch_add_relaxed(control_->next_sequence, 1) + 1;
+        store_relaxed(control_->ready[slot].epoch, epoch);
+        store_relaxed(control_->ready[slot].expert_id, static_cast<std::uint64_t>(expert));
+        __atomic_thread_fence(__ATOMIC_RELEASE);
+        store_release(control_->ready[slot].sequence, sequence);
+        published_sequence[slot] = sequence;
+      }
+
+      for (int slot = 0; slot < kFP8LayerwiseHostSlots; ++slot) {
+        if (published_sequence[slot] == 0) continue;
+        const auto wait_begin = Clock::now();
+        wait_for_slot_ack(slot, published_sequence[slot]);
+        slot_wait_ns += static_cast<std::uint64_t>(
+            std::chrono::duration_cast<std::chrono::nanoseconds>(Clock::now() - wait_begin).count());
+      }
+
+      const auto total_ns = static_cast<std::uint64_t>(
+          std::chrono::duration_cast<std::chrono::nanoseconds>(Clock::now() - producer_begin).count());
+      store_relaxed(control_->writer_ns, writer_ns);
+      store_relaxed(control_->slot_wait_ns, slot_wait_ns);
+      store_relaxed(control_->producer_total_ns, total_ns);
+      __atomic_thread_fence(__ATOMIC_RELEASE);
+      store_release(control_->producer_done_epoch, epoch);
+    } catch (const std::exception& error) {
+      if (load_acquire(control_->poison_state) == 0) publish_poison(control_, kErrorWriter, rank_, error.what());
+      throw;
+    } catch (...) {
+      publish_poison(control_, kErrorWriter, rank_, "unknown exception in FP8 layerwise writer");
+      throw;
+    }
+  }
+
+  void close() noexcept {
+    bool expected = false;
+    if (!closed_.compare_exchange_strong(expected, true, std::memory_order_acq_rel)) return;
+    const auto active = load_acquire(control_->active_epoch);
+    if (active != 0 && load_acquire(control_->consumer_done_epoch[rank_]) < active &&
+        load_acquire(control_->poison_state) == 0) {
+      publish_poison(control_, kErrorClosedWhileActive, rank_, "transport closed while a layer was active");
+    }
+    stopping_.store(true, std::memory_order_release);
+    if (worker_.joinable()) worker_.join();
+  }
+
+  int rank() const noexcept { return rank_; }
+  int tp_size() const noexcept { return tp_size_; }
+  int num_experts() const noexcept { return num_experts_; }
+  bool closed() const noexcept { return closed_.load(std::memory_order_acquire); }
+
+ private:
+  void validate_call(std::uint64_t epoch, std::int64_t layer_id, int expert_count) const {
+    if (epoch == 0) throw std::invalid_argument("FP8 layerwise epoch zero is reserved");
+    if (layer_id < 0) throw std::invalid_argument("FP8 layerwise layer_id must be non-negative");
+    if (expert_count <= 0 || expert_count > num_experts_) {
+      throw std::invalid_argument("FP8 layerwise expert_count is outside the configured expert range");
+    }
+  }
+
+  void ensure_open() const {
+    if (closed_.load(std::memory_order_acquire)) throw std::runtime_error("FP8 layerwise transport is closed");
+  }
+
+  [[noreturn]] void poison_and_throw(int code, const std::string& message) {
+    publish_poison(control_, code, rank_, message);
+    throw std::runtime_error(message);
+  }
+
+  template <typename Predicate, typename Progress>
+  void wait_until(const char* description, Predicate&& predicate, Progress&& progress) {
+    auto last_progress_time = Clock::now();
+    std::uint64_t last_progress = progress();
+    std::uint32_t spins = 0;
+    while (!predicate()) {
+      throw_if_poisoned(control_);
+      if (stopping_.load(std::memory_order_acquire)) throw std::runtime_error("FP8 layerwise transport is stopping");
+      const auto current_progress = progress();
+      if (current_progress != last_progress) {
+        last_progress = current_progress;
+        last_progress_time = Clock::now();
+      } else if (Clock::now() - last_progress_time >= timeout_) {
+        std::ostringstream message;
+        message << "timed out after " << timeout_.count() << " ms without progress while waiting for " << description;
+        poison_and_throw(kErrorTimeout, message.str());
+      }
+      if (++spins < 2048) {
+        std::this_thread::yield();
+      } else {
+        spins = 0;
+        std::this_thread::sleep_for(std::chrono::microseconds(50));
+      }
+    }
+    throw_if_poisoned(control_);
+  }
+
+  void wait_for_slot_ack(int slot, std::uint64_t sequence) {
+    wait_until(
+        "all ranks acknowledging a reused host slot",
+        [&] {
+          for (int rank = 0; rank < tp_size_; ++rank) {
+            if (load_acquire(control_->ack_sequence[rank][slot]) < sequence) return false;
+          }
+          return true;
+        },
+        [&] {
+          std::uint64_t progress = 0;
+          for (int rank = 0; rank < tp_size_; ++rank) {
+            progress = fold_progress(progress, load_relaxed(control_->ack_sequence[rank][slot]));
+          }
+          return progress;
+        });
+  }
+
+#if KT_FP8_LAYERWISE_HAS_CUDA
+  static void check_cuda(cudaError_t status, const char* operation) {
+    if (status == cudaSuccess) return;
+    std::ostringstream message;
+    message << operation << " failed: " << cudaGetErrorString(status);
+    throw std::runtime_error(message.str());
+  }
+
+  void initialize_cuda_worker() {
+    check_cuda(cudaSetDevice(cuda_device_), "cudaSetDevice");
+    check_cuda(cudaStreamCreateWithFlags(&copy_stream_, cudaStreamNonBlocking), "cudaStreamCreateWithFlags");
+    for (int slot = 0; slot < kFP8LayerwiseHostSlots; ++slot) {
+      check_cuda(cudaEventCreateWithFlags(&slot_events_[slot], cudaEventDisableTiming), "cudaEventCreateWithFlags");
+    }
+  }
+
+  void destroy_cuda_worker() noexcept {
+    for (auto& event : slot_events_) {
+      if (event != nullptr) {
+        cudaEventDestroy(event);
+        event = nullptr;
+      }
+    }
+    if (copy_stream_ != nullptr) {
+      cudaStreamDestroy(copy_stream_);
+      copy_stream_ = nullptr;
+    }
+  }
+
+  void copy_expert(int expert, int slot) {
+    const auto begin = Clock::now();
+    for (int kind = 0; kind < kFP8LayerwiseBufferKinds; ++kind) {
+      if (expert_nbytes_[kind] > std::numeric_limits<std::uintptr_t>::max() / static_cast<std::size_t>(num_experts_)) {
+        throw std::overflow_error("FP8 layerwise GPU expert offset overflows uintptr_t");
+      }
+      const auto destination = local_gpu_ptrs_[kind] + static_cast<std::uintptr_t>(expert) * expert_nbytes_[kind];
+      const auto source = local_host_ptrs_[slot * kFP8LayerwiseBufferKinds + kind];
+      check_cuda(cudaMemcpyAsync(reinterpret_cast<void*>(destination), reinterpret_cast<const void*>(source),
+                                 expert_nbytes_[kind], cudaMemcpyHostToDevice, copy_stream_),
+                 "cudaMemcpyAsync(H2D)");
+    }
+    check_cuda(cudaEventRecord(slot_events_[slot], copy_stream_), "cudaEventRecord");
+    wait_until(
+        "the local H2D completion event",
+        [&] {
+          const auto status = cudaEventQuery(slot_events_[slot]);
+          if (status == cudaSuccess) return true;
+          if (status == cudaErrorNotReady) return false;
+          check_cuda(status, "cudaEventQuery");
+          return false;
+        },
+        [] { return std::uint64_t{0}; });
+    local_h2d_ns_ += static_cast<std::uint64_t>(
+        std::chrono::duration_cast<std::chrono::nanoseconds>(Clock::now() - begin).count());
+    for (auto size : expert_nbytes_) local_bytes_ += size;
+  }
+#endif
+
+  void consumer_main() noexcept {
+#if KT_FP8_LAYERWISE_HAS_CUDA
+    try {
+      initialize_cuda_worker();
+      {
+        std::lock_guard lock(init_mutex_);
+        init_complete_ = true;
+      }
+      init_cv_.notify_one();
+
+      std::uint64_t completed_epoch = load_acquire(control_->consumer_done_epoch[rank_]);
+      while (!stopping_.load(std::memory_order_acquire)) {
+        const auto epoch = load_acquire(control_->active_epoch);
+        if (epoch == 0 || epoch <= completed_epoch || load_acquire(control_->join_epoch[rank_]) != epoch) {
+          throw_if_poisoned(control_);
+          std::this_thread::sleep_for(std::chrono::microseconds(50));
+          continue;
+        }
+
+        const int expert_count = static_cast<int>(load_relaxed(control_->expert_count));
+        if (expert_count <= 0 || expert_count > num_experts_) {
+          poison_and_throw(kErrorProtocol, "consumer observed an invalid expert_count");
+        }
+        local_h2d_ns_ = 0;
+        local_bytes_ = 0;
+
+        for (int expert = 0; expert < expert_count; ++expert) {
+          const int slot = expert % kFP8LayerwiseHostSlots;
+          std::uint64_t observed_sequence = 0;
+          wait_until(
+              "the next expert generation",
+              [&] {
+                const auto active = load_acquire(control_->active_epoch);
+                if (active > epoch) poison_and_throw(kErrorProtocol, "active epoch advanced before consumer completed");
+                const auto sequence = load_acquire(control_->ready[slot].sequence);
+                if (sequence == last_ready_sequence_[slot]) return false;
+                if (load_relaxed(control_->ready[slot].epoch) != epoch ||
+                    load_relaxed(control_->ready[slot].expert_id) != static_cast<std::uint64_t>(expert)) {
+                  return false;
+                }
+                observed_sequence = sequence;
+                return true;
+              },
+              [&] { return load_relaxed(control_->ready[slot].sequence); });
+
+          copy_expert(expert, slot);
+          last_ready_sequence_[slot] = observed_sequence;
+          __atomic_thread_fence(__ATOMIC_RELEASE);
+          store_release(control_->ack_sequence[rank_][slot], observed_sequence);
+        }
+
+        store_relaxed(control_->h2d_ns[rank_], local_h2d_ns_);
+        store_relaxed(control_->bytes[rank_], local_bytes_);
+        __atomic_thread_fence(__ATOMIC_RELEASE);
+        store_release(control_->consumer_done_epoch[rank_], epoch);
+        completed_epoch = epoch;
+      }
+    } catch (const std::exception& error) {
+      bool initialization_failure = false;
+      {
+        std::lock_guard lock(init_mutex_);
+        if (!init_complete_) {
+          initialization_failure = true;
+          init_error_ = error.what();
+          init_complete_ = true;
+        }
+      }
+      if (initialization_failure) init_cv_.notify_one();
+      if (!stopping_.load(std::memory_order_acquire)) {
+        publish_poison(control_, initialization_failure ? kErrorCudaInitialization : kErrorCudaCopy, rank_,
+                       error.what());
+      }
+    } catch (...) {
+      bool initialization_failure = false;
+      {
+        std::lock_guard lock(init_mutex_);
+        if (!init_complete_) {
+          initialization_failure = true;
+          init_error_ = "unknown CUDA worker initialization error";
+          init_complete_ = true;
+        }
+      }
+      if (initialization_failure) init_cv_.notify_one();
+      if (!stopping_.load(std::memory_order_acquire)) {
+        publish_poison(control_, initialization_failure ? kErrorCudaInitialization : kErrorCudaCopy, rank_,
+                       initialization_failure ? "unknown CUDA worker initialization error"
+                                              : "unknown exception in FP8 layerwise H2D consumer");
+      }
+    }
+    destroy_cuda_worker();
+#endif
+  }
+
+  FP8LayerwiseControl* control_;
+  int rank_;
+  int tp_size_;
+  int cuda_device_;
+  int num_experts_;
+  std::chrono::milliseconds timeout_;
+  std::array<std::uintptr_t, kFP8LayerwiseHostSlots * kFP8LayerwiseBufferKinds> local_host_ptrs_{};
+  std::array<std::uintptr_t, kFP8LayerwiseBufferKinds> local_gpu_ptrs_{};
+  std::vector<std::uintptr_t> all_rank_host_ptrs_;
+  std::array<std::size_t, kFP8LayerwiseBufferKinds> expert_nbytes_{};
+  std::array<std::uint64_t, kFP8LayerwiseHostSlots> last_ready_sequence_{};
+
+  std::atomic<bool> stopping_{false};
+  std::atomic<bool> closed_{false};
+  std::thread worker_;
+  std::mutex init_mutex_;
+  std::condition_variable init_cv_;
+  bool init_complete_ = false;
+  std::string init_error_;
+  std::uint64_t local_h2d_ns_ = 0;
+  std::uint64_t local_bytes_ = 0;
+
+#if KT_FP8_LAYERWISE_HAS_CUDA
+  cudaStream_t copy_stream_ = nullptr;
+  std::array<cudaEvent_t, kFP8LayerwiseHostSlots> slot_events_{};
+#endif
+};
+
+FP8LayerwiseTransport::FP8LayerwiseTransport(
+    std::uintptr_t control_ptr, std::size_t control_size, int rank, int tp_size, int cuda_device,
+    const std::vector<std::uintptr_t>& local_host_ptrs, const std::vector<std::uintptr_t>& local_gpu_ptrs,
+    const std::vector<std::uintptr_t>& all_rank_host_ptrs, const std::vector<std::size_t>& expert_nbytes,
+    int num_experts, std::uint64_t timeout_ms)
+    : impl_(std::make_unique<Impl>(control_ptr, control_size, rank, tp_size, cuda_device, local_host_ptrs,
+                                   local_gpu_ptrs, all_rank_host_ptrs, expert_nbytes, num_experts, timeout_ms)) {}
+
+FP8LayerwiseTransport::~FP8LayerwiseTransport() = default;
+
+void FP8LayerwiseTransport::join(std::uint64_t epoch, std::int64_t layer_id, int expert_count) {
+  impl_->join(epoch, layer_id, expert_count);
+}
+
+FP8LayerwiseStats FP8LayerwiseTransport::wait(std::uint64_t epoch) { return impl_->wait(epoch); }
+
+void FP8LayerwiseTransport::close() { impl_->close(); }
+
+void FP8LayerwiseTransport::run_producer(std::uint64_t epoch, std::int64_t layer_id, int expert_count,
+                                         const Writer& writer) {
+  impl_->run_producer(epoch, layer_id, expert_count, writer);
+}
+
+int FP8LayerwiseTransport::rank() const noexcept { return impl_->rank(); }
+
+int FP8LayerwiseTransport::tp_size() const noexcept { return impl_->tp_size(); }
+
+int FP8LayerwiseTransport::num_experts() const noexcept { return impl_->num_experts(); }
+
+bool FP8LayerwiseTransport::closed() const noexcept { return impl_->closed(); }
+
+}  // namespace kt::layerwise

--- a/kt-kernel/fp8_layerwise_transport.hpp
+++ b/kt-kernel/fp8_layerwise_transport.hpp
@@ -1,0 +1,76 @@
+#pragma once
+
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <functional>
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace kt::layerwise {
+
+inline constexpr std::size_t kFP8LayerwiseControlBytes = 4096;
+inline constexpr int kFP8LayerwiseBufferKinds = 4;
+inline constexpr int kFP8LayerwiseHostSlots = 2;
+
+struct FP8LayerwiseStats {
+  std::uint64_t epoch = 0;
+  std::int64_t layer_id = -1;
+  int expert_count = 0;
+  int rank = -1;
+  double writer_ms = 0.0;
+  double slot_wait_ms = 0.0;
+  double h2d_ms = 0.0;
+  double total_ms = 0.0;
+  std::uint64_t bytes = 0;
+  bool poisoned = false;
+  int error_code = 0;
+  int error_rank = -1;
+  std::string error_message;
+};
+
+// Initialize a page-aligned shared-memory region before constructing any
+// transport. The region is process-shared POD; it deliberately contains no
+// std::atomic objects. Synchronization is implemented with GCC/Clang
+// __atomic builtins in the implementation.
+void initialize_fp8_layerwise_control(std::uintptr_t control_ptr, std::size_t control_size, int tp_size);
+
+class FP8LayerwiseTransport final {
+ public:
+  using Writer = std::function<void(int expert_id, const std::vector<std::uintptr_t>& w13_weight_ptrs,
+                                    const std::vector<std::uintptr_t>& w13_scale_ptrs,
+                                    const std::vector<std::uintptr_t>& w2_weight_ptrs,
+                                    const std::vector<std::uintptr_t>& w2_scale_ptrs)>;
+
+  FP8LayerwiseTransport(std::uintptr_t control_ptr, std::size_t control_size, int rank, int tp_size, int cuda_device,
+                        const std::vector<std::uintptr_t>& local_host_ptrs,
+                        const std::vector<std::uintptr_t>& local_gpu_ptrs,
+                        const std::vector<std::uintptr_t>& all_rank_host_ptrs,
+                        const std::vector<std::size_t>& expert_nbytes, int num_experts,
+                        std::uint64_t timeout_ms = 60000);
+  ~FP8LayerwiseTransport();
+
+  FP8LayerwiseTransport(const FP8LayerwiseTransport&) = delete;
+  FP8LayerwiseTransport& operator=(const FP8LayerwiseTransport&) = delete;
+
+  void join(std::uint64_t epoch, std::int64_t layer_id, int expert_count);
+  FP8LayerwiseStats wait(std::uint64_t epoch);
+  void close();
+
+  // Rank zero executes the producer. The hot expert loop stays native: write
+  // one expert into a host slot, publish its generation, and wait for all
+  // local-rank DMA consumers only when that same slot is about to be reused.
+  void run_producer(std::uint64_t epoch, std::int64_t layer_id, int expert_count, const Writer& writer);
+
+  int rank() const noexcept;
+  int tp_size() const noexcept;
+  int num_experts() const noexcept;
+  bool closed() const noexcept;
+
+ private:
+  class Impl;
+  std::unique_ptr<Impl> impl_;
+};
+
+}  // namespace kt::layerwise

--- a/kt-kernel/python/experts.py
+++ b/kt-kernel/python/experts.py
@@ -363,23 +363,25 @@ def _create_inference_wrapper(
         raise NotImplementedError(f"Unsupported inference method: {method}")
 
     # Create and return backend instance.
-    # `swiglu_limit != 0` is meaningful only on the MXFP4 path. NativeMoEWrapper
-    # also serves RAWINT4 / FP8 / BF16 / FP8_PERCHANNEL / GPTQ_INT4, so a
+    # `swiglu_limit != 0` is validated for block-FP8, MXFP4, and MXFP8.
+    # NativeMoEWrapper also serves RAWINT4 / BF16 / FP8_PERCHANNEL / GPTQ_INT4, so a
     # `backend_cls is NativeMoEWrapper` test would silently forward a stale
     # 10.0 (e.g., from a leftover SGLANG_DSV4_2604_SUBMODE=2604B in the env)
     # into a non-MXFP4 backend; act_fn would then clamp gate/up to ±10 with
     # no warning. Gate strictly on method instead. Origin: kt-sglang 耦合.
     extra_kwargs = {}
-    if method in ("MXFP4", "MXFP8"):
+    if method in ("FP8", "MXFP4", "MXFP8"):
         extra_kwargs["swiglu_limit"] = swiglu_limit
         extra_kwargs["swiglu_alpha"] = swiglu_alpha
     elif swiglu_limit != 0.0:
         raise ValueError(
-            f"swiglu_limit={swiglu_limit} is only supported on method='MXFP4'/'MXFP8', "
+            f"swiglu_limit={swiglu_limit} is only supported on "
+            "method='FP8'/'MXFP4'/'MXFP8', "
             f"got method={method!r} (backend={backend_cls.__name__}). This "
             f"usually means SGLANG_DSV4_2604_SUBMODE=2604B is set in the "
             f"environment while the current launch does not actually use "
-            f"MXFP4/MXFP8 weights — either unset the env or pass --kt-method MXFP4/MXFP8."
+            "FP8/MXFP4/MXFP8 weights — either unset the env or select a "
+            "matching --kt-method."
         )
     return backend_cls(
         layer_idx=layer_idx,

--- a/kt-kernel/python/utils/amx.py
+++ b/kt-kernel/python/utils/amx.py
@@ -571,13 +571,17 @@ class NativeMoEWrapper(BaseMoEWrapper):
         swiglu_alpha: float = 0.0,
     ):
         self._swiglu_alpha = float(swiglu_alpha)
-        # Defence in depth: reject swiglu_limit on non-MXFP4/MXFP8 methods even
+        # Defence in depth: reject swiglu_limit on methods whose native MoE
+        # activation contract has not been validated.  The block-FP8 backend
+        # shares the same MOEConfig/act_fn path as MXFP4/MXFP8 and is required
+        # by GLM-5-Next's E4M3 + FP32 [128, 128] checkpoint format.
         # if the experts.py guard is bypassed (e.g., by a future caller
         # that constructs NativeMoEWrapper directly). Origin: kt-sglang 耦合.
-        if swiglu_limit != 0.0 and method not in ("MXFP4", "MXFP8"):
+        if swiglu_limit != 0.0 and method not in ("FP8", "MXFP4", "MXFP8"):
             raise ValueError(
                 f"NativeMoEWrapper received swiglu_limit={swiglu_limit} with "
-                f"method={method!r}; the clamp only applies to MXFP4/MXFP8. "
+                f"method={method!r}; the clamp is supported only by "
+                "FP8/MXFP4/MXFP8. "
                 f"This indicates a missing guard in the caller."
             )
         if method == "RAWINT4" and not (
@@ -814,18 +818,22 @@ class NativeMoEWrapper(BaseMoEWrapper):
         moe_config.layer_idx = self.layer_idx
         moe_config.pool = self.cpu_infer.backend_
         moe_config.max_len = self.chunked_prefill_size
-        # V4-Flash 2604B SwiGLU clamp; 0.0 = disabled (default for non-MXFP4
-        # paths). Read by `act_fn` in operators/amx/la/amx.hpp via
+        # Clamp-before-SiLU; 0.0 = disabled. Read by `act_fn` in
+        # operators/amx/la/amx.hpp via
         # `apply_activation` in operators/amx/moe_base.hpp. Re-checked here
         # (defence in depth) so a future caller that bypasses both the
-        # experts.py and the __init__ guards still cannot apply the clamp
-        # on RAWINT4 / FP8 / BF16 / FP8_PERCHANNEL / GPTQ_INT4 paths.
+        # experts.py and the __init__ guards still cannot apply the clamp on
+        # unvalidated RAWINT4 / BF16 / FP8_PERCHANNEL / GPTQ_INT4 paths.
         # Origin: kt-sglang 耦合.
-        if self.swiglu_limit != 0.0 and self.method not in ("MXFP4", "MXFP8"):
+        if self.swiglu_limit != 0.0 and self.method not in (
+            "FP8",
+            "MXFP4",
+            "MXFP8",
+        ):
             raise ValueError(
                 f"NativeMoEWrapper.load_weights: swiglu_limit="
                 f"{self.swiglu_limit} with method={self.method!r}; clamp is "
-                f"only valid for MXFP4/MXFP8."
+                f"only valid for FP8/MXFP4/MXFP8."
             )
         moe_config.swiglu_limit = self.swiglu_limit
 

--- a/kt-kernel/python/utils/amx.py
+++ b/kt-kernel/python/utils/amx.py
@@ -1007,3 +1007,37 @@ class NativeMoEWrapper(BaseMoEWrapper):
         """
         # The CPUInfer.sync() call blocks until pending tasks complete.
         self.cpu_infer.sync()
+
+    def run_layerwise_fp8_batch(
+        self,
+        transport,
+        epoch: int,
+        layer_id: int,
+        expert_count: int,
+    ):
+        """Run one block-FP8 layer's native writer/H2D transport pipeline.
+
+        The transport owns the hot per-expert protocol.  Python enters once per
+        layer, while the C++ producer overlaps writing expert ``e + 1`` with
+        each rank's local H2D copy of expert ``e``.
+        """
+        if self.method != "FP8":
+            raise RuntimeError(
+                "run_layerwise_fp8_batch is only valid for the block-FP8 NativeMoEWrapper backend"
+            )
+        if self.moe is None:
+            raise RuntimeError("MoE instance not initialized; cannot run FP8 layerwise transport.")
+        if not hasattr(self.moe, "run_layerwise_fp8_batch"):
+            raise NotImplementedError(
+                "The installed kt-kernel extension does not expose run_layerwise_fp8_batch."
+            )
+        # The native batch calls the shared NUMA distributor directly.  Drain
+        # CPUInfer first so it cannot race a previously queued task against the
+        # non-reentrant distributor state.
+        self.cpu_infer.sync()
+        return self.moe.run_layerwise_fp8_batch(
+            transport,
+            epoch,
+            layer_id,
+            expert_count,
+        )

--- a/kt-kernel/test/test_fp8_layerwise_transport_contract.py
+++ b/kt-kernel/test/test_fp8_layerwise_transport_contract.py
@@ -1,0 +1,79 @@
+"""CPU-only contract guards for the native FP8 layerwise transport."""
+
+from __future__ import annotations
+
+import ast
+import copy
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+
+
+AMX_PATH = Path(__file__).resolve().parents[1] / "python/utils/amx.py"
+
+
+def _compile_thin_method():
+    tree = ast.parse(AMX_PATH.read_text(encoding="utf-8"))
+    cls = next(node for node in tree.body if isinstance(node, ast.ClassDef) and node.name == "NativeMoEWrapper")
+    method = next(
+        node for node in cls.body if isinstance(node, ast.FunctionDef) and node.name == "run_layerwise_fp8_batch"
+    )
+    function = copy.deepcopy(method)
+    function.name = "invoke"
+    function.decorator_list = []
+    module = ast.fix_missing_locations(ast.Module(body=[function], type_ignores=[]))
+    namespace = {}
+    exec(compile(module, str(AMX_PATH), "exec"), namespace)
+    return namespace["invoke"]
+
+
+class _MoeRecorder:
+    def __init__(self):
+        self.calls = []
+
+    def run_layerwise_fp8_batch(self, *args):
+        self.calls.append(args)
+        return "native-result"
+
+
+class _CPUInferRecorder:
+    def __init__(self):
+        self.sync_count = 0
+
+    def sync(self):
+        self.sync_count += 1
+
+
+class TestFP8LayerwiseTransportContract(unittest.TestCase):
+    def test_thin_wrapper_forwards_exact_layer_contract(self):
+        invoke = _compile_thin_method()
+        moe = _MoeRecorder()
+        cpu_infer = _CPUInferRecorder()
+        wrapper = SimpleNamespace(method="FP8", moe=moe, cpu_infer=cpu_infer)
+        transport = object()
+
+        result = invoke(wrapper, transport, 7, 12, 288)
+
+        self.assertEqual(result, "native-result")
+        self.assertEqual(cpu_infer.sync_count, 1)
+        self.assertEqual(moe.calls, [(transport, 7, 12, 288)])
+
+    def test_thin_wrapper_rejects_non_block_fp8(self):
+        invoke = _compile_thin_method()
+        wrapper = SimpleNamespace(method="BF16", moe=_MoeRecorder())
+
+        with self.assertRaisesRegex(RuntimeError, "only valid for the block-FP8"):
+            invoke(wrapper, object(), 1, 0, 1)
+
+    def test_native_source_keeps_hot_protocol_out_of_python(self):
+        source = AMX_PATH.read_text(encoding="utf-8")
+        tree = ast.parse(source)
+        cls = next(node for node in tree.body if isinstance(node, ast.ClassDef) and node.name == "NativeMoEWrapper")
+        method = next(
+            node for node in cls.body if isinstance(node, ast.FunctionDef) and node.name == "run_layerwise_fp8_batch"
+        )
+        self.assertFalse(any(isinstance(node, (ast.For, ast.While)) for node in ast.walk(method)))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/kt-kernel/test/test_swiglu_limit_method_guards.py
+++ b/kt-kernel/test/test_swiglu_limit_method_guards.py
@@ -1,0 +1,169 @@
+"""Regression guards for native-MoE ``swiglu_limit`` method dispatch.
+
+The tests execute the relevant source AST in isolation so they do not require a
+locally compiled ``kt_kernel_ext``.  Real-extension coverage lives in the GLM
+qj5090 acceptance oracle.
+"""
+
+from __future__ import annotations
+
+import ast
+import copy
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+
+
+KT_KERNEL_ROOT = Path(__file__).resolve().parents[1]
+EXPERTS_PATH = KT_KERNEL_ROOT / "python/experts.py"
+AMX_PATH = KT_KERNEL_ROOT / "python/utils/amx.py"
+ALLOWED_METHODS = ("FP8", "MXFP4", "MXFP8")
+REJECTED_METHODS = (
+    "RAWINT4",
+    "BF16",
+    "FP8_PERCHANNEL",
+    "GPTQ_INT4",
+    "SYCL_GPTQ_INT4",
+)
+
+
+class _Recorder:
+    def __init__(self, **kwargs):
+        self.kwargs = kwargs
+
+
+def _compile_factory():
+    tree = ast.parse(EXPERTS_PATH.read_text(encoding="utf-8"))
+    function = next(
+        node
+        for node in tree.body
+        if isinstance(node, ast.FunctionDef)
+        and node.name == "_create_inference_wrapper"
+    )
+    module = ast.fix_missing_locations(
+        ast.Module(
+            body=[
+                ast.ImportFrom(
+                    module="__future__",
+                    names=[ast.alias(name="annotations")],
+                    level=0,
+                ),
+                copy.deepcopy(function),
+            ],
+            type_ignores=[],
+        )
+    )
+    namespace = {
+        "AMXMoEWrapper": _Recorder,
+        "NativeMoEWrapper": _Recorder,
+        "LlamafileMoEWrapper": _Recorder,
+        "GeneralMoEWrapper": _Recorder,
+    }
+    exec(compile(module, str(EXPERTS_PATH), "exec"), namespace)
+    return namespace["_create_inference_wrapper"]
+
+
+def _native_guard(method_name: str):
+    tree = ast.parse(AMX_PATH.read_text(encoding="utf-8"))
+    cls = next(
+        node
+        for node in tree.body
+        if isinstance(node, ast.ClassDef) and node.name == "NativeMoEWrapper"
+    )
+    method = next(
+        node
+        for node in cls.body
+        if isinstance(node, ast.FunctionDef) and node.name == method_name
+    )
+    guard = next(
+        node
+        for node in ast.walk(method)
+        if isinstance(node, ast.If)
+        and "swiglu_limit" in ast.unparse(node.test)
+        and "not in" in ast.unparse(node.test)
+    )
+    if method_name == "__init__":
+        args = ast.arguments(
+            posonlyargs=[],
+            args=[ast.arg(arg="swiglu_limit"), ast.arg(arg="method")],
+            kwonlyargs=[],
+            kw_defaults=[],
+            defaults=[],
+        )
+    else:
+        args = ast.arguments(
+            posonlyargs=[],
+            args=[ast.arg(arg="self")],
+            kwonlyargs=[],
+            kw_defaults=[],
+            defaults=[],
+        )
+    wrapper = ast.FunctionDef(
+        name="guard",
+        args=args,
+        body=[copy.deepcopy(guard)],
+        decorator_list=[],
+    )
+    module = ast.fix_missing_locations(ast.Module(body=[wrapper], type_ignores=[]))
+    namespace = {}
+    exec(compile(module, str(AMX_PATH), "exec"), namespace)
+    return namespace["guard"]
+
+
+def _factory_kwargs(method: str, limit: float):
+    return dict(
+        layer_idx=0,
+        num_experts=1,
+        num_experts_per_tok=1,
+        hidden_size=128,
+        moe_intermediate_size=128,
+        gpu_experts_mask=None,
+        cpuinfer_threads=1,
+        threadpool_count=1,
+        weight_path="unused",
+        chunked_prefill_size=1,
+        cpu_save=False,
+        max_deferred_experts_per_token=None,
+        method=method,
+        numa_nodes=None,
+        swiglu_limit=limit,
+        swiglu_alpha=0.0,
+    )
+
+
+class TestSwigluLimitMethodGuards(unittest.TestCase):
+    def test_factory_forwards_limit_to_block_fp8(self):
+        wrapper = _compile_factory()(**_factory_kwargs("FP8", 10.0))
+
+        self.assertEqual(wrapper.kwargs["method"], "FP8")
+        self.assertEqual(wrapper.kwargs["swiglu_limit"], 10.0)
+        self.assertEqual(wrapper.kwargs["swiglu_alpha"], 0.0)
+
+    def test_factory_does_not_widen_other_native_formats(self):
+        factory = _compile_factory()
+        for method in REJECTED_METHODS:
+            with self.subTest(method=method):
+                with self.assertRaisesRegex(ValueError, "only supported"):
+                    factory(**_factory_kwargs(method, 10.0))
+
+    def test_both_native_wrapper_guards_have_the_same_exact_allow_list(self):
+        init_guard = _native_guard("__init__")
+        load_guard = _native_guard("load_weights")
+
+        for method in ALLOWED_METHODS:
+            with self.subTest(guard="init", method=method):
+                init_guard(10.0, method)
+            with self.subTest(guard="load", method=method):
+                load_guard(SimpleNamespace(swiglu_limit=10.0, method=method))
+
+        for method in REJECTED_METHODS:
+            with self.subTest(guard="init", method=method):
+                with self.assertRaisesRegex(ValueError, "supported only"):
+                    init_guard(10.0, method)
+            with self.subTest(guard="load", method=method):
+                with self.assertRaisesRegex(ValueError, "only valid"):
+                    load_guard(SimpleNamespace(swiglu_limit=10.0, method=method))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- add a native block-FP8 layerwise transport with exactly two pinned Host expert slots and one full-layer GPU destination
- move the per-expert writer/H2D protocol into a persistent C++ TP4 transport with generation/ACK validation, watchdog, and poison propagation
- expose the minimal pybind/Python entry points used by the SGLang layerwise prefill controller
- include the GLM-5-Next two-round SwiGLU block-FP8 support carried by this branch

## Safety boundary

The new API is opt-in and restricted to block-FP8. Existing CPU inference and non-GLM paths are unchanged. Runtime transport errors poison the session instead of falling back after partial overwrite.

## Validation

- CUDA SM120 extension build and import/constructor smoke test
- C++20 transport syntax check
- FP8 transport contract tests: 3 passed
- SGLang TP4 GLM-5-Next 30K end-to-end at chunk 8192 and 16384
- Qwen3-30B-A3B non-GLM regression: 23/23 passed

This PR is submitted for review only and must not be auto-merged.