### PR TITLE
[feat](kt-kernel): NVFP4 routed experts on the AVX2 FP4 backend

### DIFF
--- a/kt-kernel/operators/avx2/mxfp4-moe.hpp
+++ b/kt-kernel/operators/avx2/mxfp4-moe.hpp
@@ -334,6 +334,142 @@ static void gemm_mxfp4(int m, int n, int k, GemmKernelAVX2MXFP4::BufferA& a, Gem
     return;
   }
 
+  // --------------------------------------------------------------------------
+  // group_size == 16 fast path (NVFP4-style layouts: E2M1 nibbles with a scale
+  // every 16 values).  The 32-value block decode above is reused unchanged: a
+  // 16-byte load spans exactly TWO consecutive 16-value groups, and the decode
+  // emits w0/w1 entirely from group 2b and w2/w3 entirely from group 2b+1, so
+  // the only difference from the group-32 path is that each half of the block
+  // is folded with its own scale.  The activation pre-permutation is identical
+  // because kPerm never crosses the 16-value halves (indices 0-15 stay in the
+  // first half, 16-31 in the second).
+  // --------------------------------------------------------------------------
+  if (group_size == 16 && (k % 32) == 0 && (size_t)m * (size_t)k <= (size_t)(4 << 20)) {
+    static constexpr int kPerm[32] = {0,  2,  4,  6,  1,  3,  5,  7,  8,  10, 12, 14, 9,  11, 13, 15,
+                                      16, 18, 20, 22, 17, 19, 21, 23, 24, 26, 28, 30, 25, 27, 29, 31};
+    static thread_local std::vector<float> a_perm_storage;
+    if (a_perm_storage.size() < (size_t)m * k) a_perm_storage.resize((size_t)m * k);
+    float* a_perm = a_perm_storage.data();
+    const int block_count = k / 32;  // 32-value decode blocks; 2 groups each
+    for (int mi = 0; mi < m; mi++) {
+      const ggml_bf16_t* a_row = a.data + (size_t)mi * a.k;
+      float* p_row = a_perm + (size_t)mi * k;
+      for (int blk = 0; blk < block_count; blk++) {
+        const int base = blk * 32;
+        float* dst = p_row + base;
+        for (int j = 0; j < 32; j++) dst[j] = GGML_BF16_TO_FP32(a_row[base + kPerm[j]]);
+      }
+    }
+
+    const __m256i lut_lo256 = _mm256_broadcastsi128_si256(lut_lo);
+    const __m256i lut_hi256 = _mm256_broadcastsi128_si256(lut_hi);
+    const __m256i zero256 = _mm256_setzero_si256();
+    const __m128i nib_mask = _mm_set1_epi8(0x0F);
+
+// Same decode as the group-32 path; here w0/w1 = group 2*blk, w2/w3 = 2*blk+1.
+#define KT_MXFP4_DECODE_GROUP(b_row, g)                                              \
+  const __m128i raw = _mm_loadu_si128((const __m128i*)((b_row) + (size_t)(g) * 16)); \
+  const __m128i lo = _mm_and_si128(raw, nib_mask);                                   \
+  const __m128i hi = _mm_and_si128(_mm_srli_epi16(raw, 4), nib_mask);                \
+  const __m256i v = _mm256_set_m128i(hi, lo);                                        \
+  const __m256i bl = _mm256_shuffle_epi8(lut_lo256, v);                              \
+  const __m256i bh = _mm256_shuffle_epi8(lut_hi256, v);                              \
+  const __m256i u16a = _mm256_unpacklo_epi8(bl, bh);                                 \
+  const __m256i u16b = _mm256_unpackhi_epi8(bl, bh);                                 \
+  const __m256 w0 = _mm256_castsi256_ps(_mm256_unpacklo_epi16(zero256, u16a));       \
+  const __m256 w1 = _mm256_castsi256_ps(_mm256_unpackhi_epi16(zero256, u16a));       \
+  const __m256 w2 = _mm256_castsi256_ps(_mm256_unpacklo_epi16(zero256, u16b));       \
+  const __m256 w3 = _mm256_castsi256_ps(_mm256_unpackhi_epi16(zero256, u16b))
+
+    for (int ni = n_start; ni < n_end; ni++) {
+      const uint8_t* b_row = b.b + (size_t)ni * row_bytes;
+      const float* b_scales = b.d + (size_t)ni * group_count;
+      if (ni + 1 < n_end) {
+        const char* nr = (const char*)(b.b + (size_t)(ni + 1) * row_bytes);
+        _mm_prefetch(nr, _MM_HINT_T0);
+        _mm_prefetch(nr + 64, _MM_HINT_T0);
+        _mm_prefetch(nr + 128, _MM_HINT_T0);
+        _mm_prefetch(nr + 192, _MM_HINT_T0);
+      }
+
+      // 4-token blocked path: per block, each half folds with its own scale.
+      int mi = 0;
+      for (; mi + 4 <= m; mi += 4) {
+        const float* p0 = a_perm + (size_t)(mi + 0) * k;
+        const float* p1 = a_perm + (size_t)(mi + 1) * k;
+        const float* p2 = a_perm + (size_t)(mi + 2) * k;
+        const float* p3 = a_perm + (size_t)(mi + 3) * k;
+        __m256 tot0 = _mm256_setzero_ps(), tot1 = _mm256_setzero_ps();
+        __m256 tot2 = _mm256_setzero_ps(), tot3 = _mm256_setzero_ps();
+
+        for (int blk = 0; blk < block_count; blk++) {
+          const int base = blk * 32;
+          KT_MXFP4_DECODE_GROUP(b_row, blk);
+          const __m256 sa = _mm256_broadcast_ss(&b_scales[2 * blk]);
+          const __m256 sb = _mm256_broadcast_ss(&b_scales[2 * blk + 1]);
+
+          __m256 h0 = _mm256_mul_ps(_mm256_loadu_ps(p0 + base), w0);
+          __m256 h1 = _mm256_mul_ps(_mm256_loadu_ps(p1 + base), w0);
+          __m256 h2 = _mm256_mul_ps(_mm256_loadu_ps(p2 + base), w0);
+          __m256 h3 = _mm256_mul_ps(_mm256_loadu_ps(p3 + base), w0);
+          h0 = _mm256_fmadd_ps(_mm256_loadu_ps(p0 + base + 8), w1, h0);
+          h1 = _mm256_fmadd_ps(_mm256_loadu_ps(p1 + base + 8), w1, h1);
+          h2 = _mm256_fmadd_ps(_mm256_loadu_ps(p2 + base + 8), w1, h2);
+          h3 = _mm256_fmadd_ps(_mm256_loadu_ps(p3 + base + 8), w1, h3);
+          tot0 = _mm256_fmadd_ps(h0, sa, tot0);
+          tot1 = _mm256_fmadd_ps(h1, sa, tot1);
+          tot2 = _mm256_fmadd_ps(h2, sa, tot2);
+          tot3 = _mm256_fmadd_ps(h3, sa, tot3);
+
+          h0 = _mm256_mul_ps(_mm256_loadu_ps(p0 + base + 16), w2);
+          h1 = _mm256_mul_ps(_mm256_loadu_ps(p1 + base + 16), w2);
+          h2 = _mm256_mul_ps(_mm256_loadu_ps(p2 + base + 16), w2);
+          h3 = _mm256_mul_ps(_mm256_loadu_ps(p3 + base + 16), w2);
+          h0 = _mm256_fmadd_ps(_mm256_loadu_ps(p0 + base + 24), w3, h0);
+          h1 = _mm256_fmadd_ps(_mm256_loadu_ps(p1 + base + 24), w3, h1);
+          h2 = _mm256_fmadd_ps(_mm256_loadu_ps(p2 + base + 24), w3, h2);
+          h3 = _mm256_fmadd_ps(_mm256_loadu_ps(p3 + base + 24), w3, h3);
+          tot0 = _mm256_fmadd_ps(h0, sb, tot0);
+          tot1 = _mm256_fmadd_ps(h1, sb, tot1);
+          tot2 = _mm256_fmadd_ps(h2, sb, tot2);
+          tot3 = _mm256_fmadd_ps(h3, sb, tot3);
+        }
+        c.data[(size_t)(mi + 0) * n + ni] = hsum_avx2(tot0);
+        c.data[(size_t)(mi + 1) * n + ni] = hsum_avx2(tot1);
+        c.data[(size_t)(mi + 2) * n + ni] = hsum_avx2(tot2);
+        c.data[(size_t)(mi + 3) * n + ni] = hsum_avx2(tot3);
+      }
+
+      // Single-row remainder (also the whole decode path when m == 1).  The two
+      // half-scales per block go to their own accumulators; group-16 folds a
+      // scale for each 16-value half, which is twice the group-32 rate, and at
+      // m==1 (no token blocking to amortize the decode) that scale work is the
+      // path's floor -- roughly 1.4x the group-32 single-row cost.  It is a
+      // property of the format's scale density, not the accumulator count: a
+      // four-way split by block parity was measured and made no difference.
+      for (; mi < m; mi++) {
+        const float* ap_row = a_perm + (size_t)mi * k;
+        __m256 total0 = _mm256_setzero_ps();
+        __m256 total1 = _mm256_setzero_ps();
+        for (int blk = 0; blk < block_count; blk++) {
+          const float* ap = ap_row + blk * 32;
+          KT_MXFP4_DECODE_GROUP(b_row, blk);
+
+          __m256 ha = _mm256_mul_ps(_mm256_loadu_ps(ap), w0);
+          ha = _mm256_fmadd_ps(_mm256_loadu_ps(ap + 8), w1, ha);
+          __m256 hb = _mm256_mul_ps(_mm256_loadu_ps(ap + 16), w2);
+          hb = _mm256_fmadd_ps(_mm256_loadu_ps(ap + 24), w3, hb);
+
+          total0 = _mm256_fmadd_ps(ha, _mm256_broadcast_ss(&b_scales[2 * blk]), total0);
+          total1 = _mm256_fmadd_ps(hb, _mm256_broadcast_ss(&b_scales[2 * blk + 1]), total1);
+        }
+        c.data[(size_t)mi * n + ni] = hsum_avx2(_mm256_add_ps(total0, total1));
+      }
+    }
+#undef KT_MXFP4_DECODE_GROUP
+    return;
+  }
+
   for (int ni = n_start; ni < n_end; ni++) {
     const uint8_t* b_row = b.b + (size_t)ni * row_bytes;
     const float* b_scales = b.d + (size_t)ni * group_count;

--- a/kt-kernel/python/experts.py
+++ b/kt-kernel/python/experts.py
@@ -41,6 +41,7 @@ INFERENCE_METHODS = frozenset(
         "GPTQ_INT4",  # GPTQ INT4
         "SYCL_GPTQ_INT4",  # GPTQ INT4 experts on a SYCL device
         "MXFP4",  # MXFP4 (E2M1 nibble + ue8m0 group scale, e.g. DeepSeek-V4-Flash routed experts)
+        "NVFP4",  # NVFP4 (E2M1 nibble + e4m3 per-16 block scale x per-tensor global, ModelOpt)
         "MXFP8",  # MXFP8 (E4M3fn byte + ue8m0 group scale, e.g. MiniMax-M3-Preview)
         "LLAMAFILE",  # GGUF format
         "MOE_INT4",
@@ -351,6 +352,7 @@ def _create_inference_wrapper(
         "GPTQ_INT4",
         "SYCL_GPTQ_INT4",
         "MXFP4",
+        "NVFP4",
         "MXFP8",
     ]:
         backend_cls = NativeMoEWrapper

--- a/kt-kernel/python/utils/amx.py
+++ b/kt-kernel/python/utils/amx.py
@@ -17,6 +17,7 @@ from .loader import (
     BF16SafeTensorLoader,
     GPTQSafeTensorLoader,
     MXFP4SafeTensorLoader,
+    NVFP4SafeTensorLoader,
     MXFP8SafeTensorLoader,
 )
 from kt_kernel_ext.moe import MOEConfig
@@ -625,6 +626,10 @@ class NativeMoEWrapper(BaseMoEWrapper):
                 "SYCL_GPTQ_INT4 backend not available. Rebuild kt_kernel_ext with "
                 "CPUINFER_USE_SYCL=1 using a SYCL compiler such as icpx."
             )
+        if method == "NVFP4" and not _HAS_AVX2_MXFP4_SUPPORT:
+            raise RuntimeError(
+                "NVFP4 needs the AVX2 FP4 backend (AVX2MXFP4_MOE), which is not compiled in."
+            )
         if method == "MXFP4" and not (_HAS_MXFP4_SUPPORT or _HAS_AVX2_MXFP4_SUPPORT):
             raise RuntimeError(
                 "MXFP4 backend not available. Required ISA (any one of):\n"
@@ -683,6 +688,8 @@ class NativeMoEWrapper(BaseMoEWrapper):
             return GPTQSafeTensorLoader(weight_path)
         elif method == "MXFP4":
             return MXFP4SafeTensorLoader(weight_path)
+        elif method == "NVFP4":
+            return NVFP4SafeTensorLoader(weight_path)
         elif method == "MXFP8":
             return MXFP8SafeTensorLoader(weight_path)
         else:
@@ -785,6 +792,9 @@ class NativeMoEWrapper(BaseMoEWrapper):
                 # ue8m0 is losslessly representable in bf16 (8-bit exponent, 0 mantissa);
                 # the loader has already done that conversion.
                 assert self.gate_scales[0].dtype == torch.bfloat16, "Expected bf16 scales for MXFP4"
+            elif self.method == "NVFP4":
+                # e4m3 block scale x per-tensor global, folded to bf16 by the loader.
+                assert self.gate_scales[0].dtype == torch.bfloat16, "Expected bf16 scales for NVFP4"
             elif self.method == "MXFP8":
                 # ue8m0 scales stay as uint8; C++ convert_ue8m0_to_fp32 handles conversion.
                 assert self.gate_scales[0].dtype == torch.uint8, "Expected uint8 (ue8m0) scales for MXFP8"
@@ -875,6 +885,35 @@ class NativeMoEWrapper(BaseMoEWrapper):
                 raise RuntimeError(
                     "No MXFP4 backend available after runtime selection. "
                     "Compile with AVX512_BF16 (AMXFP4_KGroup_MOE) or AVX2 (AVX2MXFP4_MOE)."
+                )
+            self.moe = backend_cls(moe_config)
+        elif self.method == "NVFP4":
+            # NVFP4: same E2M1 nibble packing as MXFP4, but a per-16 block scale
+            # in E4M3 times a per-tensor global scale. The loader has already
+            # folded both into one bf16 scale per group, so the FP4 kernel runs
+            # this unchanged -- only group_size differs (16 vs 32).
+            group_size = self.hidden_size // self.gate_scales[0].shape[1]
+            if group_size != 16:
+                raise RuntimeError(
+                    f"NVFP4 expects group_size 16, derived {group_size} from "
+                    f"hidden_size={self.hidden_size} and scale shape "
+                    f"{tuple(self.gate_scales[0].shape)}."
+                )
+            moe_config.quant_config.bits = 4
+            moe_config.quant_config.group_size = group_size
+            moe_config.quant_config.zero_point = False
+            backend_cls = _select_mxfp4_backend()
+            if backend_cls is None:
+                raise RuntimeError(
+                    "No FP4 backend available for NVFP4 after runtime selection. "
+                    "Compile with AVX512_BF16 (AMXFP4_KGroup_MOE) or AVX2 (AVX2MXFP4_MOE)."
+                )
+            if backend_cls is not AVX2MXFP4_MOE:
+                # Only the AVX2 kernel has the group-16 path; the AMX FP4 kernel
+                # is built around a 32-value k-group.
+                raise RuntimeError(
+                    "NVFP4 (group_size 16) currently requires the AVX2 FP4 backend. "
+                    "Set KT_MXFP4_BACKEND=avx2, or extend the AMX kernel to group-16."
                 )
             self.moe = backend_cls(moe_config)
         elif self.method == "MXFP8":

--- a/kt-kernel/python/utils/loader.py
+++ b/kt-kernel/python/utils/loader.py
@@ -1270,6 +1270,99 @@ class MXFP4SafeTensorLoader(SafeTensorLoader):
         }
 
 
+class NVFP4SafeTensorLoader(SafeTensorLoader):
+    """Loader for ModelOpt NVFP4 expert weights (W4A16_NVFP4, group_size 16).
+
+    Per expert layout (compressed-tensors / ModelOpt naming):
+      {base}.mlp.experts.{i}.gate_proj.weight          U8        [N, K/2]   nibble-packed E2M1
+      {base}.mlp.experts.{i}.gate_proj.weight_scale    F8_E4M3   [N, K/16]  per-block scale
+      {base}.mlp.experts.{i}.gate_proj.weight_scale_2  F32       scalar     per-tensor global
+      {base}.mlp.experts.{i}.{up_proj,down_proj}.{weight,weight_scale,weight_scale_2}
+
+    NVFP4 shares MXFP4's E2M1 codepoints and low-nibble-first packing, so the
+    weight bytes go to the FP4 kernel untouched; only the scale encoding differs.
+    The kernel consumes one FP32-valued scale per k-group, so both levels are
+    folded here into a single bf16 tensor:
+
+        scale[n, g] = float(e4m3(weight_scale[n, g])) * weight_scale_2
+
+    bf16 is lossy for E4M3 products (8 mantissa bits down to 7), which is what
+    the kernel's own group-32 MXFP4 path already accepts; measured against a
+    float64 dequant of the same bytes the end-to-end error is bf16-rounding
+    only (cosine 0.999993 on Ornith-1.5-35B-A3B-NVFP4).
+    """
+
+    EXPERTS_PATH_TPL = "{base}.mlp.experts"
+    PROJ_NAMES = ("gate_proj", "up_proj", "down_proj")
+
+    def _experts_prefix_candidates(self, base_key: str) -> list[str]:
+        candidates = [self.EXPERTS_PATH_TPL.format(base=base_key)]
+        for strip in ("model.language_model.", "language_model.model.", "language_model.", "model."):
+            if base_key.startswith(strip):
+                candidates.append(self.EXPERTS_PATH_TPL.format(base=base_key[len(strip):]))
+        # ModelOpt checkpoints for multimodal Qwen3.5-MoE nest under
+        # model.language_model.layers.{L}; callers may pass either form.
+        if not base_key.startswith("model.language_model."):
+            for pre in ("model.language_model.", "language_model.model."):
+                if base_key.startswith("model."):
+                    candidates.append(self.EXPERTS_PATH_TPL.format(base=pre + base_key[len("model."):]))
+        return list(dict.fromkeys(candidates))
+
+    @staticmethod
+    def _fold_scales_to_bf16(block_scale: torch.Tensor, global_scale: torch.Tensor) -> torch.Tensor:
+        """e4m3 block scale x per-tensor f32 global -> bf16 [N, K/16]."""
+        s = block_scale.to(torch.float32) * global_scale.to(torch.float32).reshape(())
+        return s.to(torch.bfloat16).contiguous()
+
+    def load_experts(self, base_key: str, device: str = "cpu"):
+        gate_name, up_name, down_name = self.PROJ_NAMES
+        prefix = None
+        expert_count = 0
+        for cand in self._experts_prefix_candidates(base_key):
+            expert_count = 0
+            while self.has_tensor(f"{cand}.{expert_count}.{gate_name}.weight"):
+                expert_count += 1
+            if expert_count > 0:
+                prefix = cand
+                break
+        if prefix is None:
+            raise ValueError(
+                f"No NVFP4 experts found under any of: {self._experts_prefix_candidates(base_key)}"
+            )
+
+        gate_weights = [None] * expert_count
+        up_weights = [None] * expert_count
+        down_weights = [None] * expert_count
+        gate_scales = [None] * expert_count
+        up_scales = [None] * expert_count
+        down_scales = [None] * expert_count
+
+        for exp_id in range(expert_count):
+            for proj, wdst, sdst in (
+                (gate_name, gate_weights, gate_scales),
+                (up_name, up_weights, up_scales),
+                (down_name, down_weights, down_scales),
+            ):
+                w = self.load_tensor(f"{prefix}.{exp_id}.{proj}.weight", device).contiguous()
+                if w.dtype != torch.uint8:
+                    w = w.view(torch.uint8)
+                wdst[exp_id] = w
+
+                bs = self.load_tensor(f"{prefix}.{exp_id}.{proj}.weight_scale", device)
+                gs = self.load_tensor(f"{prefix}.{exp_id}.{proj}.weight_scale_2", device)
+                sdst[exp_id] = self._fold_scales_to_bf16(bs, gs)
+
+        print(f"[NVFP4SafeTensorLoader] Loaded {expert_count} experts from {prefix}")
+        return {
+            "gate": gate_weights,
+            "up": up_weights,
+            "down": down_weights,
+            "gate_scale": gate_scales,
+            "up_scale": up_scales,
+            "down_scale": down_scales,
+        }
+
+
 class MXFP8SafeTensorLoader(SafeTensorLoader):
     """Loader for native MXFP8 expert weights (MiniMax M3 Preview format).
 


### PR DESCRIPTION
# What does this PR do?

> ~~Stacked on #2175~~ — #2175 has merged and this branch is rebased onto
> main, so the diff below is the NVFP4 addition only.

ModelOpt ships large MoE checkpoints as NVFP4 experts-only -- E2M1 nibbles
with a per-16 block scale in E4M3 times a per-tensor global scale. NVIDIA
publishes GLM-5.2, Qwen3.6, MiniMax and Gemma-4 in this format, and it is
what the 397B Ornith build uses. kt-kernel had no NVFP4 path at all: no
method, no loader, and the tuned AVX2 FP4 fast path is gated on
group_size == 32, so group-16 weights would have fallen back to the
generic loop.

Almost none of this needs new machinery. NVFP4 and MXFP4 share the E2M1
codepoints and the low-nibble-first packing, so the weight bytes are
handed to the existing kernel untouched, and BufferB already holds FP32
scales, which makes the scale encoding a loader concern rather than a
kernel one.

Kernel: a group_size == 16 fast path beside the existing group-32 one,
which is left byte-for-byte alone. The 32-value block decode is reused
verbatim: a 16-byte load spans exactly two consecutive 16-value groups and
the decode splits so w0/w1 belong to the first and w2/w3 to the second,
while the activation pre-permutation never crosses the halves. Only the
scale fold differs, once per half.

Loader: NVFP4SafeTensorLoader reads the compressed-tensors naming and
folds both scale levels into the bf16 per-group scale the kernel wants,
scale[n,g] = float(e4m3(weight_scale[n,g])) * weight_scale_2. amx.py
derives group_size from the scale shape and rejects anything but 16, and
rejects the AMX FP4 backend, which is built around a 32-value k-group,
rather than letting it produce silent garbage.

Verified on 2x EPYC 7452 (AVX2, no AVX-512) against ornith-ai/
Ornith-1.5-35B-A3B-NVFP4:

- kernel vs a float64 dequant of the same on-disk bytes: layers 0, 5, 20
  and 39 all match at cosine 0.999992-0.999994, bf16 rounding only
- through the loader rather than a hand-built fold: same, cosine 0.999993
  and 0.999994
- through SGLang end to end: all 40 layers load at TP=2 across both NUMA
  nodes and the model serves, 801-token prefill and 75.8 tok/s decode
- synthetic V4-Flash shape (256 experts, hidden 4096, inter 2048), m up to
  64: matches the reference, and group-16 costs 1.05-1.15x group-32 above
  m=4, 1.4x at m=1 where there is no token blocking to amortize the shared
  decode over. That gap is the format's scale density, not the loop: a
  four-way accumulator split was measured and changed nothing.

Existing MXFP4 behaviour is unchanged; the group-32 path produces
byte-identical output before and after.


## Before submitting

- [x] Did you read the [contributor guideline](https://github.com/kvcache-ai/ktransformers/blob/main/.github/CONTRIBUTING.md)?
- [ ] Did you write any new necessary tests?

No new test files in-tree. Correctness was checked against a float64 dequant
of the same on-disk bytes for a real ModelOpt NVFP4 checkpoint, and end to end
through SGLang; both are described above. Happy to add a bench/ script in the
style of bench_fp4_moe.py if that is wanted.

