### PR TITLE
[fix](cli): keep "1" and "0" as integers in kt config set

### DIFF
--- a/kt-kernel/python/cli/commands/config.py
+++ b/kt-kernel/python/cli/commands/config.py
@@ -137,10 +137,10 @@ def model_path_remove(
 
 def _parse_value(value: str):
     """Parse a string value into appropriate Python type."""
-    # Try boolean
-    if value.lower() in ("true", "yes", "on", "1"):
+    # Try boolean ("1"/"0" fall through to int so e.g. CUDA_VISIBLE_DEVICES=1 stays "1")
+    if value.lower() in ("true", "yes", "on"):
         return True
-    if value.lower() in ("false", "no", "off", "0"):
+    if value.lower() in ("false", "no", "off"):
         return False
 
     # Try integer

--- a/kt-kernel/test/per_commit/test_config_parse_value.py
+++ b/kt-kernel/test/per_commit/test_config_parse_value.py
@@ -1,0 +1,44 @@
+import tempfile
+import unittest
+from pathlib import Path
+
+import yaml
+
+from ci.ci_register import register_cpu_ci
+from kt_kernel.cli.commands.config import _parse_value
+from kt_kernel.cli.config.settings import Settings
+
+
+register_cpu_ci(est_time=0.1, suite="default")
+
+
+class TestConfigParseValue(unittest.TestCase):
+    def test_numeric_strings_stay_integers(self):
+        for raw, expected in (("0", 0), ("1", 1), ("2", 2), ("30000", 30000)):
+            value = _parse_value(raw)
+            self.assertIs(type(value), int, raw)
+            self.assertEqual(value, expected)
+
+    def test_boolean_words_still_parse_as_booleans(self):
+        for raw in ("true", "True", "yes", "on"):
+            self.assertIs(_parse_value(raw), True, raw)
+        for raw in ("false", "False", "no", "off"):
+            self.assertIs(_parse_value(raw), False, raw)
+
+    def test_env_var_set_to_one_is_exported_as_one(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp = Path(tmp)
+            config_path = tmp / "config.yaml"
+            # Keep every directory Settings creates inside the temp dir.
+            config_path.write_text(
+                yaml.safe_dump({"paths": {"models": str(tmp / "models"), "cache": str(tmp / "cache")}}),
+                encoding="utf-8",
+            )
+
+            Settings(config_path=config_path).set("advanced.env.CUDA_VISIBLE_DEVICES", _parse_value("1"))
+
+            self.assertEqual(Settings(config_path=config_path).get_env_vars(), {"CUDA_VISIBLE_DEVICES": "1"})
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
# What does this PR do?

While reading the kt CLI I noticed that `kt config set` stores `1` and `0` as booleans. `_parse_value()` in `kt-kernel/python/cli/commands/config.py` checks the boolean words before it tries `int()`, and `"1"`/`"0"` are in that list, whereas `"2"` goes on to become the integer 2.

Where this hurts is environment variables. After

    kt config set advanced.env.CUDA_VISIBLE_DEVICES 1

the config file contains `CUDA_VISIBLE_DEVICES: true`, `Settings.get_env_vars()` stringifies it, and `kt run` hands sglang `CUDA_VISIBLE_DEVICES=True` instead of `1`. The same goes for `OMP_NUM_THREADS 1` or any `inference.env.*` value set to 1 or 0. I reproduced this on current main by calling `_parse_value()` and `Settings` against a temporary config file. I did not launch sglang itself (no NVIDIA GPU on the machine I used), so the last step, CUDA rejecting `True` as a device list, is what I expect rather than something I watched happen.

The change drops `"1"` and `"0"` from the boolean words so they fall through to the integer parse. `true/false/yes/no/on/off` still give booleans, and `0`/`1` keep the same truthiness, so anything that does `if settings.get(...)` behaves as before. I grepped the CLI for `is True`/`== True` style checks on settings values and found none.

The new CPU test `kt-kernel/test/per_commit/test_config_parse_value.py` fails on main with

    AssertionError: {'CUDA_VISIBLE_DEVICES': 'True'} != {'CUDA_VISIBLE_DEVICES': '1'}
    AssertionError: <class 'bool'> is not <class 'int'> : 0

and passes with the change. The boolean-word test passes on both sides. The test writes nothing outside its temporary directory. I ran it without building the extension, through a bare `kt_kernel` package that only links `python/cli`, so it has not been through the `kt-cpu` runner yet. I also didn't have black installed; the new lines stay under the 120-column limit.

No issue filed for this one.

## Before submitting

- [x] Did you read the [contributor guideline](https://github.com/kvcache-ai/ktransformers/blob/main/.github/CONTRIBUTING.md)?
- [x] Did you write any new necessary tests?

AI tools used
