### PR TITLE
[perf](kt-kernel): AVX2 MXFP4 grouped fast path for decode and prefill

### DIFF
--- a/kt-kernel/operators/avx2/mxfp4-moe.hpp
+++ b/kt-kernel/operators/avx2/mxfp4-moe.hpp
@@ -20,6 +20,7 @@
 #include <stdexcept>
 #include <string>
 #include <utility>
+#include <vector>
 
 #include "avx2_bf16_gemm.hpp"
 #include "avx2_bf16_utils.hpp"
@@ -198,6 +199,140 @@ static void gemm_mxfp4(int m, int n, int k, GemmKernelAVX2MXFP4::BufferA& a, Gem
 
   const __m128i lut_lo = _mm_load_si128((const __m128i*)GemmKernelAVX2MXFP4::fp4_bf16_lo);
   const __m128i lut_hi = _mm_load_si128((const __m128i*)GemmKernelAVX2MXFP4::fp4_bf16_hi);
+
+  // --------------------------------------------------------------------------
+  // Fast path (decode AND prefill): one whole 32-value k-group is decoded per
+  // iteration with 256-bit PSHUFB.  The decode naturally emits values in a
+  // fixed in-lane permutation; rather than reordering the weights (extra
+  // shuffle uops on Zen2's two shuffle pipes, which is exactly what limits
+  // the generic path), every activation row is converted to FP32 once in that
+  // same permuted order, so the inner loops pair weights and activations with
+  // plain loads and FMAs.  unpack(zero, u16) fuses the BF16→FP32 widen and
+  // <<16 into a single shuffle.  Tokens are processed in blocks of 4 so each
+  // decoded group is amortized over 4 accumulators (16 ymm live: 4 weights +
+  // 4 group accumulators + 4 totals + LUTs); the remainder uses the
+  // single-row loop.  Very large per-expert batches fall back to the generic
+  // path to bound the per-thread FP32 staging buffer.
+  // --------------------------------------------------------------------------
+  if (group_size == 32 && (k % 32) == 0 && (size_t)m * (size_t)k <= (size_t)(4 << 20)) {
+    // Decode emission order within each 32-value group (see w0..w3 below).
+    static constexpr int kPerm[32] = {0,  2,  4,  6,  1,  3,  5,  7,  8,  10, 12, 14, 9,  11, 13, 15,
+                                      16, 18, 20, 22, 17, 19, 21, 23, 24, 26, 28, 30, 25, 27, 29, 31};
+    static thread_local std::vector<float> a_perm_storage;
+    if (a_perm_storage.size() < (size_t)m * k) a_perm_storage.resize((size_t)m * k);
+    float* a_perm = a_perm_storage.data();
+    for (int mi = 0; mi < m; mi++) {
+      const ggml_bf16_t* a_row = a.data + (size_t)mi * a.k;
+      float* p_row = a_perm + (size_t)mi * k;
+      for (int g = 0; g < group_count; g++) {
+        const int base = g * 32;
+        float* dst = p_row + base;
+        for (int j = 0; j < 32; j++) dst[j] = GGML_BF16_TO_FP32(a_row[base + kPerm[j]]);
+      }
+    }
+
+    const __m256i lut_lo256 = _mm256_broadcastsi128_si256(lut_lo);
+    const __m256i lut_hi256 = _mm256_broadcastsi128_si256(lut_hi);
+    const __m256i zero256 = _mm256_setzero_si256();
+    const __m128i nib_mask = _mm_set1_epi8(0x0F);
+
+// Decode one 32-value k-group at b_row+g*16 into w0..w3:
+// w0: cols {0,2,4,6 | 1,3,5,7};  w1: {8,10,12,14 | 9,11,13,15}
+// w2: {16,...,22 | 17,...,23};   w3: {24,...,30 | 25,...,31}
+#define KT_MXFP4_DECODE_GROUP(b_row, g)                                              \
+  const __m128i raw = _mm_loadu_si128((const __m128i*)((b_row) + (size_t)(g) * 16)); \
+  const __m128i lo = _mm_and_si128(raw, nib_mask);                                   \
+  const __m128i hi = _mm_and_si128(_mm_srli_epi16(raw, 4), nib_mask);                \
+  const __m256i v = _mm256_set_m128i(hi, lo);                                        \
+  const __m256i bl = _mm256_shuffle_epi8(lut_lo256, v);                              \
+  const __m256i bh = _mm256_shuffle_epi8(lut_hi256, v);                              \
+  const __m256i u16a = _mm256_unpacklo_epi8(bl, bh);                                 \
+  const __m256i u16b = _mm256_unpackhi_epi8(bl, bh);                                 \
+  const __m256 w0 = _mm256_castsi256_ps(_mm256_unpacklo_epi16(zero256, u16a));       \
+  const __m256 w1 = _mm256_castsi256_ps(_mm256_unpackhi_epi16(zero256, u16a));       \
+  const __m256 w2 = _mm256_castsi256_ps(_mm256_unpacklo_epi16(zero256, u16b));       \
+  const __m256 w3 = _mm256_castsi256_ps(_mm256_unpackhi_epi16(zero256, u16b))
+
+    for (int ni = n_start; ni < n_end; ni++) {
+      const uint8_t* b_row = b.b + (size_t)ni * row_bytes;
+      const float* b_scales = b.d + (size_t)ni * group_count;
+      if (ni + 1 < n_end) {
+        const char* nr = (const char*)(b.b + (size_t)(ni + 1) * row_bytes);
+        _mm_prefetch(nr, _MM_HINT_T0);
+        _mm_prefetch(nr + 64, _MM_HINT_T0);
+        _mm_prefetch(nr + 128, _MM_HINT_T0);
+        _mm_prefetch(nr + 192, _MM_HINT_T0);
+      }
+
+      // 4-token blocked path: each decoded group feeds 4 accumulators.
+      int mi = 0;
+      for (; mi + 4 <= m; mi += 4) {
+        const float* p0 = a_perm + (size_t)(mi + 0) * k;
+        const float* p1 = a_perm + (size_t)(mi + 1) * k;
+        const float* p2 = a_perm + (size_t)(mi + 2) * k;
+        const float* p3 = a_perm + (size_t)(mi + 3) * k;
+        __m256 tot0 = _mm256_setzero_ps(), tot1 = _mm256_setzero_ps();
+        __m256 tot2 = _mm256_setzero_ps(), tot3 = _mm256_setzero_ps();
+
+        for (int g = 0; g < group_count; g++) {
+          const int base = g * 32;
+          KT_MXFP4_DECODE_GROUP(b_row, g);
+
+          __m256 g0 = _mm256_mul_ps(_mm256_loadu_ps(p0 + base), w0);
+          __m256 g1 = _mm256_mul_ps(_mm256_loadu_ps(p1 + base), w0);
+          __m256 g2 = _mm256_mul_ps(_mm256_loadu_ps(p2 + base), w0);
+          __m256 g3 = _mm256_mul_ps(_mm256_loadu_ps(p3 + base), w0);
+          g0 = _mm256_fmadd_ps(_mm256_loadu_ps(p0 + base + 8), w1, g0);
+          g1 = _mm256_fmadd_ps(_mm256_loadu_ps(p1 + base + 8), w1, g1);
+          g2 = _mm256_fmadd_ps(_mm256_loadu_ps(p2 + base + 8), w1, g2);
+          g3 = _mm256_fmadd_ps(_mm256_loadu_ps(p3 + base + 8), w1, g3);
+          g0 = _mm256_fmadd_ps(_mm256_loadu_ps(p0 + base + 16), w2, g0);
+          g1 = _mm256_fmadd_ps(_mm256_loadu_ps(p1 + base + 16), w2, g1);
+          g2 = _mm256_fmadd_ps(_mm256_loadu_ps(p2 + base + 16), w2, g2);
+          g3 = _mm256_fmadd_ps(_mm256_loadu_ps(p3 + base + 16), w2, g3);
+          g0 = _mm256_fmadd_ps(_mm256_loadu_ps(p0 + base + 24), w3, g0);
+          g1 = _mm256_fmadd_ps(_mm256_loadu_ps(p1 + base + 24), w3, g1);
+          g2 = _mm256_fmadd_ps(_mm256_loadu_ps(p2 + base + 24), w3, g2);
+          g3 = _mm256_fmadd_ps(_mm256_loadu_ps(p3 + base + 24), w3, g3);
+
+          const __m256 sv = _mm256_broadcast_ss(&b_scales[g]);
+          tot0 = _mm256_fmadd_ps(g0, sv, tot0);
+          tot1 = _mm256_fmadd_ps(g1, sv, tot1);
+          tot2 = _mm256_fmadd_ps(g2, sv, tot2);
+          tot3 = _mm256_fmadd_ps(g3, sv, tot3);
+        }
+        c.data[(size_t)(mi + 0) * n + ni] = hsum_avx2(tot0);
+        c.data[(size_t)(mi + 1) * n + ni] = hsum_avx2(tot1);
+        c.data[(size_t)(mi + 2) * n + ni] = hsum_avx2(tot2);
+        c.data[(size_t)(mi + 3) * n + ni] = hsum_avx2(tot3);
+      }
+
+      // Single-row remainder (also the whole decode path when m == 1).
+      for (; mi < m; mi++) {
+        const float* ap_row = a_perm + (size_t)mi * k;
+        __m256 total0 = _mm256_setzero_ps();
+        __m256 total1 = _mm256_setzero_ps();
+        for (int g = 0; g < group_count; g++) {
+          const float* ap = ap_row + g * 32;
+          KT_MXFP4_DECODE_GROUP(b_row, g);
+
+          __m256 gacc = _mm256_mul_ps(_mm256_loadu_ps(ap), w0);
+          gacc = _mm256_fmadd_ps(_mm256_loadu_ps(ap + 8), w1, gacc);
+          gacc = _mm256_fmadd_ps(_mm256_loadu_ps(ap + 16), w2, gacc);
+          gacc = _mm256_fmadd_ps(_mm256_loadu_ps(ap + 24), w3, gacc);
+
+          const __m256 sv = _mm256_broadcast_ss(&b_scales[g]);
+          if (g & 1)
+            total1 = _mm256_fmadd_ps(gacc, sv, total1);
+          else
+            total0 = _mm256_fmadd_ps(gacc, sv, total0);
+        }
+        c.data[(size_t)mi * n + ni] = hsum_avx2(_mm256_add_ps(total0, total1));
+      }
+    }
+#undef KT_MXFP4_DECODE_GROUP
+    return;
+  }
 
   for (int ni = n_start; ni < n_end; ni++) {
     const uint8_t* b_row = b.b + (size_t)ni * row_bytes;


### PR DESCRIPTION
# What does this PR do?

The AVX2 MXFP4 MoE kernel decoded FP4 weights with 128-bit SSSE3 PSHUFB
and converted the BF16 activations per row, costing roughly 28
shuffle-port uops per 32 weights. On Zen 2, whose two shuffle pipes are
the binding resource here, that left the kernel compute-bound at about
39-45 GB/s per socket, well under the 83.6 GB/s STREAM ceiling of the
same socket.

Add a fast path for the common group_size == 32 layout:

- decode a whole 32-value k-group with one 256-bit VPSHUFB pair,
- fuse the BF16->FP32 widen and shift into unpack(zero, u16), which is a
  single shuffle,
- drop the reordering shuffles entirely by converting each activation
  row once into the decoder's natural in-lane emission order
  ({0,2,4,6,1,3,5,7,...} per 32-group) instead of permuting the weights,
- process tokens in blocks of 4 so each decoded group is amortized over
  4 accumulators, with a single-row remainder loop that also serves
  decode (m == 1).

This is about 9 shuffle uops per 32 weights, which makes the kernel
memory-bound. Large per-expert batches fall back to the generic path so
the per-thread FP32 staging buffer stays bounded.

Measured on 2x EPYC 7452 (AVX2, 2x30 threads) with DeepSeek-V4-Flash
MXFP4:

- microbench per layer-token: m=1 989 -> 440 us (2.25x),
  m=4 1713 -> 1002 us, m=16 6567 -> 3829 us, m=64 25651 -> 19361 us
- end-to-end 512-token decode: 18.4 -> 29.5 tok/s at 65K context, and
  18.3 -> 32.3 tok/s on a 1M-context serving profile
- NUMA pool scaling verified unchanged (1937 us 1 pool -> 968 us 2 pools)

Output stays coherent in generation smoke tests on both profiles.


## Before submitting

- [x] Did you read the [contributor guideline](https://github.com/kvcache-ai/ktransformers/blob/main/.github/CONTRIBUTING.md)?
- [ ] Did you write any new necessary tests?

No new test files. Correctness was checked with bench/bench_fp4_moe.py adapted
to the AVX2 backend against the unmodified generic path, and end to end by
serving DeepSeek-V4-Flash; the numbers above are from that host.
