### PR TITLE
release: align the post4 main stack and enable CI artifact builds

### DIFF
--- a/.github/release/README.md
+++ b/.github/release/README.md
@@ -1,8 +1,14 @@
 # 四仓 main 一键发布（Draft，尚未启用）
 
 入口：**KTransformers → Actions → Release four-main stack → Run workflow**。
-选择 `main`，`target=candidate` 只构建和验收；`target=pypi` 才允许上传。
+选择 `main`，`target=build` 只产出候选 artifact；`target=candidate` 构建和验收；
+`target=pypi` 才允许上传。
 合并 PR、修改版本号均不会自动上传；此 PR 不改变已经安装的 PyPI 包。
+
+`build` 用于验收 runner 尚未就绪时先通过 CI 构建；它不会启用 GPU runner、
+跳过发布验收或上传 PyPI，不能把构建成功当成发布成功。管理员可设置
+`KT_RELEASE_WORK_ROOT` 为可执行的空闲内存盘目录，避免填满 runner 磁盘；
+构建和临时文件都进入该目录下本次创建、带 run ID 标记的独立子目录。
 
 ```text
 Run workflow

--- a/.github/workflows/release-four-main.yml
+++ b/.github/workflows/release-four-main.yml
@@ -5,11 +5,11 @@ on:
   workflow_dispatch:
     inputs:
       target:
-        description: 'Build and test only, or publish the same validated wheels to PyPI'
+        description: 'Build artifacts only, build and test, or publish the validated wheels'
         type: choice
         required: true
         default: candidate
-        options: [candidate, pypi]
+        options: [build, candidate, pypi]
 
 permissions:
   contents: read
@@ -40,9 +40,10 @@ jobs:
         env:
           RELEASE_ENABLED: ${{ vars.KT_FOUR_MAIN_RELEASE_ENABLED }}
           E2E_ENABLED: ${{ vars.KT_MODEL_E2E_ENABLED }}
+          TARGET: ${{ inputs.target }}
         run: |
           test "$RELEASE_ENABLED" = true
-          test "$E2E_ENABLED" = true
+          if [ "$TARGET" != build ]; then test "$E2E_ENABLED" = true; fi
           test -f .github/workflows/model-e2e-release.yml
           test -f .github/model-e2e/release_contracts.py
       - name: Resolve latest main heads once
@@ -93,6 +94,7 @@ jobs:
       PYTHONHOME: ''
       CONDA_PREFIX: ''
       CMAKE_PREFIX_PATH: ''
+      RELEASE_WORK_ROOT: ${{ vars.KT_RELEASE_WORK_ROOT }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -108,7 +110,10 @@ jobs:
       - name: Create an isolated build directory and environment
         run: |
           set -euo pipefail
-          release_work="$(mktemp -d "$RUNNER_TEMP/kt-four-main.XXXXXXXX")"
+          RELEASE_WORK_ROOT="${RELEASE_WORK_ROOT:-$RUNNER_TEMP}"
+          echo "RELEASE_WORK_ROOT=$RELEASE_WORK_ROOT" >> "$GITHUB_ENV"
+          test -d "$RELEASE_WORK_ROOT" && test -w "$RELEASE_WORK_ROOT"
+          release_work="$(mktemp -d "$RELEASE_WORK_ROOT/kt-four-main.XXXXXXXX")"
           echo "RELEASE_WORK=$release_work" >> "$GITHUB_ENV"
           echo "$GITHUB_RUN_ID" > "$release_work/.kt-release-owned"
           python -m venv "$release_work/venv"
@@ -118,6 +123,8 @@ jobs:
           echo "$CUDA_HOME/bin" >> "$GITHUB_PATH"
           echo "VIRTUAL_ENV=$release_work/venv" >> "$GITHUB_ENV"
           echo "LD_LIBRARY_PATH=$CUDA_HOME/lib64" >> "$GITHUB_ENV"
+          mkdir "$release_work/tmp"
+          echo "TMPDIR=$release_work/tmp" >> "$GITHUB_ENV"
       - name: Check build prerequisites
         run: |
           set -euo pipefail
@@ -263,10 +270,11 @@ jobs:
         if: always() && env.RELEASE_WORK != ''
         run: |
           python ci-tools/.github/release/cleanup.py \
-            --directory "$RELEASE_WORK" --parent "$RUNNER_TEMP"
+            --directory "$RELEASE_WORK" --parent "$RELEASE_WORK_ROOT"
 
   candidate-e2e:
     needs: raw-build
+    if: inputs.target != 'build'
     uses: ./.github/workflows/model-e2e-release.yml
     with:
       stage: candidate

--- a/setup.py
+++ b/setup.py
@@ -19,8 +19,8 @@ setup(
     ],
     extras_require={
         "sft": [
-            "transformers-kt==5.6.0.post3",
-            "accelerate-kt==1.14.0.post2",
+            "transformers-kt==5.6.0.post5",
+            "accelerate-kt==1.14.0.post3",
         ],
         "sglang": [
             f"sglang-kt=={_v}",

--- a/version.py
+++ b/version.py
@@ -3,4 +3,4 @@ KTransformers version information.
 Shared across the top-level package and kt-kernel.
 """
 
-__version__ = "0.7.0.post1"
+__version__ = "0.7.0.post4"


### PR DESCRIPTION
## 本次发布

经维护者批准，将四仓公开 main 的发行元数据对齐为：

- ktransformers / kt-kernel / sglang-kt：0.7.0.post4
- transformers-kt：5.6.0.post5
- accelerate-kt：1.14.0.post3

模型运行时代码不在本 PR 中修改，不同步额外上游提交。其他三仓的版本和依赖更新已快进到公开 main。

## CI 构建入口

增加 `target=build`，用于 GPU 验收 runner 尚未完成部署时，先通过 CI 构建同一批候选 wheels。该目标只输出候选，不上传 PyPI，不将构建成功当成验收成功，也不启用社区 PR 执行权限。

增加可配置的 `KT_RELEASE_WORK_ROOT`，使原生编译、下载及临时文件使用可执行内存盘，避免写满 qj5090 的磁盘。清理仍只针对带本次 run ID 标记的独立临时子目录。

## 检查

- 45 项发行脚本测试通过。
- actionlint 通过（忽略已知自建 runner 标签）。
- 保留候选验收、SHA256 绑定、PyPI 上传及公开索引复验门禁。
- 本次发布还需要 sap4 Kimi K2.5 猫娘训练、保存、转换和重载实机验收；这些尚未完成，不以历史记录替代。
