### PR TITLE
[docs]: use official LlamaFactory repository in VLM guide

### DIFF
--- a/doc/en/SFT/KTransformers-VLM-LoRA-Fine-Tuning-Guide.md
+++ b/doc/en/SFT/KTransformers-VLM-LoRA-Fine-Tuning-Guide.md
@@ -39,7 +39,7 @@ environment.
 ### 3. Install LLaMA-Factory and KT
 
 ```bash
-git clone https://github.com/Illumination111/LlamaFactory.git
+git clone https://github.com/hiyouga/LlamaFactory.git
 cd LlamaFactory
 pip install -e .
 pip install -r requirements/ktransformers.txt


### PR DESCRIPTION
## Summary

- replace the personal LlamaFactory fork URL with the official repository URL in the VLM LoRA fine-tuning guide
- keep the existing clone directory and subsequent installation commands unchanged

## Validation

- confirmed `requirements/ktransformers.txt` is available on the official LlamaFactory `main` branch
- ran `git diff --check`