### PR TITLE
ci: run release jobs on self-hosted runner

### DIFF
--- a/.github/workflows/release-pypi.yml
+++ b/.github/workflows/release-pypi.yml
@@ -128,7 +128,7 @@ jobs:
   build-sft-packages:
     name: Build accelerate-kt and transformers-kt
     needs: runner-preflight
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, gpu]
 
     steps:
       - name: Checkout Accelerate-KT source
@@ -234,7 +234,7 @@ jobs:
   build-sglang-kt:
     name: Build sglang-kt
     needs: runner-preflight
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, gpu]
 
     steps:
       - name: Checkout repository
@@ -439,7 +439,7 @@ jobs:
   build-ktransformers:
     name: Build ktransformers shell package
     needs: runner-preflight
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, gpu]
 
     steps:
       - name: Checkout repository
@@ -531,7 +531,7 @@ jobs:
       - build-kt-kernel
       - build-ktransformers
     if: needs.runner-preflight.outputs.target != 'build-only'
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, gpu]
     environment: prod
     permissions:
       contents: read
@@ -685,13 +685,18 @@ jobs:
     needs:
       - runner-preflight
       - publish-all
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, gpu]
 
     steps:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
           python-version: "3.12"
+
+      - name: Create clean verification environment
+        run: |
+          python -m venv --clear "$RUNNER_TEMP/kt-release-verify"
+          echo "$RUNNER_TEMP/kt-release-verify/bin" >> "$GITHUB_PATH"
 
       - name: Install published SFT stack
         env:

--- a/.github/workflows/release-sglang-kt.yml
+++ b/.github/workflows/release-sglang-kt.yml
@@ -27,7 +27,7 @@ concurrency:
 jobs:
   build-sglang-kt:
     name: Build sglang-kt wheel
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, gpu]
     outputs:
       transformers_version: ${{ steps.verify.outputs.transformers_version }}
 
@@ -131,7 +131,7 @@ jobs:
   publish-pypi:
     name: Publish sglang-kt to PyPI
     needs: [build-sglang-kt]
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, gpu]
     if: github.repository == 'kvcache-ai/ktransformers' && github.ref == 'refs/heads/main'
     environment: prod
     permissions:


### PR DESCRIPTION
## Summary

- run every PyPI release job on the online qj5090 self-hosted runner
- keep the existing release dependency graph and shared concurrency unchanged
- create a fresh virtual environment for the final published-package installation check

## Why

All GitHub-hosted jobs in this public repository remain queued without receiving a runner, while qj5090 is online and listening for jobs. The release workflow cannot complete while some jobs target `ubuntu-latest`.

The runner was preflighted with Python 3.12, CUDA 12.8, CMake, PyPI connectivity, and 128 GiB free space under `/mnt`. The final verification venv prevents packages installed by earlier build jobs from satisfying the published-package check.

## Validation

- actionlint passed
- ShellCheck passed
- workflow diff check passed
- qj5090 is online in the GitHub API
