### PR TITLE
ci: support verified manual release takeover and faster CUDA builds

### DIFF
--- a/.github/release/README.md
+++ b/.github/release/README.md
@@ -10,6 +10,26 @@
 `KT_RELEASE_WORK_ROOT` 为可执行的空闲内存盘目录，避免填满 runner 磁盘；
 构建和临时文件都进入该目录下本次创建、带 run ID 标记的独立子目录。
 
+### 模型验收 runner 未就绪时的人工接管
+
+`Promote manually validated CI wheels` 只接管上传，不重新编译、不执行 Kimi
+训练，也不伪造自动验收 workflow 的成功记录。它只能从官方 main 手动触发，
+读取成功的 `Release four-main stack` 构建 artifact，并要求：
+
+- 用完整 commit SHA 和文件 SHA256 固定维护者的人工验收 JSON；该文件只作为
+  数据读取，不能执行其中的代码。
+- 核对同一份四仓 source lock、构建 run/attempt、五个 wheels 与完整依赖哈希。
+- 核对两台机器的全新环境、两种 extras 安装报告、安装训练工具前后的核心
+  文件哈希，及 Qwen/DeepSeek 一个 optimizer step 的有限 raw loss 和 GLM 问答。
+- 本次 post4 的人工记录还包含 sap4 Kimi 的完整 LoRA 保存、转换、至少 32 步
+  风格训练及未出现在训练集中的风格问答；Kimi 不被添加为 CI 自动训练任务。
+
+凭据仅在最终上传 step 注入，先预检整批版本，再按 Accelerate → Transformers
+→ KT-Kernel → SGLang → KTransformers 的顺序上传同一批文件。上传后状态明确为
+`uploaded-awaiting-public-e2e`，正式 PyPI 新环境复验仍由维护者完成。
+人工记录依赖维护者真实执行、审核与授权，不等同于自动 runner 的执行证明。
+没有完成验收记录时，不能通过该入口发布。
+
 ```text
 Run workflow
   → 两次观测并锁定四仓 main SHA + 工作流 SHA

--- a/.github/release/manual_promote.py
+++ b/.github/release/manual_promote.py
@@ -1,0 +1,142 @@
+"""Promote a CI-built candidate after explicit, immutable manual acceptance.
+
+This is an honest manual-takeover path, not synthetic #2195 CI evidence. It does
+not run Kimi training in CI, rebuild wheels, or claim public-PyPI revalidation.
+"""
+
+import argparse
+import base64
+import hashlib
+import json
+import math
+import os
+from pathlib import Path
+import re
+import subprocess
+import sys
+import time
+import urllib.request
+
+from four_main import save_json, sha256
+from release_stack import ORDER, existing_matches, pypi_files
+from release_contracts import verify_install_report, verify_release
+
+REPO = "kvcache-ai/ktransformers"
+
+
+def require(condition, message):
+    if not condition:
+        raise ValueError(message)
+
+
+def finite(value):
+    return isinstance(value, (int, float)) and not isinstance(value, bool) and math.isfinite(value)
+
+
+def check_attestation(data, manifest, digest):
+    require(data.get("schema") == 1 and data.get("execution") == "manual", "Require explicit manual acceptance")
+    require(data.get("manifest_sha256") == digest, "Different candidate digest")
+    require(data.get("source_lock") == manifest["source_lock"], "Different source lock")
+    require(data.get("wheels") == manifest["wheels"], "Different accepted wheel bytes")
+    require(data.get("candidate_run_id") == manifest["run_id"], "Different build run")
+    require(data.get("candidate_attempt") == manifest["run_attempt"], "Different build attempt")
+    for host in ("sap4", "qj5090"):
+        for extra in ("sglang", "sglang,sft"):
+            verify_install_report(data["install_reports"][host][extra], manifest, extra, public=False)
+        integrity = data["runtime_integrity"][host]
+        require(integrity.get("fresh_venvs") is True and integrity.get("no_upstream_namespace") is True, "Unclean installation")
+        before = integrity.get("before_tooling_sha256", "")
+        require(re.fullmatch(r"[0-9a-f]{64}", before) and before == integrity.get("after_tooling_sha256"), "Tooling changed runtime")
+    for case, world in (("qwen3_lora", 1), ("deepseek_v31_lora", 8)):
+        records = data["qj5090"][case]["records"]
+        require(len(records) == world and {r["rank"] for r in records} == set(range(world)), "Missing rank evidence")
+        for record in records:
+            require(record["global_step"] == record["optimizer_steps"] == 1 and record["train_end"] is True, "Incomplete LoRA step")
+            require(record["raw_losses"] and all(finite(v) for v in record["raw_losses"]), "Nonfinite raw loss")
+    glm = data["qj5090"]["glm"]
+    require(glm["completion_tokens"] > 0 and ("巴黎" in glm["content"] or "paris" in glm["content"].lower()), "GLM Q&A did not pass")
+    kimi = data["sap4"]["kimi"]
+    require(kimi["global_step"] >= 32 and kimi["adapter_status"] == "ready", "Kimi smoke is not completed style training")
+    require(kimi["loss_records"] and all(finite(r["loss"]) and finite(r["grad_norm"]) for r in kimi["loss_records"]), "Invalid Kimi training values")
+    require(set(kimi["adapter_files"]) == {"adapter_model.safetensors", "fused_expert_lora.safetensors"}, "Incomplete adapter bundle")
+    for item in kimi["adapter_files"].values():
+        require(item["nonzero_B_tensors"] > 0 and item["tensors"] > 0 and re.fullmatch(r"[0-9a-f]{64}", item["sha256"]), "Invalid saved LoRA")
+    answers = kimi["style_answers"]
+    require(len(answers) == 4 and all(a["completion_tokens"] > 0 and a["content"].strip() and "\ufffd" not in a["content"] for a in answers), "Invalid style generations")
+    require(sum("喵" in a["content"] for a in answers) >= 3, "Style validation failed")
+    require(kimi["heldout_overlap_count"] == 0 and kimi["baseline_completed"] is True and kimi["arithmetic_correct"] is True, "Incomplete Kimi comparison")
+    require(kimi["conversion_from_main_script"] is True, "Untracked conversion implementation")
+
+
+def github(path):
+    request = urllib.request.Request("https://api.github.com/repos/" + REPO + path, headers={"Authorization": "Bearer " + os.environ["GH_TOKEN"], "Accept": "application/vnd.github+json"})
+    with urllib.request.urlopen(request, timeout=60) as response:
+        return json.load(response)
+
+
+def fetch():
+    require(os.environ.get("GITHUB_REPOSITORY") == REPO and os.environ.get("GITHUB_REF") == "refs/heads/main" and os.environ.get("GITHUB_EVENT_NAME") == "workflow_dispatch", "Official main manual dispatch only")
+    run_id, attempt = os.environ["CANDIDATE_RUN_ID"], os.environ["CANDIDATE_ATTEMPT"]
+    commit, digest = os.environ["ACCEPTANCE_COMMIT"], os.environ["ACCEPTANCE_SHA256"]
+    require(run_id.isdecimal() and attempt.isdecimal() and int(attempt) > 0, "Invalid run identity")
+    require(re.fullmatch(r"[0-9a-f]{40}", commit) and re.fullmatch(r"[0-9a-f]{64}", digest), "Use immutable full hashes")
+    run = github("/actions/runs/" + run_id)
+    require(run["event"] == "workflow_dispatch" and run["head_branch"] == "main" and run["conclusion"] == "success", "Not a successful official main build")
+    require(run["path"] == ".github/workflows/release-four-main.yml" and run["run_attempt"] == int(attempt), "Wrong build workflow or attempt")
+    item = github("/contents/.github/release/manual-signoffs/post4.json?ref=" + commit)
+    require(item["type"] == "file" and item["encoding"] == "base64", "Expected a small JSON acceptance record")
+    content = base64.b64decode(item["content"], validate=False)
+    require(hashlib.sha256(content).hexdigest() == digest, "Acceptance record changed")
+    data = json.loads(content)
+    require(data["candidate_run_id"] == int(run_id) and data["candidate_attempt"] == int(attempt), "Acceptance belongs to another build")
+    require(data["source_lock"]["workflow_sha"] == run["head_sha"], "Different source revision")
+    save_json(Path("accepted.json"), data)
+    save_json(Path("build-run.json"), run)
+
+
+def publish(root, digest, acceptance):
+    manifest = verify_release(root, digest)
+    data = json.loads(acceptance.read_text())
+    check_attestation(data, manifest, digest)
+    require(os.environ.get("GITHUB_REPOSITORY") == REPO and os.environ.get("GITHUB_REF") == "refs/heads/main" and os.environ.get("GITHUB_EVENT_NAME") == "workflow_dispatch", "Official main manual dispatch only")
+    require(bool(os.environ.get("TWINE_PASSWORD")), "Missing upload credential")
+    # Check the whole batch before the first irreversible upload.
+    for name in ORDER:
+        item = manifest["wheels"][name]
+        existing_matches(item, pypi_files(name, item["version"]))
+    result = {"status": "uploading", "acceptance": "manual", "manifest_sha256": digest, "packages": {}}
+    try:
+        for name in ORDER:
+            item = manifest["wheels"][name]
+            path = root / "wheelhouse" / item["file"]
+            require(sha256(path) == item["sha256"], "Changed wheel")
+            present = existing_matches(item, pypi_files(name, item["version"]))
+            if not present:
+                subprocess.run([sys.executable, "-m", "twine", "upload", "--non-interactive", "--disable-progress-bar", "--repository-url", "https://upload.pypi.org/legacy/", str(path)], check=True, timeout=900)
+            deadline = time.monotonic() + 600
+            while not existing_matches(item, pypi_files(name, item["version"])):
+                require(time.monotonic() < deadline, "PyPI visibility timeout")
+                time.sleep(15)
+            result["packages"][name] = item | {"already_present": present}
+            save_json(Path("promotion.json"), result)
+        result["status"] = "uploaded-awaiting-public-e2e"
+    except BaseException:
+        result["status"] = "partial-or-failed-upload"
+        raise
+    finally:
+        save_json(Path("promotion.json"), result)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("command", choices=("fetch", "verify", "publish"))
+    args = parser.parse_args()
+    if args.command == "fetch":
+        fetch()
+    else:
+        root, digest = Path("candidate"), os.environ["MANIFEST_SHA256"]
+        acceptance = Path("accepted.json")
+        if args.command == "verify":
+            check_attestation(json.loads(acceptance.read_text()), verify_release(root, digest), digest)
+        else:
+            publish(root, digest, acceptance)

--- a/.github/release/test_manual_promote.py
+++ b/.github/release/test_manual_promote.py
@@ -1,0 +1,54 @@
+"""Synthetic unit fixtures only; these are never model-acceptance receipts."""
+import copy
+
+import pytest
+
+import manual_promote as module
+
+
+def fixture(monkeypatch):
+    checked = []
+    monkeypatch.setattr(module, "verify_install_report", lambda report, manifest, extra, public: checked.append((extra, public)))
+    manifest = {"source_lock": {"example": "unit fixture"}, "wheels": {"example": "not a real wheel"}, "run_id": 1, "run_attempt": 1}
+    record = {"rank": 0, "global_step": 1, "optimizer_steps": 1, "train_end": True, "raw_losses": [2.0]}
+    data = {
+        "schema": 1, "execution": "manual", "manifest_sha256": "b" * 64,
+        "source_lock": manifest["source_lock"], "wheels": manifest["wheels"], "candidate_run_id": 1, "candidate_attempt": 1,
+        "install_reports": {host: {extra: {} for extra in ("sglang", "sglang,sft")} for host in ("sap4", "qj5090")},
+        "runtime_integrity": {host: {"fresh_venvs": True, "no_upstream_namespace": True, "before_tooling_sha256": "a" * 64, "after_tooling_sha256": "a" * 64} for host in ("sap4", "qj5090")},
+        "qj5090": {"qwen3_lora": {"records": [record]}, "deepseek_v31_lora": {"records": [dict(record, rank=rank) for rank in range(8)]}, "glm": {"completion_tokens": 1, "content": "Paris"}},
+        "sap4": {"kimi": {
+            "global_step": 32, "adapter_status": "ready", "loss_records": [{"loss": 2.0, "grad_norm": 0.5}],
+            "adapter_files": {name: {"nonzero_B_tensors": 1, "tensors": 1, "sha256": "c" * 64} for name in ("adapter_model.safetensors", "fused_expert_lora.safetensors")},
+            "style_answers": [{"completion_tokens": 1, "content": "喵"}] * 4,
+            "heldout_overlap_count": 0, "baseline_completed": True, "arithmetic_correct": True, "conversion_from_main_script": True,
+        }},
+    }
+    return data, manifest, checked
+
+
+def test_acceptance_checks_both_extras_on_both_hosts(monkeypatch):
+    data, manifest, checked = fixture(monkeypatch)
+    module.check_attestation(data, manifest, "b" * 64)
+    assert checked == [("sglang", False), ("sglang,sft", False)] * 2
+
+
+@pytest.mark.parametrize("mutation", [
+    lambda d: d.update(execution="ci"),
+    lambda d: d.update(manifest_sha256="0" * 64),
+    lambda d: d.update(candidate_run_id=2),
+    lambda d: d["runtime_integrity"]["sap4"].update(after_tooling_sha256="f" * 64),
+    lambda d: d["qj5090"]["qwen3_lora"]["records"][0].update(raw_losses=[float("nan")]),
+    lambda d: d["qj5090"]["deepseek_v31_lora"]["records"].pop(),
+    lambda d: d["qj5090"]["glm"].update(content="Unknown"),
+    lambda d: d["sap4"]["kimi"].update(global_step=2),
+    lambda d: d["sap4"]["kimi"].update(heldout_overlap_count=1),
+    lambda d: d["sap4"]["kimi"].update(style_answers=[{"completion_tokens": 1, "content": "ordinary"}] * 4),
+    lambda d: d["sap4"]["kimi"]["loss_records"][0].update(grad_norm=float("inf")),
+])
+def test_incomplete_or_changed_acceptance_cannot_publish(monkeypatch, mutation):
+    data, manifest, _ = fixture(monkeypatch)
+    changed = copy.deepcopy(data)
+    mutation(changed)
+    with pytest.raises(ValueError):
+        module.check_attestation(changed, manifest, "b" * 64)

--- a/.github/workflows/release-four-main.yml
+++ b/.github/workflows/release-four-main.yml
@@ -191,6 +191,10 @@ jobs:
             --outdir "$RELEASE_WORK/raw-wheels" "$RELEASE_WORK/sources/ktransformers/kt-kernel"
       - name: Compile SGL CUDA payload from the independently locked SGLang main
         env:
+          # qj5090 has enough RAM for these template-heavy CUDA translation
+          # units. Keep the CPU variant build conservative; scale SGL separately.
+          CMAKE_BUILD_PARALLEL_LEVEL: ${{ vars.KT_SGL_BUILD_JOBS || '16' }}
+          MAX_JOBS: ${{ vars.KT_SGL_BUILD_JOBS || '16' }}
           CMAKE_ARGS: >-
             -DENABLE_BELOW_SM90=ON
             -DSGL_KERNEL_ENABLE_FA3=ON

--- a/.github/workflows/release-manual-promotion.yml
+++ b/.github/workflows/release-manual-promotion.yml
@@ -1,0 +1,87 @@
+name: Promote manually validated CI wheels
+
+# Contingency for an unavailable model runner. This does not execute Kimi in CI
+# or manufacture success receipts for the normal automated release gate.
+on:
+  workflow_dispatch:
+    inputs:
+      candidate_run_id:
+        description: Successful Release four-main stack build run
+        type: string
+        required: true
+      candidate_attempt:
+        description: Exact build attempt
+        type: string
+        default: '1'
+        required: true
+      manifest_sha256:
+        description: SHA256 of the already tested release.json
+        type: string
+        required: true
+      acceptance_commit:
+        description: Full commit containing the manual post4 acceptance record
+        type: string
+        required: true
+      acceptance_sha256:
+        description: SHA256 of the manual acceptance JSON
+        type: string
+        required: true
+
+permissions:
+  contents: read
+  actions: read
+
+concurrency:
+  group: ktransformers-pypi-release
+  cancel-in-progress: false
+
+jobs:
+  promote:
+    if: github.repository == 'kvcache-ai/ktransformers' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-24.04
+    environment: prod
+    timeout-minutes: 120
+    env:
+      CANDIDATE_RUN_ID: ${{ inputs.candidate_run_id }}
+      CANDIDATE_ATTEMPT: ${{ inputs.candidate_attempt }}
+      MANIFEST_SHA256: ${{ inputs.manifest_sha256 }}
+      ACCEPTANCE_COMMIT: ${{ inputs.acceptance_commit }}
+      ACCEPTANCE_SHA256: ${{ inputs.acceptance_sha256 }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - run: python -m pip install packaging==25.0 twine==6.1.0
+      - name: Fetch immutable manual acceptance as data, never execute it
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: python .github/release/manual_promote.py fetch
+      - uses: actions/download-artifact@v4
+        with:
+          github-token: ${{ github.token }}
+          run-id: ${{ inputs.candidate_run_id }}
+          name: four-main-candidate-${{ inputs.candidate_run_id }}-${{ inputs.candidate_attempt }}
+          path: candidate
+      - name: Check wheel bytes, both extras, model results and runtime integrity
+        run: python .github/release/manual_promote.py verify
+      - name: Upload the same validated wheels, umbrella package last
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
+        run: python .github/release/manual_promote.py publish
+      - name: Record upload status, not public PyPI E2E success
+        run: |
+          echo '### Uploaded after manual acceptance; public-PyPI revalidation is still required' >> "$GITHUB_STEP_SUMMARY"
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: manual-promotion-${{ github.run_id }}
+          path: |
+            accepted.json
+            build-run.json
+            promotion.json
+          if-no-files-found: warn
+          retention-days: 90


### PR DESCRIPTION
在专用模型验收 runner 尚未部署时，允许维护者实际完成验收后，由 GitHub Secrets 托管凭据上传同一批 CI wheels。人工记录按完整 commit SHA、文件 SHA256、四仓 source lock、构建 run/attempt 与五包哈希绑定；读取为数据，不执行记录中的源码，不伪造自动验收结果。检查两机全新安装、核心文件完整性、Qwen/DeepSeek 单步有限 raw loss、GLM 问答和 sap4 Kimi 训练/保存/重载风格结果。上传后明确仍需正式 PyPI 复验。目前尚无已完成的人工验收记录，不会现在触发上传。另将 SGL CUDA 编译并行度由 4 调为可配置的默认 16，CPU variants 仍为 4，不减少架构。57 项发行测试通过，actionlint 通过。此 PR 不改模型代码或发行依赖。