### PR TITLE
fix(ci): preserve the release Python shared library path

### DIFF
--- a/.github/workflows/release-four-main.yml
+++ b/.github/workflows/release-four-main.yml
@@ -122,7 +122,9 @@ jobs:
           echo "$release_work/venv/bin" >> "$GITHUB_PATH"
           echo "$CUDA_HOME/bin" >> "$GITHUB_PATH"
           echo "VIRTUAL_ENV=$release_work/venv" >> "$GITHUB_ENV"
-          echo "LD_LIBRARY_PATH=$CUDA_HOME/lib64" >> "$GITHUB_ENV"
+          # setup-python's CPython is linked against libpython in its own lib/.
+          # Do not discard that directory when adding the CUDA toolkit.
+          echo "LD_LIBRARY_PATH=$CUDA_HOME/lib64:$pythonLocation/lib" >> "$GITHUB_ENV"
           mkdir "$release_work/tmp"
           echo "TMPDIR=$release_work/tmp" >> "$GITHUB_ENV"
       - name: Check build prerequisites


### PR DESCRIPTION
The first real four-main build failed before compilation: adding CUDA to LD_LIBRARY_PATH discarded setup-python libpython3.12.so.1.0. Preserve the explicit setup-python lib directory alongside CUDA. Reproduced and checked on qj5090. Release unit tests: 45 passed; actionlint passed. No model changes, no publishing or validation bypass.