### PR TITLE
fix(kt-kernel): AMXMoEWrapper cpu_save branch crashes on load_experts keys/prefix (#2151)

### DIFF
--- a/kt-kernel/python/utils/amx.py
+++ b/kt-kernel/python/utils/amx.py
@@ -435,16 +435,12 @@ class AMXMoEWrapper(BaseMoEWrapper):
         if self.cpu_save:
             moe_config.save = True
             moe_config.load = False
-            base_key = f"model.layers.{self.layer_idx}"
-            try:
-                w = self.safetensor_loader.load_experts(base_key)
-            except (ValueError, KeyError):
-                base_key = f"model.language_model.layers.{self.layer_idx}"
-                w = self.safetensor_loader.load_experts(base_key)
+            base_key = f"blk.{self.layer_idx}"
+            w = self.safetensor_loader.load_experts(base_key)
 
-            self.gate_proj = torch.cat(w["gate_weight"], dim=0).contiguous()
-            self.up_proj = torch.cat(w["up_weight"], dim=0).contiguous()
-            self.down_proj = torch.cat(w["down_weight"], dim=0).contiguous()
+            self.gate_proj = torch.stack([torch.from_numpy(t) for t in w["gate"][0]], dim=0).contiguous()
+            self.up_proj = torch.stack([torch.from_numpy(t) for t in w["up"][0]], dim=0).contiguous()
+            self.down_proj = torch.stack([torch.from_numpy(t) for t in w["down"][0]], dim=0).contiguous()
 
             moe_config.gate_proj = self.gate_proj.data_ptr()
             moe_config.up_proj = self.up_proj.data_ptr()


### PR DESCRIPTION
## What

Fix `AMXMoEWrapper.load_weights()`'s `cpu_save` branch, which cannot run without crashing.

## Why

The branch does:

```python
base_key = f"model.layers.{self.layer_idx}"
try:
    w = self.safetensor_loader.load_experts(base_key)
except (ValueError, KeyError):
    base_key = f"model.language_model.layers.{self.layer_idx}"
    w = self.safetensor_loader.load_experts(base_key)

self.gate_proj = torch.cat(w["gate_weight"], dim=0).contiguous()
self.up_proj   = torch.cat(w["up_weight"],   dim=0).contiguous()
self.down_proj = torch.cat(w["down_weight"], dim=0).contiguous()
```

Two guaranteed failures against `SafeTensorLoader.load_experts()` (`utils/loader.py`):

1. **Key prefix** — `load_experts()` builds `f"{base_key}.ffn_{gate,up,down}_exps..."` and only recognizes `blk.`-prefixed keys; a `model.layers.` key finds no experts and raises `ValueError`. The `model.language_model.layers.` fallback fails the same way, so the branch raises before it ever reads `w`.
2. **Dict keys / shape** — even past that, the returned dict uses keys `gate/up/down` (no `_weight` suffix), so `w["gate_weight"]` raises `KeyError`; and each value is `[numa_id][expert_id] -> numpy array`, so `torch.cat` over numpy arrays is wrong anyway.

The `load_merged_weight` branch in this same file already uses `base_key = f"blk.{self.layer_idx}"`, so the fix simply aligns the `cpu_save` branch with that convention and stacks the per-expert numpy arrays into the `[expert_num, ...]` tensor the native kernel expects.

This is the byte-for-byte sibling of the `GeneralMoEWrapper` bug fixed in #2152, which issue #2151 explicitly called out as deliberately left untouched here.

## Reachability

Not hypothetical — `scripts/convert_cpu_weights.py` and `scripts/convert_cpu_weights_ds4.py` both construct `AMXMoEWrapper(..., cpu_save=True, ...)`, so the AMX online-quantization/save path hits this crash.

Fixes the AMX half of #2151.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
